### PR TITLE
refactor: use client->get_event( ) and get_app_prev( ) shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,7 +604,7 @@ Use a `CASE` statement (inside an `ELSEIF client->check_on_event( )` block) only
 | Messages | `message_box_display(text)`, `message_toast_display(text)` | User notifications |
 | Session | `set_session_stateful(val)`, `set_app_state_active(val)` | Session management |
 | Browser | `set_push_state(val)`, `follow_up_action(val)` | Browser interaction (history back rides `follow_up_action( cs_event-history_back )`; routing via `cs_event-set_nav_routing`) |
-| Info | `get()`, `get_event_arg()`, `get_app(id)` | Request/context data |
+| Info | `get()`, `get_event()`, `get_event_arg()`, `get_app(id)` | Request/context data |
 | Constants | `cs_event`, `cs_view` | Predefined event IDs and view names |
 
 ### Navigation
@@ -631,7 +631,7 @@ Only use the manual pattern (handling `BACK` in `on_event`) when you need to do 
 ```abap
 METHOD on_event.
 
-  CASE client->get( )-event.
+  CASE client->get_event( ).
     WHEN `BACK`.
       " interact with previous app instance first
       CAST z2ui5_cl_app_parent( client->get_app_prev( ) )->set_result( s_result ).
@@ -851,7 +851,7 @@ CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `SAVE`.
         on_event_save( ).
       WHEN `BACK`.

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `POPUP_OPEN`.
         s_input = VALUE #( hint   = `this label was styled from ABAP`

--- a/src/00/97/z2ui5_cl_smp_app_321.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_321.clas.abap
@@ -32,7 +32,7 @@ CLASS z2ui5_cl_smp_app_321 IMPLEMENTATION.
               )->stringify( ) ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_POST`.
         client->message_toast_display( `data updated` ).
         "this is where the magic happens...

--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -40,7 +40,7 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_POST`.
         client->set_push_state( `/head/pos/` && client->get( )-s_draft-id ).
     ENDCASE.

--- a/src/00/97/z2ui5_cl_smp_app_323.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_323.clas.abap
@@ -32,7 +32,7 @@ CLASS z2ui5_cl_smp_app_323 IMPLEMENTATION.
               )->stringify( ) ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_POST`.
         client->follow_up_action( z2ui5_if_client=>cs_event-clipboard_app_state ).

--- a/src/00/97/z2ui5_cl_smp_app_468.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_468.clas.abap
@@ -48,7 +48,7 @@ CLASS z2ui5_cl_smp_app_468 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `INC`.
         counter = counter + 1.

--- a/src/00/97/z2ui5_cl_smp_app_480.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_480.clas.abap
@@ -47,7 +47,7 @@ CLASS z2ui5_cl_smp_app_480 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `INC`.
         counter = counter + 1.

--- a/src/00/98/z2ui5_cl_smp_app_117.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_117.clas.abap
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_131.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_131.clas.abap
@@ -38,7 +38,7 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_138.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_138.clas.abap
@@ -63,7 +63,7 @@ CLASS z2ui5_cl_smp_app_138 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_POST`.
         client->message_toast_display( |{ quantity } - send to the server| ).

--- a/src/00/98/z2ui5_cl_smp_app_185.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_185.clas.abap
@@ -38,7 +38,7 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_191.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_191.clas.abap
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_195.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_195.clas.abap
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_199.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_199.clas.abap
@@ -25,7 +25,7 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `CLEAR`.
         refresh_data( ).
 

--- a/src/00/98/z2ui5_cl_smp_app_211.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_211.clas.abap
@@ -38,7 +38,7 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `ONSELECTICONTABBAR`.
 
         CASE mv_selectedkey.

--- a/src/00/98/z2ui5_cl_smp_app_324.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_324.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_324 IMPLEMENTATION.
                                     )->stringify( ) ).
         ENDIF.
 
-        CASE client->get( )-event.
+        CASE client->get_event( ).
           WHEN `PRESS`.
             call_dynpro( ).
         ENDCASE.

--- a/src/00/98/z2ui5_cl_smp_app_328.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_328.clas.abap
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
 
         ASSIGN mt_table->* TO <tab>.

--- a/src/00/98/z2ui5_cl_smp_app_335.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_335.clas.abap
@@ -39,7 +39,7 @@ CLASS z2ui5_cl_smp_app_335 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
 
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).

--- a/src/00/98/z2ui5_cl_smp_app_337.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_337.clas.abap
@@ -44,7 +44,7 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_338.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_338.clas.abap
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ONSELECTICONTABBAR`.
 

