### PR TITLE
Replace _event_client with follow_up_action across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,7 +573,7 @@ Use a `CASE` statement (inside an `ELSEIF client->check_on_event( )` block) only
 | Popups | `popup_display`, `popup_destroy` | Modal dialogs |
 | Popovers | `popover_display`, `popover_destroy` | Context popovers |
 | Binding | `_bind(val)` | Two-way binding (`_bind_edit` is an obsolete alias) |
-| Events | `_event(val)`, `_event_client(val)`, `check_on_event(val)` | Event registration and checking |
+| Events | `_event(val)`, `follow_up_action(val)`, `check_on_event(val)` | Event registration and checking (`_event_client` is an obsolete alias — `follow_up_action` covers both roles: returned into a view attribute it binds the frontend action to a control, called on `client` it queues the action after the current response renders) |
 | Navigation | `nav_app_call(app)`, `nav_app_leave()`, `get_app_prev()` | App stack navigation |
 | Lifecycle | `check_on_init()`, `check_on_navigated()`, `check_app_prev_stack()` | State checks |
 | Messages | `message_box_display(text)`, `message_toast_display(text)` | User notifications |
@@ -894,9 +894,9 @@ new/edited samples stay consistent:
   (leading space), surfaced in the overview:
   - `(C)` — uses an abap2UI5 **custom control** (`view->_z2ui5( )->…`, or the
     `z2ui5` cc namespace: `_generic( … ns = `z2ui5` … )`, `z2ui5.cc`, `xmlns:z2ui5`).
-  - `(A)` — performs a **frontend action**: `client->_event_client( )`,
-    `client->follow_up_action( )` (including the `cs_event-control_by_id` /
-    `cs_event-control_global` / `cs_event-binding_call` events), or a
+  - `(A)` — performs a **frontend action**: `client->follow_up_action( )`
+    (including the `cs_event-control_by_id` / `cs_event-control_global` /
+    `cs_event-binding_call` events), or a
     client-side interaction like drag-and-drop. The ubiquitous back-button
     `client->_event_nav_app_leave( )` does **not** count.
   - `(A,C)` — both. Regenerate the overviews after changing any DESCRIPT (§4).

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -131,7 +131,7 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
         " 1.21.1 and right-aligns them the same way.
         )->buttons(
             )->button( text  = `Cancel`
-                       press = client->_event_client( client->cs_event-popup_close )
+                       press = client->follow_up_action( client->cs_event-popup_close )
             )->button( text  = `Confirm`
                        type  = `Emphasized`
                        press = client->_event( `POPUP_CONFIRM` ) ).

--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
       client->view_display( view->shell(
              )->page(
                      title          = `abap2UI5 - Navigation with app state`
-                     navbuttonpress = client->_event_client( `HISTORY_BACK` )
+                     navbuttonpress = client->follow_up_action( `HISTORY_BACK` )
                      shownavbutton  = client->check_app_prev_stack( )
           )->simple_form( title = `Form Title` editable = abap_true
                      )->content( `form`
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
                              press = client->_event( `BUTTON_POST` )
                          )->button(
                              text  = `back`
-                             press = client->_event_client( `HISTORY_BACK` )
+                             press = client->follow_up_action( `HISTORY_BACK` )
               )->stringify( ) ).
 
       IF client->check_app_prev_stack( ).

