### PR TITLE
Reorganize samples catalog and improve overview app UI

### DIFF
--- a/.github/abaplint/rename_test.jsonc
+++ b/.github/abaplint/rename_test.jsonc
@@ -8,9 +8,9 @@
   // overview app in the src/ root package, plus the shared context classes
   // in src/00/01 the samples there reference. It is
   // the only namespace-clean area free of dependencies on the stripped
-  // packages (the restricted src/00/02, the experimental src/00/97, the
-  // testing src/00/98 and the obsolete src/00/99 are removed from the 702
-  // build and carry non-ABAP objects that are out of scope for renaming).
+  // packages (the experimental src/00/97 and the testing src/00/98 are removed
+  // from the 702 build and carry non-ABAP objects that are out of scope for
+  // renaming).
   // Runs standalone as well:
   //   npx abaplint .github/abaplint/rename_test.jsonc --rename
   "global": {

--- a/.github/workflows/publish-702.yaml
+++ b/.github/workflows/publish-702.yaml
@@ -1,8 +1,8 @@
 name: publish-702
 
 # Rebuilds the 702 branch from main: downports the sources (which also removes
-# the restricted, experimental, testing and obsolete samples), lints the result
-# with the 702 config and force-pushes it.
+# the experimental and testing samples), lints the result with the 702 config
+# and force-pushes it.
 #
 # 702 is the only derived branch. main itself is installed on both standard and
 # ABAP Cloud systems and is published as-is, so nothing is generated for those.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,22 +27,20 @@ titles, PR descriptions, and any other text must be written in English.
 ## 1. Repository layout
 
 Everything lives under `src/`, split into two top-level packages
-(abapGit `FOLDER_LOGIC=PREFIX`, `STARTING_FOLDER=/src/`). `01` "Basic" holds the
-portable samples directly; `00` is the system package — shared code plus every
-sample that carries a restriction, and the retired ones. There
+(abapGit `FOLDER_LOGIC=PREFIX`, `STARTING_FOLDER=/src/`). `01` "samples" holds
+the portable samples directly; `00` is the system package — shared code plus
+every sample that carries a restriction. There
 are **no demo apps directly in `src/` root** — every sample sits in a
 categorised subpackage. The only class in the root package is
 `z2ui5_cl_smp_app_000`, the overview app (§3), which is an index, not a sample.
 
 ```
 src/
-├── 00/  "system"     not a sample category — shared code and everything with a restriction
-│   ├── 01/  "context"                          helper classes the samples share (no demo apps) — survives every build
-│   ├── 02/  "restricted - release/version"     needs a UI5 release newer than 1.71, or a control outside OpenUI5 (sap.suite.*, sap.ui.comp.*, sap.viz.*, …), or a runtime the sample cannot ship (native JS/CSS) — STRIPPED from the 702 build
-│   ├── 97/  "experimental"                     work-in-progress / not finished — STRIPPED from the 702 build
-│   ├── 98/  "testing"                          test / scaffolding apps, not demos — STRIPPED from the 702 build
-│   └── 99/  "obsolet"                          superseded, or built on a deprecated UI5 control — STRIPPED from the 702 build
-└── 01/  "Basic"     cloud-ready & downportable — the sample catalog: bindings, events, popups, framework actions, custom controls and use cases — survives every build
+├── 00/  "system"     not a sample category — shared code, plus the samples held back by maturity or purpose
+│   ├── 01/  "context"        helper classes the samples share (no demo apps) — survives every build
+│   ├── 97/  "experimental"   work-in-progress / not finished — STRIPPED from the 702 build
+│   └── 98/  "testing"        test / scaffolding apps, not demos — STRIPPED from the 702 build
+└── 01/  "samples"     cloud-ready & downportable — the sample catalog: bindings, events, popups, framework actions, custom controls and use cases — survives every build
 ```
 
 The former wrapper level (`01` "basic" holding a single subpackage `01/01`
@@ -50,10 +48,26 @@ The former wrapper level (`01` "basic" holding a single subpackage `01/01`
 `src/01`, and the overview app moved from `src/01` into the `src/` root
 package.
 
-**`src/00/02` is currently empty** — a category with no members, not a dropped
-one. It stays in the tree and in the strip list because it is the designated
-home of the next restricted sample; the check below verifies the package
-exists, not that it holds anything.
+### The restricted and obsolete packages are gone
+
+**`src/00/02` ("restricted - release/version") and `src/00/99` ("obsolet") were
+removed on 2026-08-12**, `00/99` together with the samples it still held. Two
+categories, not two policies: what made a sample restricted or obsolete is
+unchanged, there is simply no package standing empty in the tree waiting for
+the next one.
+
+So a sample that plain OpenUI5 1.71 cannot run — a SAPUI5-only control
+(`sap.suite.*`, `sap.ui.comp.*`, `sap.viz.*`, …), a control or property
+introduced after UI5 1.71, or native JavaScript / CSS the sample would have to
+ship — has **no home in this repository today**, and neither has a superseded
+one. Do not park it in `src/01`: every sample there must survive the 702
+downport (§2). Either it belongs in
+[samples-stack](https://github.com/abap2UI5/samples-stack) or
+[ai-demokit](https://github.com/abap2UI5/ai-demokit) (§2), or the category has
+to come back. Re-creating one is a deliberate, self-contained change: add the
+package, put it back into the tree above, into the §2 build table, and into the
+`downport` strip list in `package.json` — all three in the same commit, or the
+two checks below fail.
 
 There is **no on-premise-only package**: `main` is installed on ABAP Cloud
 systems as it is, so every sample in the repository must be ABAP Cloud ready.
@@ -65,8 +79,8 @@ drift (runs in CI). **Whenever a subpackage is added, removed, or renamed,
 update this tree in the same change.**
 
 Each subpackage's `package.devc.xml` `<CTEXT>` is the quoted name shown above
-(e.g. `restricted - release/version`). **That CTEXT string is also the overview
-group name — keep the two identical** (see §4).
+(e.g. `experimental`). **That CTEXT string is also the overview group name —
+keep the two identical** (see §4).
 
 > Class names never encode the folder (`FOLDER_LOGIC=PREFIX`). Moving a sample
 > between packages needs **no rename** and keeps navigation intact — but the
@@ -98,12 +112,12 @@ and it goes into the basic package (`src/01`) as an ordinary sample:
 - a **free-style control demo** with no single demo kit original.
 
 A sample with a restriction still goes to the matching `src/00` category
-(`src/00/02` release/version, `src/00/97` experimental, `src/00/98` when it is
-a test app, `src/00/99` once it is obsolete) — that model is unchanged.
+(`src/00/97` experimental, `src/00/98` when it is a test app) — that model is
+unchanged.
 
 ---
 
-## 2. Compatibility model — what belongs in `src/01` vs `src/00/02` vs `src/00/97` vs `src/00/98` vs `src/00/99`
+## 2. Compatibility model — what belongs in `src/01` vs `src/00/97` vs `src/00/98`
 
 `main` is the default branch and the only branch anyone commits to. It is
 installed **both** on standard on-premise systems and on ABAP Cloud, so it is
@@ -112,28 +126,27 @@ branch, generated from `main` by `publish-702`.
 
 The split is driven directly by the CI builds:
 
-| Build (workflow)   | What it does                                    | Sees `src/00/01` | Sees `src/00/02` | Sees `src/00/97` | Sees `src/00/98` | Sees `src/00/99` | Sees `src/01` |
-|--------------------|-------------------------------------------------|:---:|:---:|:---:|:---:|:---:|:---:|
-| `abap-standard`    | `abaplint ./abaplint.jsonc` (syntax `v750`)     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `abap-cloud`       | `abaplint abap_cloud.jsonc` (syntax `Cloud`)    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `abap-702`         | `npm run downport` (does `rm -rf src/00/02 src/00/97 src/00/98 src/00/99`) → `abaplint abap_702.jsonc` | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Build (workflow)   | What it does                                    | Sees `src/00/01` | Sees `src/00/97` | Sees `src/00/98` | Sees `src/01` |
+|--------------------|-------------------------------------------------|:---:|:---:|:---:|:---:|
+| `abap-standard`    | `abaplint ./abaplint.jsonc` (syntax `v750`)     | ✅ | ✅ | ✅ | ✅ |
+| `abap-cloud`       | `abaplint abap_cloud.jsonc` (syntax `Cloud`)    | ✅ | ✅ | ✅ | ✅ |
+| `abap-702`         | `npm run downport` (does `rm -rf src/00/97 src/00/98`) → `abaplint abap_702.jsonc` | ✅ | ❌ | ❌ | ✅ |
 
 **Only the 702 build strips anything.** `main` is published as it is and runs on
 both standard and ABAP Cloud systems, so `abap-standard` and `abap-cloud` lint
-the *whole* tree — restricted, experimental, testing and obsolete samples
-included — and all of it passes. The ABAP restriction that used to justify a
-strip for cloud is gone with the on-premise package (§1): what is left is
-restricted by UI5, by maturity or by purpose, never by ABAP release.
+the *whole* tree — experimental and testing samples included — and all of it
+passes. The ABAP restriction that used to justify a strip for cloud is gone with
+the on-premise package (§1): what is left is restricted by maturity or by
+purpose, never by ABAP release.
 
-**Test, obsolete, experimental and restricted samples never reach the 702
-branch.** `src/00/02`, `src/00/97`, `src/00/98` and `src/00/99` are all removed
-by the downport, so the `702` branch carries only the portable set. Keep the
-four paths together in the two places that name them — `package.json`
-`downport` and the build table above. That is machine-checked: `node
-scripts/check-strip-lists.js` compares both and fails if one names a different
-set, or a package that no longer exists (runs in CI). The rest of `src/00` —
-today `src/00/01` "context", the helper classes the samples share — survives
-every build and must stay free of references into any stripped package.
+**Test and experimental samples never reach the 702 branch.** `src/00/97` and
+`src/00/98` are removed by the downport, so the `702` branch carries only the
+portable set. Keep the two paths together in the two places that name them —
+`package.json` `downport` and the build table above. That is machine-checked:
+`node scripts/check-strip-lists.js` compares both and fails if one names a
+different set, or a package that no longer exists (runs in CI). The rest of
+`src/00` — today `src/00/01` "context", the helper classes the samples share —
+survives every build and must stay free of references into any stripped package.
 
 **Stripped is not unchecked, and nothing is suppressed.** `abaplint.jsonc` has
 no `noIssues` list: every package under `src/` is really linted, by
@@ -156,42 +169,41 @@ in `abap2UI5/abap2UI5@main` and report every type declared there with
 
 **Consequence of the rule:**
 
-- **`src/01` ("Basic")** — a sample may only live here if it is **ABAP Cloud
+- **`src/01` ("samples")** — a sample may only live here if it is **ABAP Cloud
   ready AND downportable to 7.02** and runs on plain OpenUI5 1.71 without any
   restriction. These survive all three builds.
-- **`src/00/02` ("restricted - release/version")**, **`src/00/97`
-  ("experimental")**, **`src/00/98` ("testing")** and **`src/00/99`
-  ("obsolet")** — anything with *any* restriction. All four are deleted before
-  the 702 build, so they are only ever checked by `abap-standard` and
-  `abap-cloud`. Pick the subpackage by the **first** restriction that
-  applies:
+- **`src/00/97` ("experimental")** and **`src/00/98` ("testing")** — a sample
+  held back by its maturity or its purpose. Both are deleted before the 702
+  build, so they are only ever checked by `abap-standard` and `abap-cloud`.
+  Pick the subpackage by the **first** restriction that applies:
 
-  1. Deprecated control/property, or superseded → `00/99`
-  2. Test / scaffolding app → `00/98`
-  3. Experimental / work-in-progress → `00/97`
-  4. Everything else → `00/02` — the catch-all for a sample that plain
-     OpenUI5 1.71 on a standalone stack cannot run: a **SAPUI5-only control**
-     (`sap.suite.*`, `sap.ui.comp.*`, `sap.viz.*`, `sap.ui.vk`/`vbm`, `sap.ndc`,
-     `sap.ui.richtexteditor`, …), a control/property **introduced after UI5
-     1.71**, or a **runtime the sample cannot ship** — native JavaScript /
-     CSS / HTML.
+  1. Test / scaffolding app → `00/98`
+  2. Experimental / work-in-progress → `00/97`
+
+  A sample restricted by **UI5** — a SAPUI5-only control (`sap.suite.*`,
+  `sap.ui.comp.*`, `sap.viz.*`, `sap.ui.vk`/`vbm`, `sap.ndc`,
+  `sap.ui.richtexteditor`, …), a control or property introduced after UI5 1.71,
+  or a runtime it cannot ship (native JavaScript / CSS / HTML) — and one that is
+  **superseded or deprecated** have no package here any more (§1). Neither may
+  be filed under `00/97` or `00/98` to get it in: those two say *not finished
+  yet* and *not a demo*, not *does not run*.
 
 **A sample that needs something the system provides does not belong here at
-all** — not in `src/00/02` either. Those live in
+all.** Those live in
 [abap2UI5/samples-stack](https://github.com/abap2UI5/samples-stack), one package per
 technology: an OData service, smart controls, a RAP business object, a stateful
 session, an APC channel, the MIME repository, and the **Fiori Launchpad**
 (`src/09` there — the demos that read startup parameters, set the shell title and
-navigate cross-app, moved out of `src/00/02` on 2026-08-12). What `src/00/02`
-keeps is restricted by UI5 alone.
+navigate cross-app, moved out of the restricted package on 2026-08-12).
 
 A sample qualifies for `src/01` **only if none** of the above restrictions
 apply: OpenUI5-compatible, ABAP-Cloud-ready, standalone, every control **and**
 property available since UI5 1.71 (16 Jan 2020) **and** not deprecated, no native
-JS, not a test, finished and clean. "Old" is not enough (deprecated → `00/99`);
-"non-deprecated" is not enough (post-1.71 → `00/02`). ABAP Cloud readiness is
-not a sorting criterion at all — it is a precondition for every sample in the
-repository (§1).
+JS, not a test, finished and clean. "Old" is not enough and "non-deprecated" is
+not enough either — a deprecated control and a post-1.71 one both disqualify a
+sample from `src/01`, and neither has a package to fall back on any more (§1).
+ABAP Cloud readiness is not a sorting criterion at all — it is a precondition
+for every sample in the repository (§1).
 
 ---
 
@@ -208,13 +220,13 @@ live in [abap2UI5/samples-stack](https://github.com/abap2UI5/samples-stack) unde
 |------------------------|--------------|----------------------|-------------|
 | `z2ui5_cl_smp_app_000` | `src/` root  | `abap2UI5 - Samples` | `src/01/**` |
 
-**It is the only one.** `src/00` (the system package, restricted samples
-included) has no overview app: their samples are reachable by class name only,
-and the generator merely reports how many tiles they would hold (§4). An
-extended overview app existed once (`z2ui5_cl_sample_app_g01`, mirroring the
-restricted area, cross-linked with this one); it was removed when the extended
-samples were reorganised. Should it ever return, it comes back as a second
-`TARGETS` entry in `scripts/generate-launchpad.js` and a second row above.
+**It is the only one.** `src/00` (the system package) has no overview app: its
+samples are reachable by class name only, and the generator merely reports how
+many tiles they would hold (§4). An extended overview app existed once
+(`z2ui5_cl_sample_app_g01`, mirroring the restricted area, cross-linked with
+this one); it was removed when the extended samples were reorganised. Should it
+ever return, it comes back as a second `TARGETS` entry in
+`scripts/generate-launchpad.js` and a second row above.
 
 Its shape: a `get_catalog( )` method returning a flat table of tiles, and a
 `view_display( )` that loops the catalog, emitting one link (`header` + optional
@@ -254,8 +266,9 @@ the block plus roughly one space, precomputed by `block_widths( )` /
 `header_width( )` — so the `sub` descriptions of a block line up exactly
 underneath each other in one column, directly next to the links.
 
-`z2ui5_cl_smp_app_000_0` is the old "classic" overview app, retired to `00/99`.
-It is not generated and nothing links to it. Do not extend it.
+`z2ui5_cl_smp_app_000_0`, the old "classic" overview app, is gone with the
+`00/99` package it was retired to (§1). Do not bring it back — `smp_app_000` is
+the only overview app, and it is generated.
 
 ---
 
@@ -328,11 +341,9 @@ from the old catalog.
 ### Generation rules
 
 1. **One catalog per area — and only `src/01` has one.** Apps in `src/01/**`
-   belong in `smp_app_000`. `src/00/**` has no overview app
-   (§3): an app moved to `src/00/02` ("restricted - release/version"),
-   `src/00/97` ("experimental"), `src/00/98` ("testing") or `src/00/99`
-   ("obsolet") gets **no** tile — the generator only reports how
-   many those packages hold.
+   belong in `smp_app_000`. `src/00/**` has no overview app (§3): an app moved
+   to `src/00/97` ("experimental") or `src/00/98` ("testing") gets **no** tile —
+   the generator only reports how many those packages hold.
 2. **Each app appears exactly once**, and every demo app physically present in an
    area is listed (no missing tiles) — **except hidden helper apps**: a class
    whose `<DESCRIPT>` header is `ZZZ` (e.g. `ZZZ - called by SubApp I`) is only
@@ -344,7 +355,8 @@ from the old catalog.
 4. **Group blocks follow folder order.** Emit groups in ascending folder number
    so the on-screen order mirrors the tree; a nested subpackage forms its own
    group directly after its parent slot. The samples live directly in `src/01`
-   today, so there is a single group ("Basic") — when a nested subpackage is
+   today, so there is a single group ("samples") — and with only one group the
+   overview leaves the heading out entirely (§3). When a nested subpackage is
    added, place its group at its numeric position rather than appending it.
 5. **Within a group, sort tiles alphabetically (case-insensitive) by `header`,
    then by `sub`.** Sorting by `header` first keeps numbered series together and
@@ -352,9 +364,9 @@ from the old catalog.
    likewise `Popover I…IV`, `Popup I…III`). The group order from rule 4 is
    untouched; only the tiles inside each group are ordered.
 6. **Moving a subpackage out of `src/01` drops its whole tile group** — there
-   is no catalog on the other side, in `src/00/02` ("restricted") no more than
-   in `src/00/97`, `src/00/98` or `src/00/99`. Moving one *into* `src/01` adds its group at the
-   matching numeric slot (rule 4).
+   is no catalog on the other side, in `src/00/97` no more than in `src/00/98`.
+   Moving one *into* `src/01` adds its group at the matching numeric slot
+   (rule 4).
 7. After every change, verify: `get_catalog( )` and the folder tree agree —
    same apps, same group names (== CTEXT), same grouping, no app in the wrong
    overview, none missing. The safest way to regenerate is to rebuild the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,21 @@ samples were reorganised. Should it ever return, it comes back as a second
 `TARGETS` entry in `scripts/generate-launchpad.js` and a second row above.
 
 Its shape: a `get_catalog( )` method returning a flat table of tiles, and a
-`view_display( )` that loops the catalog, emitting an H3 section title whenever
-the `group` changes and one link (`header` + optional `sub`) per tile.
+`view_display( )` that loops the catalog, emitting one link (`header` + optional
+`sub`) per tile. Around that list it renders a fixed frame: a `GitHub` link in
+the page's `header_content( )` (top right, opens the repository in a new tab),
+an intro `MessageStrip` naming the tile count and the `(A)` / `(C)` markers, and
+an empty `vbox( height = 4rem )` after the last tile so the list does not end
+glued to the page bottom.
+
+An H3 section title is emitted whenever the `group` changes — but only when
+there is more than one group to tell apart. `group_titles_needed( )` decides
+that by comparing every tile's group against the first one; with the whole
+catalog in a single package the heading would only repeat the page title, so it
+is left out. Keep that check free of table expressions (`t_catalog[ 1 ]`): the
+702 downport hoists them out of their guarding condition, so an `IS NOT INITIAL`
+guard around one does not survive the transformation.
+
 Navigation is by class name: the tile press event is the `app` value, `on_event`
 does `to_upper( )` → `CREATE OBJECT TYPE (classname)` → `nav_app_call( )`,
 wrapped in a `TRY`/`CATCH cx_root` so a catalog entry whose class is missing

--- a/README.md
+++ b/README.md
@@ -57,17 +57,16 @@ sample repositories take you further:
 
 #### What's inside
 
-* **`src/01` "basic"** — cloud-ready, downportable and plain OpenUI5 1.71: the
+* **`src/01` "samples"** — cloud-ready, downportable and plain OpenUI5 1.71: the
   sample catalog (bindings, events, popups, framework actions, custom controls
   and use cases) plus a small curated set of control demos — the complete
   control reference lives in
   [samples-controls](https://github.com/abap2UI5/samples-controls). Present on both
   branches.
 * **`src/00` "system"** — no demo category: `00/01` holds the helper classes
-  the samples share (present on both branches), `00/02` the restricted samples
-  (SAPUI5-only controls, features newer than UI5 1.71), `00/97` the
-  experimental ones, `00/98` the test and scaffolding apps, `00/99` the retired
-  apps. Everything but `00/01` is stripped from `702`.
+  the samples share (present on both branches), `00/97` the experimental
+  samples and `00/98` the test and scaffolding apps. Everything but `00/01` is
+  stripped from `702`.
 
 Every sample runs on ABAP Cloud — that is why `main` needs no cloud-specific
 branch. `main` is the default branch and is checked against both ABAP Standard

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -1,8 +1,8 @@
 {
   "global": {
     // Nothing is suppressed: every package under src/ is really checked, the
-    // release/version, experimental, testing and obsolete packages that the
-    // 702 build strips (AGENTS.md section 2) included - they pass. The
+    // experimental and testing packages that the 702 build strips
+    // (AGENTS.md section 2) included - they pass. The
     // on-premise samples that once needed a `noIssues` entry here, because
     // they referenced objects no dependency below can provide
     // (cl_apc_wsp_ext_stateless_base, icfservloc, VBELN_VA, ...), are gone:
@@ -39,8 +39,8 @@
     // installation therefore never needs truncation patterns.
     // "Z2UI5_CL_SMP_" is 13 chars, so 12 remain for the object name.
     // The legacy tokens DEMO and SAMPLE are gone - the last classes carrying
-    // them (the restricted and the obsolete package) were renamed, so the
-    // alternation is dropped and only SMP is accepted.
+    // them were renamed, so the alternation is dropped and only SMP is
+    // accepted.
     "object_naming": {
       "patternKind": "required",
       "severity": "Error",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:agents": "node scripts/check-agents-structure.js",
     "check:strip": "node scripts/check-strip-lists.js",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
-    "downport": "rm -rf src/00/02 src/00/97 src/00/98 src/00/99 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes"
+    "downport": "rm -rf src/00/97 src/00/98 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-launchpad.js
+++ b/scripts/generate-launchpad.js
@@ -5,8 +5,8 @@
  * Launchpad - those demos live in abap2UI5/samples-stack, src/09.)
  *
  * Note: only src/01 has an overview app. Everything under src/00 - the
- * restricted (src/00/02), experimental (src/00/97), testing (src/00/98) and
- * obsolete (src/00/99) samples - is reported but not listed anywhere.
+ * experimental (src/00/97) and testing (src/00/98) samples - is reported but
+ * not listed anywhere.
  *
  * Job (see AGENTS.md §4):
  *   1. Scan every demo app class under src/ and read its abapGit <DESCRIPT>
@@ -34,11 +34,10 @@ const SRC = path.join(__dirname, '..', 'src');
 // area (top-level package under src) -> overview app file. Every area listed
 // here must have its overview app in the tree - a missing file is an error,
 // not something to skip, because it means the catalog stops being generated.
-// src/00 is deliberately absent: the restricted (src/00/02), experimental
-// (src/00/97), testing (src/00/98) and obsolete (src/00/99) samples have no
-// overview app since the extended samples were reorganised, so their tiles are
-// counted but listed nowhere. Add an entry back here the day an extended
-// overview returns.
+// src/00 is deliberately absent: the experimental (src/00/97) and testing
+// (src/00/98) samples have no overview app since the extended samples were
+// reorganised, so their tiles are counted but listed nowhere. Add an entry back
+// here the day an extended overview returns.
 const TARGETS = {
   '01': path.join(SRC, 'z2ui5_cl_smp_app_000.clas.abap'),
 };

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -56,6 +56,11 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
         header        TYPE string
       RETURNING
         VALUE(result) TYPE string.
+    METHODS group_titles_needed
+      IMPORTING
+        t_catalog     TYPE ty_t_tile
+      RETURNING
+        VALUE(result) TYPE abap_bool.
 
   PRIVATE SECTION.
 ENDCLASS.
@@ -123,6 +128,21 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
         navbuttonpress = client->_event_nav_app_leave( )
         shownavbutton  = client->check_app_prev_stack( ) ).
 
+    page->header_content(
+       )->link(
+           text   = `GitHub`
+           target = `_blank`
+           href   = `https://github.com/abap2UI5/samples` ).
+
+    page->message_strip(
+        text     = |All { lines( t_catalog ) } abap2UI5 samples - bindings, events, popups, tables, trees | &&
+                   `and framework actions. Select a link to open a sample, the back button returns here. ` &&
+                   `Markers: (A) frontend action, (C) custom control.`
+        type     = `Information`
+        showicon = abap_true
+        class    = `sapUiSmallMargin` ).
+
+    DATA(show_groups) = group_titles_needed( t_catalog ).
     DATA(prev_group) = ``.
     DATA(prev_base) = ``.
 
@@ -133,10 +153,13 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       DATA(new_block) = abap_false.
 
       IF tile-group <> prev_group.
-        page->title(
-            text  = tile-group
-            level = `H3`
-            class = `sapUiSmallMarginTop sapUiTinyMarginBottom` ).
+
+        IF show_groups = abap_true.
+          page->title(
+              text  = tile-group
+              level = `H3`
+              class = `sapUiSmallMarginTop sapUiTinyMarginBottom` ).
+        ENDIF.
         prev_group = tile-group.
 
       ELSEIF base <> prev_base.
@@ -152,8 +175,8 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
           alignitems = `Center`
           wrap       = `Wrap`
           class      = COND #( WHEN new_block = abap_true
-                               THEN `sapUiTinyMarginBegin sapUiSmallMarginTop`
-                               ELSE `sapUiTinyMarginBegin` ) ).
+                               THEN `sapUiSmallMarginBegin sapUiSmallMarginTop`
+                               ELSE `sapUiSmallMarginBegin` ) ).
 
       IF tile-sub IS INITIAL.
         row->link(
@@ -171,6 +194,9 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
     ENDLOOP.
 
+    " a few blank lines so the last tiles do not end glued to the page bottom
+    page->vbox( height = `4rem` ).
+
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
@@ -179,97 +205,97 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
   METHOD get_catalog.
 
     result = VALUE #(
-      ( group = `Basic` header = `Binding` sub = `Expression Binding` app = `z2ui5_cl_smp_app_027` )
-      ( group = `Basic` header = `Binding` sub = `Formatting Currencies` app = `z2ui5_cl_smp_app_067` )
-      ( group = `Basic` header = `Binding` sub = `Formatting Integers, Decimals, Dates & Time` app = `z2ui5_cl_smp_app_047` )
-      ( group = `Basic` header = `Binding` sub = `Level Structure/Component` app = `z2ui5_cl_smp_app_166` )
-      ( group = `Basic` header = `Binding` sub = `Level Table/Cell` app = `z2ui5_cl_smp_app_144` )
-      ( group = `Basic` header = `Browser` sub = `Clipboard (A)` app = `z2ui5_cl_smp_app_325` )
-      ( group = `Basic` header = `Browser` sub = `Hide/show Soft Keyboard (A)` app = `z2ui5_cl_smp_app_352` )
-      ( group = `Basic` header = `Browser` sub = `Logout (A)` app = `z2ui5_cl_smp_app_361` )
-      ( group = `Basic` header = `Browser` sub = `Open an URL in a new tab (A)` app = `z2ui5_cl_smp_app_073` )
-      ( group = `Basic` header = `Browser` sub = `Open Telephon, Email usw (A)` app = `z2ui5_cl_smp_app_316` )
-      ( group = `Basic` header = `Browser` sub = `Title (A)` app = `z2ui5_cl_smp_app_125` )
-      ( group = `Basic` header = `CSS` sub = `Cell Coloring` app = `z2ui5_cl_smp_app_305` )
-      ( group = `Basic` header = `CSS` sub = `Flex Box with Navigation Examples` app = `z2ui5_cl_smp_app_255` )
-      ( group = `Basic` header = `CSS` sub = `Send your own CSS to the frontend` app = `z2ui5_cl_smp_app_050` )
-      ( group = `Basic` header = `Event` sub = `Additional Infos with t_args` app = `z2ui5_cl_smp_app_167` )
-      ( group = `Basic` header = `Event` sub = `Facet Filter T_arg with Objects` app = `z2ui5_cl_smp_app_197` )
-      ( group = `Basic` header = `Event` sub = `Handle events & change the view` app = `z2ui5_cl_smp_app_004` )
-      ( group = `Basic` header = `Focus` sub = `Focus Aggregations (A)` app = `z2ui5_cl_smp_app_421` )
-      ( group = `Basic` header = `Focus` sub = `Jump with the focus (A)` app = `z2ui5_cl_smp_app_189` )
-      ( group = `Basic` header = `Focus` sub = `Set Focus in Textfield (A)` app = `z2ui5_cl_smp_app_133` )
-      ( group = `Basic` header = `Formatter` sub = `ABAP date strings (DATS/TIMS)` app = `z2ui5_cl_smp_app_450` )
-      ( group = `Basic` header = `Formatter` sub = `Date Object for DatePicker` app = `z2ui5_cl_smp_app_457` )
-      ( group = `Basic` header = `Formatter` sub = `Date Objects for PlanningCalendar` app = `z2ui5_cl_smp_app_456` )
-      ( group = `Basic` header = `Formatter` sub = `Inline Icons` app = `z2ui5_cl_smp_app_466` )
-      ( group = `Basic` header = `Formatter` sub = `Thin frontend, computed in ABAP` app = `z2ui5_cl_smp_app_453` )
-      ( group = `Basic` header = `List` sub = `Events & Visualization` app = `z2ui5_cl_smp_app_048` )
-      ( group = `Basic` header = `List` sub = `Frontend Filter/Sort via Backend Event (A)` app = `z2ui5_cl_smp_app_454` )
-      ( group = `Basic` header = `List` sub = `Frontend Live Filter without Backend (A)` app = `z2ui5_cl_smp_app_455` )
-      ( group = `Basic` header = `Message` sub = `Backend Processing` app = `z2ui5_cl_smp_app_008` )
-      ( group = `Basic` header = `Message` sub = `Message Model & Manager (C)` app = `z2ui5_cl_smp_app_467` )
-      ( group = `Basic` header = `Message` sub = `MessageBox` app = `z2ui5_cl_smp_app_382` )
-      ( group = `Basic` header = `Message` sub = `MessageToast` app = `z2ui5_cl_smp_app_381` )
-      ( group = `Basic` header = `Message` sub = `MessageView (A)` app = `z2ui5_cl_smp_app_452` )
-      ( group = `Basic` header = `Model` sub = `Device Model (A)` app = `z2ui5_cl_smp_app_445` )
-      ( group = `Basic` header = `Model` sub = `Set Size Limit (A)` app = `z2ui5_cl_smp_app_071` )
-      ( group = `Basic` header = `More` sub = `CameraSelector (C)` app = `z2ui5_cl_smp_app_306` )
-      ( group = `Basic` header = `More` sub = `Data Loss Protection (A,C)` app = `z2ui5_cl_smp_app_279` )
-      ( group = `Basic` header = `More` sub = `Error Handling` app = `z2ui5_cl_smp_app_464` )
-      ( group = `Basic` header = `More` sub = `File Download to the Frontend (A)` app = `z2ui5_cl_smp_app_186` )
-      ( group = `Basic` header = `More` sub = `File Uploader (C)` app = `z2ui5_cl_smp_app_074` )
-      ( group = `Basic` header = `More` sub = `Generic Data Reference` app = `z2ui5_cl_smp_app_061` )
-      ( group = `Basic` header = `More` sub = `Geoloaction (C)` app = `z2ui5_cl_smp_app_120` )
-      ( group = `Basic` header = `More` sub = `Keyboard Shortcuts (A)` app = `z2ui5_cl_smp_app_471` )
-      ( group = `Basic` header = `More` sub = `Link with preventDefault (A)` app = `z2ui5_cl_smp_app_472` )
-      ( group = `Basic` header = `More` sub = `Menu Item Path (A)` app = `z2ui5_cl_smp_app_473` )
-      ( group = `Basic` header = `More` sub = `MessagePopover URL Policy (A)` app = `z2ui5_cl_smp_app_474` )
-      ( group = `Basic` header = `More` sub = `Multi Input (C)` app = `z2ui5_cl_smp_app_078` )
-      ( group = `Basic` header = `More` sub = `Panel, setExpanded (A)` app = `z2ui5_cl_smp_app_448` )
-      ( group = `Basic` header = `More` sub = `PDF Viewer Display (A)` app = `z2ui5_cl_smp_app_449` )
-      ( group = `Basic` header = `More` sub = `Read Frontend Infos` app = `z2ui5_cl_smp_app_122` )
-      ( group = `Basic` header = `More` sub = `Require Object in XML View` app = `z2ui5_cl_smp_app_163` )
-      ( group = `Basic` header = `More` sub = `Storage Local/Session (A,C)` app = `z2ui5_cl_smp_app_327` )
-      ( group = `Basic` header = `More` sub = `Wizard Control (A)` app = `z2ui5_cl_smp_app_202` )
-      ( group = `Basic` header = `NavContainer` sub = `Popup (A)` app = `z2ui5_cl_smp_app_170` )
-      ( group = `Basic` header = `NavContainer` sub = `Simple (A)` app = `z2ui5_cl_smp_app_088` )
-      ( group = `Basic` header = `Navigation` sub = `Call and leave to apps` app = `z2ui5_cl_smp_app_024` )
-      ( group = `Basic` header = `Navigation` sub = `Exchange Data and Event` app = `z2ui5_cl_smp_app_488` )
-      ( group = `Basic` header = `Nested Views` sub = `Basic Example` app = `z2ui5_cl_smp_app_065` )
-      ( group = `Basic` header = `Nested Views` sub = `Head & Item Table` app = `z2ui5_cl_smp_app_097` )
-      ( group = `Basic` header = `Nested Views` sub = `Head & Item Table & Detail` app = `z2ui5_cl_smp_app_098` )
-      ( group = `Basic` header = `Nested Views` sub = `Sub-App` app = `z2ui5_cl_smp_app_104` )
-      ( group = `Basic` header = `Popover` sub = `Display Quick View` app = `z2ui5_cl_smp_app_109` )
-      ( group = `Basic` header = `Popover` sub = `Display Toggle (A)` app = `z2ui5_cl_smp_app_465` )
-      ( group = `Basic` header = `Popover` sub = `Item Level of Table` app = `z2ui5_cl_smp_app_052` )
-      ( group = `Basic` header = `Popover` sub = `List to select in Popover` app = `z2ui5_cl_smp_app_081` )
-      ( group = `Basic` header = `Popover` sub = `Opened with the View Build` app = `z2ui5_cl_smp_app_490` )
-      ( group = `Basic` header = `Popover` sub = `Simple Example` app = `z2ui5_cl_smp_app_026` )
-      ( group = `Basic` header = `Popup` sub = `Aggregation binding to the selected row (A)` app = `z2ui5_cl_smp_app_470` )
-      ( group = `Basic` header = `Popup` sub = `Different ways of calling Popups (A)` app = `z2ui5_cl_smp_app_012` )
-      ( group = `Basic` header = `Popup` sub = `Popup in Popup - Backend Stack Handling` app = `z2ui5_cl_smp_app_161` )
-      ( group = `Basic` header = `Popup` sub = `Value Help with Popups` app = `z2ui5_cl_smp_app_009` )
-      ( group = `Basic` header = `Scroll` sub = `Scroll into view (A)` app = `z2ui5_cl_smp_app_363` )
-      ( group = `Basic` header = `Scroll` sub = `Scroll to position (A)` app = `z2ui5_cl_smp_app_362` )
-      ( group = `Basic` header = `Table` sub = `Backend Filter` app = `z2ui5_cl_smp_app_045` )
-      ( group = `Basic` header = `Table` sub = `Drag and Drop (A)` app = `z2ui5_cl_smp_app_459` )
-      ( group = `Basic` header = `Table` sub = `Editable` app = `z2ui5_cl_smp_app_011` )
-      ( group = `Basic` header = `Table` sub = `Live Search via Backend` app = `z2ui5_cl_smp_app_059` )
-      ( group = `Basic` header = `Table` sub = `Search via Backend` app = `z2ui5_cl_smp_app_053` )
-      ( group = `Basic` header = `Table` sub = `Selection Modes: Single Select & Multi Select` app = `z2ui5_cl_smp_app_019` )
-      ( group = `Basic` header = `Table` sub = `Table with ScrollContainer` app = `z2ui5_cl_smp_app_006` )
-      ( group = `Basic` header = `Templating` sub = `Basic Example` app = `z2ui5_cl_smp_app_173` )
-      ( group = `Basic` header = `Templating` sub = `Nested Views` app = `z2ui5_cl_smp_app_176` )
-      ( group = `Basic` header = `Timer` sub = `Loading Indicator with WAIT UP Backend (A)` app = `z2ui5_cl_smp_app_064` )
-      ( group = `Basic` header = `Timer` sub = `Wait n MS and call again the server (A)` app = `z2ui5_cl_smp_app_028` )
-      ( group = `Basic` header = `Tree` sub = `Drag and Drop (A,C)` app = `z2ui5_cl_smp_app_461` )
-      ( group = `Basic` header = `Tree` sub = `Editable with Custom Item (C)` app = `z2ui5_cl_smp_app_463` )
-      ( group = `Basic` header = `Tree` sub = `Inside Popup (C)` app = `z2ui5_cl_smp_app_462` )
-      ( group = `Basic` header = `Tree` sub = `Simple` app = `z2ui5_cl_smp_app_460` )
-      ( group = `Basic` header = `ui.Table` sub = `Default Filtering (C)` app = `z2ui5_cl_smp_app_143` )
-      ( group = `Basic` header = `ui.Table` sub = `Events on Cell Level` app = `z2ui5_cl_smp_app_160` )
-      ( group = `Basic` header = `ui.Table` sub = `Full Example` app = `z2ui5_cl_smp_app_070` ) ).
+      ( group = `samples` header = `Binding` sub = `Expression Binding` app = `z2ui5_cl_smp_app_027` )
+      ( group = `samples` header = `Binding` sub = `Formatting Currencies` app = `z2ui5_cl_smp_app_067` )
+      ( group = `samples` header = `Binding` sub = `Formatting Integers, Decimals, Dates & Time` app = `z2ui5_cl_smp_app_047` )
+      ( group = `samples` header = `Binding` sub = `Level Structure/Component` app = `z2ui5_cl_smp_app_166` )
+      ( group = `samples` header = `Binding` sub = `Level Table/Cell` app = `z2ui5_cl_smp_app_144` )
+      ( group = `samples` header = `Browser` sub = `Clipboard (A)` app = `z2ui5_cl_smp_app_325` )
+      ( group = `samples` header = `Browser` sub = `Hide/show Soft Keyboard (A)` app = `z2ui5_cl_smp_app_352` )
+      ( group = `samples` header = `Browser` sub = `Logout (A)` app = `z2ui5_cl_smp_app_361` )
+      ( group = `samples` header = `Browser` sub = `Open an URL in a new tab (A)` app = `z2ui5_cl_smp_app_073` )
+      ( group = `samples` header = `Browser` sub = `Open Telephon, Email usw (A)` app = `z2ui5_cl_smp_app_316` )
+      ( group = `samples` header = `Browser` sub = `Title (A)` app = `z2ui5_cl_smp_app_125` )
+      ( group = `samples` header = `Control` sub = `CameraSelector (C)` app = `z2ui5_cl_smp_app_306` )
+      ( group = `samples` header = `Control` sub = `File Uploader (C)` app = `z2ui5_cl_smp_app_074` )
+      ( group = `samples` header = `Control` sub = `Multi Input (C)` app = `z2ui5_cl_smp_app_078` )
+      ( group = `samples` header = `Control` sub = `Panel, setExpanded (A)` app = `z2ui5_cl_smp_app_448` )
+      ( group = `samples` header = `Control` sub = `PDF Viewer Display (A)` app = `z2ui5_cl_smp_app_449` )
+      ( group = `samples` header = `Control` sub = `Wizard Control (A)` app = `z2ui5_cl_smp_app_202` )
+      ( group = `samples` header = `CSS` sub = `Cell Coloring` app = `z2ui5_cl_smp_app_305` )
+      ( group = `samples` header = `CSS` sub = `Flex Box with Navigation Examples` app = `z2ui5_cl_smp_app_255` )
+      ( group = `samples` header = `CSS` sub = `Send your own CSS to the frontend` app = `z2ui5_cl_smp_app_050` )
+      ( group = `samples` header = `Event` sub = `Additional Infos with t_args` app = `z2ui5_cl_smp_app_167` )
+      ( group = `samples` header = `Event` sub = `Facet Filter T_arg with Objects` app = `z2ui5_cl_smp_app_197` )
+      ( group = `samples` header = `Event` sub = `Handle events & change the view` app = `z2ui5_cl_smp_app_004` )
+      ( group = `samples` header = `Focus` sub = `Focus Aggregations (A)` app = `z2ui5_cl_smp_app_421` )
+      ( group = `samples` header = `Focus` sub = `Jump with the focus (A)` app = `z2ui5_cl_smp_app_189` )
+      ( group = `samples` header = `Focus` sub = `Set Focus in Textfield (A)` app = `z2ui5_cl_smp_app_133` )
+      ( group = `samples` header = `Formatter` sub = `ABAP date strings (DATS/TIMS)` app = `z2ui5_cl_smp_app_450` )
+      ( group = `samples` header = `Formatter` sub = `Date Object for DatePicker` app = `z2ui5_cl_smp_app_457` )
+      ( group = `samples` header = `Formatter` sub = `Date Objects for PlanningCalendar` app = `z2ui5_cl_smp_app_456` )
+      ( group = `samples` header = `Formatter` sub = `Inline Icons` app = `z2ui5_cl_smp_app_466` )
+      ( group = `samples` header = `Formatter` sub = `Thin frontend, computed in ABAP` app = `z2ui5_cl_smp_app_453` )
+      ( group = `samples` header = `Function` sub = `Data Loss Protection (A,C)` app = `z2ui5_cl_smp_app_279` )
+      ( group = `samples` header = `Function` sub = `File Download to the Frontend (A)` app = `z2ui5_cl_smp_app_186` )
+      ( group = `samples` header = `Function` sub = `Geoloaction (C)` app = `z2ui5_cl_smp_app_120` )
+      ( group = `samples` header = `Function` sub = `Link with preventDefault (A)` app = `z2ui5_cl_smp_app_472` )
+      ( group = `samples` header = `Function` sub = `Menu Item Path (A)` app = `z2ui5_cl_smp_app_473` )
+      ( group = `samples` header = `Function` sub = `MessagePopover URL Policy (A)` app = `z2ui5_cl_smp_app_474` )
+      ( group = `samples` header = `Function` sub = `Read Frontend Infos` app = `z2ui5_cl_smp_app_122` )
+      ( group = `samples` header = `Function` sub = `Storage Local/Session (A,C)` app = `z2ui5_cl_smp_app_327` )
+      ( group = `samples` header = `List` sub = `Events & Visualization` app = `z2ui5_cl_smp_app_048` )
+      ( group = `samples` header = `List` sub = `Frontend Filter/Sort via Backend Event (A)` app = `z2ui5_cl_smp_app_454` )
+      ( group = `samples` header = `List` sub = `Frontend Live Filter without Backend (A)` app = `z2ui5_cl_smp_app_455` )
+      ( group = `samples` header = `Message` sub = `Backend Processing` app = `z2ui5_cl_smp_app_008` )
+      ( group = `samples` header = `Message` sub = `Message Model & Manager (C)` app = `z2ui5_cl_smp_app_467` )
+      ( group = `samples` header = `Message` sub = `MessageBox` app = `z2ui5_cl_smp_app_382` )
+      ( group = `samples` header = `Message` sub = `MessageToast` app = `z2ui5_cl_smp_app_381` )
+      ( group = `samples` header = `Message` sub = `MessageView (A)` app = `z2ui5_cl_smp_app_452` )
+      ( group = `samples` header = `Model` sub = `Device Model (A)` app = `z2ui5_cl_smp_app_445` )
+      ( group = `samples` header = `Model` sub = `Set Size Limit (A)` app = `z2ui5_cl_smp_app_071` )
+      ( group = `samples` header = `More` sub = `Generic Data Reference` app = `z2ui5_cl_smp_app_061` )
+      ( group = `samples` header = `More` sub = `Keyboard Shortcuts (A)` app = `z2ui5_cl_smp_app_471` )
+      ( group = `samples` header = `More` sub = `Require Object in XML View` app = `z2ui5_cl_smp_app_163` )
+      ( group = `samples` header = `NavContainer` sub = `Popup (A)` app = `z2ui5_cl_smp_app_170` )
+      ( group = `samples` header = `NavContainer` sub = `Simple (A)` app = `z2ui5_cl_smp_app_088` )
+      ( group = `samples` header = `Navigation` sub = `Call and leave to apps` app = `z2ui5_cl_smp_app_024` )
+      ( group = `samples` header = `Navigation` sub = `Exchange Data and Event between Apps` app = `z2ui5_cl_smp_app_488` )
+      ( group = `samples` header = `Navigation` sub = `Uncatched Error` app = `z2ui5_cl_smp_app_464` )
+      ( group = `samples` header = `Nested Views` sub = `Basic Example` app = `z2ui5_cl_smp_app_065` )
+      ( group = `samples` header = `Nested Views` sub = `Head & Item Table` app = `z2ui5_cl_smp_app_097` )
+      ( group = `samples` header = `Nested Views` sub = `Head & Item Table & Detail` app = `z2ui5_cl_smp_app_098` )
+      ( group = `samples` header = `Nested Views` sub = `Sub-App` app = `z2ui5_cl_smp_app_104` )
+      ( group = `samples` header = `Popover` sub = `Display Quick View` app = `z2ui5_cl_smp_app_109` )
+      ( group = `samples` header = `Popover` sub = `Display Toggle (A)` app = `z2ui5_cl_smp_app_465` )
+      ( group = `samples` header = `Popover` sub = `Item Level of Table` app = `z2ui5_cl_smp_app_052` )
+      ( group = `samples` header = `Popover` sub = `List to select in Popover` app = `z2ui5_cl_smp_app_081` )
+      ( group = `samples` header = `Popover` sub = `Opened with the View Build` app = `z2ui5_cl_smp_app_490` )
+      ( group = `samples` header = `Popover` sub = `Simple Example` app = `z2ui5_cl_smp_app_026` )
+      ( group = `samples` header = `Popup` sub = `Aggregation binding to the selected row (A)` app = `z2ui5_cl_smp_app_470` )
+      ( group = `samples` header = `Popup` sub = `Different ways of calling Popups (A)` app = `z2ui5_cl_smp_app_012` )
+      ( group = `samples` header = `Popup` sub = `Popup in Popup - Backend Stack Handling` app = `z2ui5_cl_smp_app_161` )
+      ( group = `samples` header = `Popup` sub = `Value Help with Popups` app = `z2ui5_cl_smp_app_009` )
+      ( group = `samples` header = `Scroll` sub = `Scroll into view (A)` app = `z2ui5_cl_smp_app_363` )
+      ( group = `samples` header = `Scroll` sub = `Scroll to position (A)` app = `z2ui5_cl_smp_app_362` )
+      ( group = `samples` header = `Table` sub = `Backend Filter` app = `z2ui5_cl_smp_app_045` )
+      ( group = `samples` header = `Table` sub = `Drag and Drop (A)` app = `z2ui5_cl_smp_app_459` )
+      ( group = `samples` header = `Table` sub = `Editable` app = `z2ui5_cl_smp_app_011` )
+      ( group = `samples` header = `Table` sub = `Live Search via Backend` app = `z2ui5_cl_smp_app_059` )
+      ( group = `samples` header = `Table` sub = `Search via Backend` app = `z2ui5_cl_smp_app_053` )
+      ( group = `samples` header = `Table` sub = `Selection Modes: Single Select & Multi Select` app = `z2ui5_cl_smp_app_019` )
+      ( group = `samples` header = `Table` sub = `Table with ScrollContainer` app = `z2ui5_cl_smp_app_006` )
+      ( group = `samples` header = `Templating` sub = `Basic Example` app = `z2ui5_cl_smp_app_173` )
+      ( group = `samples` header = `Templating` sub = `Nested Views` app = `z2ui5_cl_smp_app_176` )
+      ( group = `samples` header = `Timer` sub = `Loading Indicator with WAIT UP Backend (A)` app = `z2ui5_cl_smp_app_064` )
+      ( group = `samples` header = `Timer` sub = `Wait n MS and call again the server (A)` app = `z2ui5_cl_smp_app_028` )
+      ( group = `samples` header = `Tree` sub = `Drag and Drop (A,C)` app = `z2ui5_cl_smp_app_461` )
+      ( group = `samples` header = `Tree` sub = `Editable with Custom Item (C)` app = `z2ui5_cl_smp_app_463` )
+      ( group = `samples` header = `Tree` sub = `Inside Popup (C)` app = `z2ui5_cl_smp_app_462` )
+      ( group = `samples` header = `Tree` sub = `Simple` app = `z2ui5_cl_smp_app_460` )
+      ( group = `samples` header = `ui.Table` sub = `Default Filtering (C)` app = `z2ui5_cl_smp_app_143` )
+      ( group = `samples` header = `ui.Table` sub = `Events on Cell Level` app = `z2ui5_cl_smp_app_160` )
+      ( group = `samples` header = `ui.Table` sub = `Full Example` app = `z2ui5_cl_smp_app_070` ) ).
 
   ENDMETHOD.
 
@@ -353,6 +379,27 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
     ELSE.
       result = header_base( header ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD group_titles_needed.
+
+    " A group heading only tells the reader something when there is more than
+    " one group to tell apart. With every sample in a single package it would
+    " just repeat the page title, so it is left out.
+    DATA first_group TYPE string.
+    LOOP AT t_catalog INTO DATA(tile).
+
+      IF sy-tabix = 1.
+        first_group = tile-group.
+
+      ELSEIF tile-group <> first_group.
+        result = abap_true.
+        RETURN.
+      ENDIF.
+
+    ENDLOOP.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary

This change reorganizes the samples repository structure by removing the restricted and obsolete package categories, consolidating all portable samples under a single "samples" group. The overview app (`z2ui5_cl_smp_app_000`) is enhanced with better UI presentation and conditional group title rendering.

## Key Changes

**Repository Structure (AGENTS.md, README.md, documentation)**
- Removed `src/00/02` ("restricted - release/version") and `src/00/99` ("obsolet") packages entirely
- Renamed `src/01` "Basic" to `src/01` "samples" for clarity
- Updated all references in build configuration, CI workflows, and documentation to reflect the new two-package model (`src/00` system + `src/01` samples)
- Simplified compatibility rules: samples now only need to be ABAP Cloud ready and downportable to 7.02, or held back by maturity (`src/00/97` experimental, `src/00/98` testing)

**Overview App (`z2ui5_cl_smp_app_000`)**
- Added `group_titles_needed()` method to conditionally render group headings only when multiple groups exist (avoids redundant titles when all samples are in one group)
- Enhanced page header with GitHub repository link in `header_content()`
- Added informational `MessageStrip` displaying tile count and explanation of `(A)` and `(C)` markers
- Added trailing empty `vbox( height = 4rem )` to prevent tiles from ending glued to page bottom
- Updated all catalog entries from `group = 'Basic'` to `group = 'samples'`
- Reorganized catalog entries into new logical groups: "Control", "Function", "Navigation" (moved error handling here)
- Adjusted CSS class margins from `sapUiTinyMarginBegin` to `sapUiSmallMarginBegin` for better spacing

**Build Configuration**
- Updated `package.json` downport strip list to remove `src/00/02` and `src/00/99`
- Updated CI build table in AGENTS.md to reflect removal of two stripped packages
- Updated comments in `abaplint.jsonc`, `.github/abaplint/rename_test.jsonc`, and `.github/workflows/publish-702.yaml`

## Implementation Details

The `group_titles_needed()` method uses a simple loop-based approach (avoiding table expressions) to check if the catalog contains more than one unique group value. This ensures the method survives the 702 downport transformation without issues.

The catalog reorganization consolidates related samples into clearer functional groups while maintaining alphabetical sorting within each group and preserving the overall sample count and functionality.

https://claude.ai/code/session_012sNdFkeYnqczTcouXAtJEZ