--- a/src/00/98/z2ui5_cl_smp_app_339.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_339.clas.abap
@@ -80,7 +80,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SELECTION_CHANGE`.
 

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -81,7 +81,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SELECTION_CHANGE`.
 

--- a/src/00/98/z2ui5_cl_smp_app_344.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_344.clas.abap
@@ -50,7 +50,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_345.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_345.clas.abap
@@ -163,7 +163,7 @@ CLASS z2ui5_cl_smp_app_345 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_347.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_347.clas.abap
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_347 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_348.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_348.clas.abap
@@ -40,7 +40,7 @@ CLASS z2ui5_cl_smp_app_348 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_349.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_349.clas.abap
@@ -44,7 +44,7 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GO`.
         DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
         client->nav_app_call( app ).

--- a/src/00/98/z2ui5_cl_smp_app_446.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_446.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_446 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `TOAST`.
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_global

--- a/src/00/98/z2ui5_cl_smp_app_447.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_447.clas.abap
@@ -46,7 +46,7 @@ CLASS z2ui5_cl_smp_app_447 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       " t_arg is positional: id, method, params (the view defaults to
       " cs_view-main and can be omitted for a main-view control)

--- a/src/01/z2ui5_cl_smp_app_004.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_004.clas.abap
@@ -40,7 +40,7 @@ CLASS z2ui5_cl_smp_app_004 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_ROUNDTRIP`.
         client->message_box_display( `server-client roundtrip, method on_event of the abap controller was called` ).
       WHEN `BUTTON_RESTART`.

--- a/src/01/z2ui5_cl_smp_app_006.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_006.clas.abap
@@ -57,7 +57,7 @@ CLASS Z2UI5_CL_SMP_APP_006 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `SORT_ASCENDING`.
         SORT t_tab BY count ASCENDING.
         client->message_toast_display( `sort ascending` ).

--- a/src/01/z2ui5_cl_smp_app_008.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_008.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_smp_app_008 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_MESSAGE_BOX_SY`.
         DATA(ls_msg_sy) = z2ui5_cl_smp_context=>msg_get_by_msg(
             id = `NET`

--- a/src/01/z2ui5_cl_smp_app_009.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_009.clas.abap
@@ -108,7 +108,7 @@ CLASS z2ui5_cl_smp_app_009 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `POPUP_TABLE_VALUE`.
         t_suggestion_sel = t_suggestion.
         popup_value_suggestion( ).

--- a/src/01/z2ui5_cl_smp_app_012.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_012.clas.abap
@@ -25,7 +25,7 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
     IF check_popup = abap_true.
 
       check_popup = abap_false.
-      DATA(app) = CAST z2ui5_cl_smp_app_020( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+      DATA(app) = CAST z2ui5_cl_smp_app_020( client->get_app_prev( ) ).
       client->message_toast_display( |{ app->event } pressed| ).
     ENDIF.
 
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_POPUP_01`.
         popup_decide( ).
         client->view_destroy( ).

--- a/src/01/z2ui5_cl_smp_app_020.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_020.clas.abap
@@ -41,9 +41,9 @@ CLASS z2ui5_cl_smp_app_020 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN cancel_event OR confirm_event.
-        event = client->get( )-event.
+        event = client->get_event( ).
         client->popup_destroy( ).
         client->nav_app_leave( ).
         RETURN.

