### PR TITLE
Refactor app 197: improve filter logic and code organization

### DIFF
--- a/src/01/z2ui5_cl_smp_app_197.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_197.clas.abap
@@ -5,33 +5,88 @@ CLASS z2ui5_cl_smp_app_197 DEFINITION PUBLIC.
 
     TYPES:
       BEGIN OF ty_s_tab,
-        selkz            TYPE abap_bool,
         product          TYPE string,
         create_date      TYPE string,
         create_by        TYPE string,
         storage_location TYPE string,
         quantity         TYPE i,
       END OF ty_s_tab.
-    TYPES
-      ty_t_table TYPE STANDARD TABLE OF ty_s_tab WITH EMPTY KEY.
+    TYPES ty_t_table TYPE STANDARD TABLE OF ty_s_tab WITH EMPTY KEY.
 
     DATA mt_table TYPE ty_t_table.
     DATA mt_table_full TYPE ty_t_table.
     DATA mt_table_products TYPE ty_t_table.
-    DATA mv_check_popover TYPE abap_bool.
-    DATA mv_product TYPE string.
-
-    METHODS set_data.
-    METHODS view_display.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS on_init.
+    METHODS on_event_filter.
+    METHODS view_display.
+    METHODS data_read.
 
   PRIVATE SECTION.
 ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+    IF client->check_on_init( ).
+      on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
+    ELSEIF client->check_on_event( `RESET` ).
+      mt_table = mt_table_full.
+    ELSEIF client->check_on_event( `FILTER` ).
+      on_event_filter( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD on_init.
+
+    data_read( ).
+    view_display( ).
+
+  ENDMETHOD.
+
+
+  METHOD on_event_filter.
+
+    " listClose hands over selectedItems - an ARRAY OF CONTROLS
+    " (sap.m.FacetFilterItem). The framework marshals every control-valued
+    " event argument into a flat JSON object carrying its ID plus the values
+    " of its metadata properties, so a property is read as /<index>/<property>
+    " - there is no mProperties level in the payload.
+    DATA t_range TYPE RANGE OF string.
+
+    TRY.
+        DATA(json) = z2ui5_cl_ajson=>parse( client->get_event_arg( ) ).
+        DATA(t_members) = json->members( `/` ).
+
+        LOOP AT t_members INTO DATA(member).
+          APPEND VALUE #( sign   = `I`
+                          option = `EQ`
+                          low    = json->get( |/{ member }/key| ) ) TO t_range.
+        ENDLOOP.
+
+      CATCH cx_root.
+    ENDTRY.
+
+    " an empty selection is no filter at all - the list closed with every
+    " item unchecked, which must show all rows again, not none of them
+    mt_table = mt_table_full.
+
+    IF t_range IS NOT INITIAL.
+      DELETE mt_table WHERE product NOT IN t_range.
+    ENDIF.
+
+  ENDMETHOD.
+
 
   METHOD view_display.
 
@@ -44,22 +99,26 @@ CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
 
     page->message_strip(
         text     = `This sample shows a list-report table with a FacetFilter: selecting products ` &&
-                   `filters the rows, and Reset restores the full list.`
+                   `filters the rows, and Reset restores the full list. The listClose event sends ` &&
+                   `the selected FacetFilterItem controls as event arguments - the framework ` &&
+                   `marshals each one into a JSON object of its properties.`
         type     = `Information`
         showicon = abap_true
         class    = `sapUiSmallMargin` ).
 
