### PR TITLE
Update ABAP version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![abap version](https://img.shields.io/badge/abap%20version-standard%20%28%E2%89%A5%207.02%29%20%2B%20cloud-blue)](#try-it-in-60-seconds)
+[![ABAP NW 7.02 to ABAP Cloud](https://img.shields.io/badge/ABAP-NW%207.02%20%E2%86%92%20Cloud-blue)](#try-it-in-60-seconds)
 [![namespace](https://img.shields.io/badge/namespace-z2ui5__cl__smp-blue)](abaplint.jsonc)
 [![dependency](https://img.shields.io/badge/dependency-abap2UI5-blue)](https://github.com/abap2UI5/abap2UI5)
 


### PR DESCRIPTION
## Summary
Updated the ABAP version badge in the README to use clearer, more concise messaging about supported ABAP versions.

## Changes
- Replaced the badge text from "abap version: standard (≥ 7.02) + cloud" with "ABAP: NW 7.02 → Cloud"
- Improved readability by using an arrow (→) to indicate the version range progression
- Simplified the badge label from "abap version" to "ABAP" for brevity

## Details
This is a documentation-only change that makes the supported ABAP version range more immediately clear to users viewing the repository. The badge now explicitly shows that the project supports ABAP NetWeaver 7.02 through ABAP Cloud.

https://claude.ai/code/session_012n5ab2EH8fEZFJs5N6sbBb