--- a/src/01/z2ui5_cl_smp_app_024.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_024.clas.abap
@@ -49,7 +49,7 @@ CLASS Z2UI5_CL_SMP_APP_024 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `CALL_NEW_APP`.
         client->nav_app_call( NEW z2ui5_cl_smp_app_025( ) ).

--- a/src/01/z2ui5_cl_smp_app_025.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_025.clas.abap
@@ -42,7 +42,7 @@ CLASS z2ui5_cl_smp_app_025 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_ROUNDTRIP`.
         client->message_box_display( `server-client roundtrip, method on_event of the abap controller was called` ).
@@ -51,7 +51,7 @@ CLASS z2ui5_cl_smp_app_025 IMPLEMENTATION.
         client->nav_app_call( NEW z2ui5_cl_smp_app_025( ) ).
 
       WHEN `BUTTON_READ_PREVIOUS`.
-        DATA(app_024) = CAST z2ui5_cl_smp_app_024( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+        DATA(app_024) = CAST z2ui5_cl_smp_app_024( client->get_app_prev( ) ).
         input_previous = app_024->input2.
         client->message_toast_display( `data of previous app read` ).
 

--- a/src/01/z2ui5_cl_smp_app_045.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_045.clas.abap
@@ -45,7 +45,7 @@ CLASS Z2UI5_CL_SMP_APP_045 IMPLEMENTATION.
       refresh_data( ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `FILTER_INFO`.
         refresh_data( ).

--- a/src/01/z2ui5_cl_smp_app_047.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_047.clas.abap
@@ -43,7 +43,7 @@ CLASS Z2UI5_CL_SMP_APP_047 IMPLEMENTATION.
       client->_bind( mt_tab ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_INT`.
         int_sum = int1 + int2.
       WHEN `BUTTON_DEC`.

--- a/src/01/z2ui5_cl_smp_app_048.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_048.clas.abap
@@ -39,7 +39,7 @@ CLASS z2ui5_cl_smp_app_048 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `EDIT`.
         DATA(lv_row_title) = client->get_event_arg( ).
         client->message_box_display( |EDIT - { lv_row_title }| ).

--- a/src/01/z2ui5_cl_smp_app_050.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_050.clas.abap
@@ -21,7 +21,7 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
       quantity = `500`.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_POST`.
         client->message_toast_display( |{ product } { quantity } - send to the server| ).
     ENDCASE.

--- a/src/01/z2ui5_cl_smp_app_052.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_052.clas.abap
@@ -117,7 +117,7 @@ CLASS z2ui5_cl_smp_app_052 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_DETAILS`.
         client->popover_destroy( ).

--- a/src/01/z2ui5_cl_smp_app_053.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_053.clas.abap
@@ -47,7 +47,7 @@ CLASS z2ui5_cl_smp_app_053 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_SEARCH` OR `BUTTON_START`.
         set_data( ).

--- a/src/01/z2ui5_cl_smp_app_065.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_065.clas.abap
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_smp_app_065 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `TEST`.
         client->message_box_display( |input { mv_input_nest }| ).

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -79,7 +79,7 @@ CLASS Z2UI5_CL_SMP_APP_070 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON_SEARCH` OR `BUTTON_START`.
         client->message_toast_display( `Search Entries` ).
         set_data( ).

--- a/src/01/z2ui5_cl_smp_app_073.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_073.clas.abap
@@ -51,7 +51,7 @@ CLASS z2ui5_cl_smp_app_073 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `BUTTON_OPEN_NEW_TAB`.
 

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
 
     TRY.
 
-        CASE client->get( )-event.
+        CASE client->get_event( ).
 
           WHEN `START` OR `CHANGE`.
             view_display( ).

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -81,7 +81,7 @@ CLASS Z2UI5_CL_SMP_APP_078 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `UPDATE_BACKEND`.
 