-    DATA(facet) = page->facet_filter( id                  = `idFacetFilter`
-                                      type                = `Light`
-                                      showpersonalization = abap_true
-                                      showreset           = abap_true
-                                      reset               = client->_event( `RESET` )
+    page->facet_filter( id                  = `idFacetFilter`
+                        type                = `Light`
+                        showpersonalization = abap_true
+                        showreset           = abap_true
+                        reset               = client->_event( `RESET` )
       )->facet_filter_list( title     = `Products`
                             mode      = `MultiSelect`
                             items     = client->_bind( mt_table_products )
                             listclose = client->_event( val   = `FILTER`
                                                         t_arg = VALUE #( ( `$event.mParameters.selectedItems` ) ) )
-        )->facet_filter_item( text = `{PRODUCT}` ).
+        )->facet_filter_item(
+            key  = `{PRODUCT}`
+            text = `{PRODUCT}` ).
 
     DATA(tab) = page->table( id    = `tab`
                              items = client->_bind( val = mt_table ) ).
@@ -83,55 +142,7 @@ CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD z2ui5_if_app~main.
-
-    DATA lt_range TYPE RANGE OF string.
-
-    me->client = client.
-
-    IF client->check_on_init( ).
-
-      view_display( ).
-      set_data( ).
-      RETURN.
-    ENDIF.
-
-    CASE client->get_event( ).
-      WHEN `RESET`.
-        mt_table = mt_table_full.
-      WHEN `FILTER`.
-
-        DATA(lt_arg) = client->get( )-t_event_arg.
-        DATA(lv_json) = lt_arg[ 1 ].
-        TRY.
-            DATA(lo_json) = z2ui5_cl_ajson=>parse( lv_json ).
-
-            DATA(l_members) = lo_json->members( `/` ).
-
-            LOOP AT l_members INTO DATA(l_member).
-              DATA(lv_val) = lo_json->get( `/` && l_member && `/mProperties/text` ).
-
-              APPEND VALUE #( sign = `I` option = `EQ` low = lv_val ) TO lt_range.
-
-            ENDLOOP.
-
-          CATCH cx_root.
-        ENDTRY.
-
-        mt_table = mt_table_full.
-
-        LOOP AT mt_table INTO DATA(ls_tab).
-          IF ls_tab-product NOT IN lt_range.
-            DELETE mt_table.
-          ENDIF.
-        ENDLOOP.
-
-    ENDCASE.
-
-  ENDMETHOD.
-
-
-  METHOD set_data.
+  METHOD data_read.
 
     mt_table = VALUE #(
         ( product = `table` create_date = `01.01.2023` create_by = `Peter` storage_location = `AREA_001` quantity = 400 )
@@ -187,7 +198,6 @@ CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
     mt_table_full = mt_table.
 
     mt_table_products = mt_table.
-
     DELETE ADJACENT DUPLICATES FROM mt_table_products COMPARING product.
 
   ENDMETHOD.


### PR DESCRIPTION
## Summary
Refactored the sample app to improve code clarity, fix filter logic, and better organize methods according to lifecycle events. The main improvements include fixing the FacetFilter item key binding, simplifying the filter event handler, and restructuring the main method flow.

## Key Changes

- **Removed unused data members**: Deleted `selkz` field from `ty_s_tab` struct and removed unused `mv_check_popover` and `mv_product` variables
- **Reorganized method structure**: Moved methods to PROTECTED section and renamed `set_data` to `data_read` for clarity; added new `on_init` and `on_event_filter` methods to handle specific lifecycle events
- **Refactored main method**: Simplified event handling with clearer conditional flow using `check_on_init`, `check_on_navigated`, and `check_on_event` helpers
- **Fixed FacetFilter binding**: Added explicit `key` attribute to `facet_filter_item` binding (using `{PRODUCT}`) instead of relying on implicit text-based matching
- **Improved filter logic**: Rewrote `on_event_filter` to parse event arguments more robustly, using JSON path `/` to extract product keys directly instead of navigating through `mProperties/text`
- **Enhanced documentation**: Updated message strip text to explain how the framework marshals control-valued event arguments into JSON objects
- **Code cleanup**: Removed unnecessary variable assignments and simplified the filter deletion loop using a range-based WHERE clause

## Implementation Details

The filter event now correctly handles the FacetFilterItem controls passed as event arguments by:
1. Parsing the JSON payload from `client->get_event_arg()`
2. Iterating through members and extracting the `key` property directly
3. Building a range for efficient filtering
4. Handling empty selections (no filter) by resetting to the full table before applying the range

This approach is more maintainable and aligns with how the framework marshals control properties into JSON.

https://claude.ai/code/session_015rvEVKwr1hhiZhWTRdN7RQ