--- a/src/01/z2ui5_cl_smp_app_012.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_012.clas.abap
@@ -159,7 +159,7 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
             )->buttons(
                 )->button(
                     text  = `close`
-                    press = client->_event_client( client->cs_event-popup_close )
+                    press = client->follow_up_action( client->cs_event-popup_close )
                     type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -63,8 +63,8 @@ CLASS z2ui5_cl_smp_app_088 IMPLEMENTATION.
         class    = `sapUiSmallMargin` ).
 
     page->icon_tab_header( selectedkey                   = client->_bind( mv_selected_key )
-                                                  select = client->_event_client( val   = client->cs_event-control_by_id
-                                                                                  t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
+                                                  select = client->follow_up_action( val   = client->cs_event-control_by_id
+                                                                                     t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
                                                   mode   = `Inline`
                                   )->items(
                                     )->icon_tab_filter( key  = `page1`

--- a/src/01/z2ui5_cl_smp_app_170.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_170.clas.abap
@@ -28,9 +28,9 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
          )->content( ).
 
     DATA(content) = dialog->icon_tab_bar( selectedkey        = client->_bind( mv_selected_key )
-                                                  select     = client->_event_client( val   = client->cs_event-control_by_id
-                                                                                      view  = client->cs_view-popup
-                                                                                      t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
+                                                  select     = client->follow_up_action( val   = client->cs_event-control_by_id
+                                                                                         view  = client->cs_view-popup
+                                                                                         t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
                                                   headermode = `Inline`
                                                   expanded   = abap_true
                                                   expandable = abap_false

--- a/src/01/z2ui5_cl_smp_app_316.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_316.clas.abap
@@ -94,7 +94,7 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
                        width           = `100%` ).
 
     email_form->button( text  = `Trigger Email`
-                        press = client->_event_client( val   = client->cs_event-urlhelper
+                        press = client->follow_up_action( val   = client->cs_event-urlhelper
                         t_arg = VALUE #( ( `TRIGGER_EMAIL` )
                                                                         ( |${ client->_bind( email ) }| ) ) ) ).
 
@@ -109,7 +109,7 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
                            class       = `sapUiSmallMarginBottom` ).
     telephone_form->button(
         text  = `Trigger Telephone`
-        press = client->_event_client( val   = client->cs_event-urlhelper
+        press = client->follow_up_action( val   = client->cs_event-urlhelper
         t_arg = VALUE #( ( `TRIGGER_TEL` )
                                                         ( |${ client->_bind( phone ) }| ) ) ) ).
 
@@ -123,7 +123,7 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
                         placeholder = `Enter a number`
                         class       = `sapUiSmallMarginBottom` ).
     mobile_form->button( text  = `Trigger SMS`
-                         press = client->_event_client( val   = client->cs_event-urlhelper
+                         press = client->follow_up_action( val   = client->cs_event-urlhelper
                          t_arg = VALUE #( ( `TRIGGER_SMS` ) ( |${ client->_bind( mobile ) }| ) ) ) ).
 
     DATA(url_form) = layout->simple_form( `Redirect` ).
@@ -135,7 +135,7 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
                      placeholder = `Enter URL`
                      class       = `sapUiSmallMarginBottom` ).
     url_form->button( text  = `Redirect`
-                      press = client->_event_client( val   = client->cs_event-urlhelper
+                      press = client->follow_up_action( val   = client->cs_event-urlhelper
                       t_arg = VALUE #( ( `REDIRECT` ) ( |${ client->_bind( url ) }| ) ) ) ).
 
     client->view_display( page->stringify( ) ).

--- a/src/01/z2ui5_cl_smp_app_327.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_327.clas.abap
@@ -137,7 +137,7 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
             )->input( client->_bind( s_storage-value-field2 )
             )->label( ``
             )->button( text  = `store`
-                       press = client->_event_client(
+                       press = client->follow_up_action(
                            val   = z2ui5_if_client=>cs_event-store_data
                            t_arg = VALUE #( ( |${ client->_bind( s_storage ) }| ) ) )
             )->button( text  = `get`

--- a/src/01/z2ui5_cl_smp_app_361.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_361.clas.abap
@@ -22,24 +22,27 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
               shownavbutton  = client->check_app_prev_stack( ) ).
 
       page->message_strip(
-          text     = `Trigger SYSTEM_LOGOUT on the client. Inside a Fiori Launchpad the shell container handles the sign-out; otherwise the app navigates to the ICF logoff endpoint.`
+          text     = `follow_up_action( ) returned straight into the press attribute: the button carries SYSTEM_LOGOUT ` &&
+                     `itself, so pressing it signs out on the client without ever reaching the backend. Inside a Fiori ` &&
+                     `Launchpad the shell container handles the sign-out; otherwise the app navigates to the ICF logoff endpoint.`
           type     = `Information`
           showicon = abap_true
           class    = `sapUiMediumMargin`
       )->button(
-          text  = `Logout now`
+          text  = `Logout (client)`
           icon  = `sap-icon://log`
           type  = `Reject`
           class = `sapUiSmallMargin`
           press = client->follow_up_action( client->cs_event-system_logout ) ).
 
       page->message_strip(
-          text     = `Trigger SYSTEM_LOGOUT on the client and a redirect to google.com`
+          text     = `The same client-side call, but with an argument: t_arg passes the ICF logoff endpoint, here with a ` &&
+                     `redirect to google.com appended. Still no backend roundtrip - the argument is baked into the view.`
           type     = `Information`
           showicon = abap_true
           class    = `sapUiMediumMargin`
       )->button(
-          text  = `Logout now`
+          text  = `Logout (client, with redirect)`
           icon  = `sap-icon://log`
           type  = `Reject`
           class = `sapUiSmallMargin`
@@ -48,12 +51,14 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
                       t_arg = VALUE #( ( `/sap/public/bc/icf/logoff?redirecturl=www.google.com` ) ) ) ).
 
       page->message_strip(
-          text     = `Trigger Event LOGOUT which is handled in the APP.`
+          text     = `The other way round: _event( 'LOGOUT' ) makes the button call the backend, and follow_up_action( ) ` &&
+                     `is invoked there on client - the identical SYSTEM_LOGOUT, only queued after the response renders. ` &&
+                     `Take this route when the logout depends on backend logic, e.g. saving a draft first.`
           type     = `Information`
           showicon = abap_true
           class    = `sapUiMediumMargin`
       )->button(
-          text  = `Logout now`
+          text  = `Logout (via backend)`
           icon  = `sap-icon://log`
           type  = `Reject`
           class = `sapUiSmallMargin`
@@ -62,6 +67,8 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `LOGOUT` ).
+      " same method as in the two buttons above, only called on client instead of
+      " returned into the view - the action is queued and runs once this response renders
       client->follow_up_action( client->cs_event-system_logout ).
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_361.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_361.clas.abap
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
           icon  = `sap-icon://log`
           type  = `Reject`
           class = `sapUiSmallMargin`
-          press = client->_event_client( client->cs_event-system_logout ) ).
+          press = client->follow_up_action( client->cs_event-system_logout ) ).
 
       page->message_strip(
           text     = `Trigger SYSTEM_LOGOUT on the client and a redirect to google.com`
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
           icon  = `sap-icon://log`
           type  = `Reject`
           class = `sapUiSmallMargin`
-          press = client->_event_client(
+          press = client->follow_up_action(
                       val   = client->cs_event-system_logout
                       t_arg = VALUE #( ( `/sap/public/bc/icf/logoff?redirecturl=www.google.com` ) ) ) ).
 

--- a/src/01/z2ui5_cl_smp_app_445.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_445.clas.abap
@@ -156,7 +156,7 @@ CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
             )->button(
                 text  = `Close`
                 type  = `Emphasized`
-                press = client->_event_client( client->cs_event-popup_close ) ).
+                press = client->follow_up_action( client->cs_event-popup_close ) ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_452.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_452.clas.abap
@@ -188,7 +188,7 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
         contentheight     = `50%`
         contentwidth      = `50%`
         verticalscrolling = abap_false
-        afterclose        = client->_event_client( client->cs_event-popup_close ) ).
+        afterclose        = client->follow_up_action( client->cs_event-popup_close ) ).
 
     dialog->message_view(
         items      = client->_bind( t_msg )
@@ -206,7 +206,7 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
 
     dialog->end_button( )->button(
         text  = `Close`
-        press = client->_event_client( client->cs_event-popup_close ) ).
+        press = client->follow_up_action( client->cs_event-popup_close ) ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_455.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_455.clas.abap
@@ -52,7 +52,7 @@ CLASS Z2UI5_CL_SMP_APP_455 IMPLEMENTATION.
 
     page->message_strip(
         text     = `Every keystroke filters the list's items binding purely client-side ` &&
-                   `(cs_event-binding_call via _event_client) - no backend roundtrip, exactly like ` &&
+                   `(cs_event-binding_call via follow_up_action) - no backend roundtrip, exactly like ` &&
                    `the original UI5 controller's oBinding.filter(...). Clearing the field clears the filter.`
         type     = `Information`
         showicon = abap_true
@@ -64,7 +64,7 @@ CLASS Z2UI5_CL_SMP_APP_455 IMPLEMENTATION.
     " without any server contact.
     page->vbox( `sapUiSmallMargin`
         )->search_field( width      = `30%`
-                         livechange = client->_event_client(
+                         livechange = client->follow_up_action(
                              val   = z2ui5_if_client=>cs_event-binding_call
                              t_arg = VALUE #( ( `productList` )
                                               ( `items` )

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -144,7 +144,7 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
         )->button(
             text  = `Close`
             type  = `Emphasized`
-            press = client->_event_client( client->cs_event-popup_close ) ).
+            press = client->follow_up_action( client->cs_event-popup_close ) ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_473.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_473.clas.abap
@@ -47,7 +47,7 @@ CLASS z2ui5_cl_smp_app_473 IMPLEMENTATION.
     " the item's breadcrumb is resolved on the client and substituted into the
     " toast template ({0}); an argument starting with $ is a client-side
     " expression, everything else travels as a plain string
-    DATA(menu_selected) = client->_event_client(
+    DATA(menu_selected) = client->follow_up_action(
         val   = z2ui5_if_client=>cs_event-control_global
         t_arg = VALUE #( ( `MESSAGE_TOAST` )
                          ( `show` )


### PR DESCRIPTION
## Summary
Deprecate the `_event_client()` method in favor of the more semantically clear `follow_up_action()` method across all sample apps and documentation. This change unifies the API for client-side actions, whether they are bound to view controls or queued after backend responses.

## Key Changes
- **App 361**: Updated logout examples with clearer button labels and expanded message descriptions explaining the difference between client-side actions (returned into view) vs. backend-routed actions (queued after response)
- **App 316, 170, 322, 088, 452, 455, 141, 012, 327, 445, 470, 473**: Replaced all `_event_client()` calls with `follow_up_action()` 
- **AGENTS.md**: Updated API documentation to mark `_event_client` as an obsolete alias and clarify that `follow_up_action()` covers both roles:
  - When returned into a view attribute, it binds the frontend action to a control
  - When called on `client`, it queues the action after the current response renders
- **AGENTS.md**: Updated the sample app classification rules to reference only `follow_up_action()` for frontend actions, removing mention of the deprecated `_event_client()`

## Implementation Details
The refactoring maintains full backward compatibility while improving code clarity. All three logout patterns in App 361 now use `follow_up_action()` with updated documentation explaining when to use client-side vs. backend-routed logout flows. The method signature and behavior remain identical; only the method name changes to better reflect its dual purpose.

https://claude.ai/code/session_01FpgpHAiqBABTai6HsVn9VP