--- a/src/01/z2ui5_cl_smp_app_081.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_081.clas.abap
@@ -153,7 +153,7 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SEL_CHANGE`.
         DATA(lt_sel) = mt_tab.

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -36,9 +36,9 @@ CLASS z2ui5_cl_smp_app_088 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN OTHERS.
-        mv_page = client->get( )-event.
+        mv_page = client->get_event( ).
         view_display( ).
 
     ENDCASE.

--- a/src/01/z2ui5_cl_smp_app_097.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_097.clas.abap
@@ -127,7 +127,7 @@ CLASS z2ui5_cl_smp_app_097 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `ROW_DELETE`.
 

--- a/src/01/z2ui5_cl_smp_app_098.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_098.clas.abap
@@ -153,7 +153,7 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN 'NN_VIEW'.
         client->message_box_display(  `Event in nested nested view raised` ).

--- a/src/01/z2ui5_cl_smp_app_109.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_109.clas.abap
@@ -131,7 +131,7 @@ CLASS z2ui5_cl_smp_app_109 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `CLOSE_POPOVER`.
         client->popover_destroy( ).
       WHEN `POPOVER`.

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `GEOLOCATION_ERROR`.
 

--- a/src/01/z2ui5_cl_smp_app_133.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_133.clas.abap
@@ -83,11 +83,11 @@ CLASS Z2UI5_CL_SMP_APP_133 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BUTTON01` OR `BUTTON02`.
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-set_focus
-            t_arg = VALUE #( ( client->get( )-event ) ( selstart ) ( selend ) ) ).
+            t_arg = VALUE #( ( client->get_event( ) ) ( selstart ) ( selend ) ) ).
         client->message_toast_display( |focus changed| ).
     ENDCASE.
 

--- a/src/01/z2ui5_cl_smp_app_161.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_161.clas.abap
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GOTO_2ND`.
         simple_popup2( ).
 

--- a/src/01/z2ui5_cl_smp_app_167.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_167.clas.abap
@@ -74,7 +74,7 @@ CLASS Z2UI5_CL_SMP_APP_167 IMPLEMENTATION.
       set_view( ).
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `EVENT_FIX_VAL` OR `EVENT_MODEL_VALUE` OR `SOURCE_PROPERTY_TEXT` OR `EVENT_PROPERTY_VALUE` OR `PARENT_PROPERTY_ID`.
         client->message_box_display( |backend event: { client->get_event_arg( ) }| ).
     ENDCASE.

--- a/src/01/z2ui5_cl_smp_app_170.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_170.clas.abap
@@ -119,7 +119,7 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `GOTO_2ND`.
         simple_popup2( ).
 

--- a/src/01/z2ui5_cl_smp_app_173.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_173.clas.abap
@@ -104,7 +104,7 @@ CLASS Z2UI5_CL_SMP_APP_173 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `CHANGE_FLAG`.
         view_display( ).
     ENDCASE.

--- a/src/01/z2ui5_cl_smp_app_189.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_189.clas.abap
@@ -23,7 +23,7 @@ CLASS Z2UI5_CL_SMP_APP_189 IMPLEMENTATION.
 
   METHOD dispatch.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `one_enter`.
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-set_focus

--- a/src/01/z2ui5_cl_smp_app_197.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_197.clas.abap
@@ -96,7 +96,7 @@ CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `RESET`.
         mt_table = mt_table_full.
       WHEN `FILTER`.

--- a/src/01/z2ui5_cl_smp_app_202.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_202.clas.abap
@@ -80,7 +80,7 @@ CLASS Z2UI5_CL_SMP_APP_202 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `STEP22` OR `STEP23`.
         " the original wizard flow (discardProgress + setNextStep) as two
         " generic whitelisted control calls - t_arg is positional:
@@ -91,7 +91,7 @@ CLASS Z2UI5_CL_SMP_APP_202 IMPLEMENTATION.
             t_arg = VALUE #( ( `wiz` ) ( `discardProgress` ) ( `STEP2` ) ) ).
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-control_by_id
-            t_arg = VALUE #( ( `STEP2` ) ( `setNextStep` ) ( client->get( )-event ) ) ).
+            t_arg = VALUE #( ( `STEP2` ) ( `setNextStep` ) ( client->get_event( ) ) ) ).
 
     ENDCASE.
 

--- a/src/01/z2ui5_cl_smp_app_279.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_279.clas.abap
@@ -74,7 +74,7 @@ CLASS Z2UI5_CL_SMP_APP_279 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `BACK`.
         IF dirty = abap_true.
           security_check_popup( ).
@@ -122,7 +122,7 @@ CLASS Z2UI5_CL_SMP_APP_279 IMPLEMENTATION.
   METHOD on_navigation.
 
     TRY.
-        DATA(prev) = client->get_app( client->get( )-s_draft-id_prev_app ).
+        DATA(prev) = client->get_app_prev( ).
         DATA(confirm_leave) = CAST z2ui5_cl_pop_to_confirm( prev )->result( ).
 
       CATCH cx_root.

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -137,7 +137,7 @@ CLASS Z2UI5_CL_SMP_APP_306 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `CAPTURE`.
         INSERT VALUE #( data             = mv_picture_base
@@ -189,7 +189,7 @@ CLASS Z2UI5_CL_SMP_APP_306 IMPLEMENTATION.
   METHOD on_navigation.
 
     TRY.
-        DATA(lo_prev) = client->get_app( client->get( )-s_draft-id_prev_app ).
+        DATA(lo_prev) = client->get_app_prev( ).
         DATA(result) = CAST z2ui5_cl_pop_image_editor( lo_prev )->result( ).
 
         IF result-check_confirmed = abap_true.

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -80,7 +80,7 @@ CLASS Z2UI5_CL_SMP_APP_325 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `COPY_INPUT`.
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-clipboard_copy

--- a/src/01/z2ui5_cl_smp_app_327.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_327.clas.abap
@@ -73,7 +73,7 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `LOCAL_STORAGE_LOADED`.
         " The z2ui5:Storage control read a value out of the browser storage

--- a/src/01/z2ui5_cl_smp_app_362.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_362.clas.abap
@@ -60,7 +60,7 @@ CLASS Z2UI5_CL_SMP_APP_362 IMPLEMENTATION.
     " The SCROLL_TO client event sets scrollTop / scrollLeft by pixel.
     " args: ( control-id, scrollTop, scrollLeft, behavior )
     " behavior is one of: "auto" (default, instant), "smooth", "instant".
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `SCROLL_TOP`.
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-scroll_to

--- a/src/01/z2ui5_cl_smp_app_363.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_363.clas.abap
@@ -33,7 +33,7 @@ CLASS z2ui5_cl_smp_app_363 IMPLEMENTATION.
 
   METHOD on_event.
 
-    DATA(target) = client->get( )-event.
+    DATA(target) = client->get_event( ).
     DATA(behavior) = `smooth`.
     DATA(block) = `start`.
 

--- a/src/01/z2ui5_cl_smp_app_382.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_382.clas.abap
@@ -44,7 +44,7 @@ CLASS z2ui5_cl_smp_app_382 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `CUSTOM`.
         client->message_box_display(
             text             = message
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_smp_app_382 IMPLEMENTATION.
         client->message_box_display(
             text    = message
             title   = title
-            type    = client->get( )-event
+            type    = client->get_event( )
             details = details ).
     ENDCASE.
 

--- a/src/01/z2ui5_cl_smp_app_421.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_421.clas.abap
@@ -78,7 +78,7 @@ CLASS z2ui5_cl_smp_app_421 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `FOCUS`.
         focus( ).
       WHEN `NEXT`.

--- a/src/01/z2ui5_cl_smp_app_448.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_448.clas.abap
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_smp_app_448 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `TOGGLE`.
         " invert the mirrored state and call the whitelisted setExpanded on

--- a/src/01/z2ui5_cl_smp_app_449.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_449.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_449 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `OPEN`.
         " open the popup-mode PDFViewer via the whitelisted open method -

--- a/src/01/z2ui5_cl_smp_app_452.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_452.clas.abap
@@ -106,7 +106,7 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `POPUP`.
         popup_display( ).
       WHEN `POPOVER`.

--- a/src/01/z2ui5_cl_smp_app_454.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_454.clas.abap
@@ -45,7 +45,7 @@ CLASS Z2UI5_CL_SMP_APP_454 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SEARCH`.
         " apply a declarative filter to the list's items binding -
@@ -67,7 +67,7 @@ CLASS Z2UI5_CL_SMP_APP_454 IMPLEMENTATION.
                                                    ( `items` )
                                                    ( `sort` )
                                                    ( `NAME` )
-                                                   ( COND #( WHEN client->get( )-event = `SORT_DESC`
+                                                   ( COND #( WHEN client->get_event( ) = `SORT_DESC`
                                                              THEN `true`
                                                              ELSE `false` ) ) ) ).
 

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `REORDER`.
         " the three event args arrive resolved client-side from the drop

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -49,7 +49,7 @@ CLASS Z2UI5_CL_SMP_APP_461 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `MOVE_NODE`.
         " both event args arrive resolved client-side: the binding context

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -58,7 +58,7 @@ CLASS Z2UI5_CL_SMP_APP_462 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `OPEN_POPUP`.
         popup_display( ).

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -55,7 +55,7 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SHOW_MODEL`.
         " the two-way bound inputs have already written the edits back into

--- a/src/01/z2ui5_cl_smp_app_464.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_464.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_464 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `RAISE_EXCEPTION`.
         RAISE EXCEPTION TYPE z2ui5_cx_smp_error

--- a/src/01/z2ui5_cl_smp_app_465.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_465.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_465 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `TOGGLE`.
         " toggle the popover open/closed, anchored to the pressed button's DOM

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -70,7 +70,7 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `SHOW`.
         popup_components( client->get_event_arg( ) ).
     ENDCASE.

--- a/src/01/z2ui5_cl_smp_app_471.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_471.clas.abap
@@ -53,7 +53,7 @@ CLASS z2ui5_cl_smp_app_471 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `SAVE`.
         INSERT VALUE #( entry = `Ctrl+S - save triggered` ) INTO TABLE t_log.

--- a/src/01/z2ui5_cl_smp_app_472.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_472.clas.abap
@@ -35,7 +35,7 @@ CLASS z2ui5_cl_smp_app_472 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `LINK_PRESS`.
 

--- a/src/01/z2ui5_cl_smp_app_474.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_474.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_smp_app_474 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN `OPEN_RELATIVE_ONLY`.
         popover_open( `RELATIVE_ONLY` ).

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -89,7 +89,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
   METHOD on_event.
 
     TRY.
-        DATA(classname) = to_upper( client->get( )-event ).
+        DATA(classname) = to_upper( client->get_event( ) ).
         DATA li_app TYPE REF TO z2ui5_if_app.
         CREATE OBJECT li_app TYPE (classname).
         s_scroll = CORRESPONDING #( client->get( )-s_scroll-main ).


### PR DESCRIPTION
Switch every event dispatcher from CASE client->get( )-event. to the new dedicated accessor client->get_event( ) introduced in the framework (abap2UI5/abap2UI5 branch claude/client-event-methods-l42hz7), and replace the four hand-rolled
client->get_app( client->get( )-s_draft-id_prev_app ) calls with the existing client->get_app_prev( ). The id_prev_app_stack variants have no shortcut and stay as they are. AGENTS.md examples and the client API table follow.


Claude-Session: https://claude.ai/code/session_016KuvJ2RAaZWi32pqbxjncD