### PR TITLE
Add shared overview header with cross-repository navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,11 +240,46 @@ ever return, it comes back as a second `TARGETS` entry in
 
 Its shape: a `get_catalog( )` method returning a flat table of tiles, and a
 `view_display( )` that loops the catalog, emitting one link (`header` + optional
-`sub`) per tile. Around that list it renders a fixed frame: a `GitHub` link in
-the page's `header_content( )` (top right, opens the repository in a new tab),
-an intro `MessageStrip` naming the tile count and the `(A)` / `(C)` markers, a
+`sub`) per tile. Around that list it renders a fixed frame: the **shared
+overview header** in the page's `header_content( )` (see below), an intro
+`MessageStrip` naming the tile count and the `(A)` / `(C)` markers, a
 `SearchField` below the strip, and an empty `vbox( height = 4rem )` after the
 last tile so the list does not end glued to the page bottom.
+
+### The shared overview header
+
+Every abap2UI5 overview app renders the **same** header — here
+(`render_header( )` / `header_button( )`), in
+[samples-controls](https://github.com/abap2UI5/samples-controls) and in
+[samples-stack](https://github.com/abap2UI5/samples-stack). Six transparent
+icon buttons, always in this order, each carrying its explanation as a tooltip:
+
+| Icon | Target | Repository |
+|------|--------|------------|
+| `sap-icon://home` | `z2ui5_cl_app_startup` | abap2UI5/abap2UI5 |
+| `sap-icon://lightbulb` | `z2ui5_cl_smp_app_000` | abap2UI5/samples |
+| `sap-icon://palette` | `z2ui5_cl_dmo_app_overview` | abap2UI5/samples-controls |
+| `sap-icon://database` | `z2ui5_cl_smpe_app_00` | abap2UI5/samples-stack |
+| `sap-icon://learning-assistant` | — | <https://abap2UI5.org> |
+| `sap-icon://source-code` | — | the repository the app itself lives in |
+
+Each repository is installed on its own, so every button decides for itself:
+`class_installed( )` instantiates the target class, and
+
+- **on this system** → the press is `cs_event-nav` with the class name as its
+  event argument; `on_event` hands it to `app_call( )`, which navigates with
+  `nav_app_call( )` — the back button returns to the overview.
+- **not on this system** → the press opens that repository on GitHub, and the
+  tooltip says why (`… - not installed, opens GitHub`). A `Button` carries no
+  `href` and `cs_event-open_new_tab` is same-origin only, so the new tab comes
+  from the `URLHELPER` `REDIRECT` frontend action (`open_url( )`) — client-side,
+  inside the click handler, which is what keeps the popup blocker quiet.
+- **the app you are in** (`here = abap_true`, the lightbulb here) → the button
+  stays, disabled, tooltip `… - you are here`, so the row reads the same in
+  every overview.
+
+**Keep the three headers in sync.** A change to the order, the icons or the
+behaviour belongs in all three repositories in the same change.
 
 The search field filters the tile list: its `search` event (Enter, or the
 clear button) fires `SEARCH`, which re-renders the view with `catalog_filter( )`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ icon buttons, always in this order, each carrying its explanation as a tooltip:
 |------|--------|------------|
 | `sap-icon://home` | `z2ui5_cl_app_startup` | abap2UI5/abap2UI5 |
 | `sap-icon://lightbulb` | `z2ui5_cl_smp_app_000` | abap2UI5/samples |
-| `sap-icon://palette` | `z2ui5_cl_dmo_app_overview` | abap2UI5/samples-controls |
+| `sap-icon://palette` | `z2ui5_cl_smpc_app_overview` | abap2UI5/samples-controls |
 | `sap-icon://database` | `z2ui5_cl_smpe_app_00` | abap2UI5/samples-stack |
 | `sap-icon://learning-assistant` | — | <https://abap2UI5.org> |
 | `sap-icon://source-code` | — | the repository the app itself lives in |
@@ -277,6 +277,13 @@ Each repository is installed on its own, so every button decides for itself:
 - **the app you are in** (`here = abap_true`, the lightbulb here) → the button
   stays, disabled, tooltip `… - you are here`, so the row reads the same in
   every overview.
+
+A repository that **renames** its overview app is installed under both names in
+the wild for a while, so `header_button( )` takes an optional `class_old` and
+falls back to it when the current name is not on the system —
+`z2ui5_cl_dmo_app_overview` for samples-controls (renamed 2026-08),
+`z2ui5_cl_demo_app_g00` for this repository. Add the old name there when an
+overview app is renamed; drop it again once the rename is old enough.
 
 **Keep the three headers in sync.** A change to the order, the icons or the
 behaviour belongs in all three repositories in the same change.

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -23,6 +23,32 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
       END OF ty_s_block.
     TYPES ty_t_block TYPE STANDARD TABLE OF ty_s_block WITH DEFAULT KEY.
 
+    CONSTANTS:
+      BEGIN OF cs_event,
+        search TYPE string VALUE `SEARCH`,
+        nav    TYPE string VALUE `NAV_APP`,
+      END OF cs_event.
+
+    " the three sample repositories and the framework, in the order the shared
+    " overview header renders them - each one is installed on its own, so the
+    " header asks per entry whether its overview app is on THIS system
+    CONSTANTS:
+      BEGIN OF cs_class,
+        startup  TYPE string VALUE `z2ui5_cl_app_startup`,
+        samples  TYPE string VALUE `z2ui5_cl_smp_app_000`,
+        controls TYPE string VALUE `z2ui5_cl_dmo_app_overview`,
+        stack    TYPE string VALUE `z2ui5_cl_smpe_app_00`,
+      END OF cs_class.
+
+    CONSTANTS:
+      BEGIN OF cs_url,
+        docs      TYPE string VALUE `https://abap2UI5.org`,
+        framework TYPE string VALUE `https://github.com/abap2UI5/abap2UI5`,
+        samples   TYPE string VALUE `https://github.com/abap2UI5/samples`,
+        controls  TYPE string VALUE `https://github.com/abap2UI5/samples-controls`,
+        stack     TYPE string VALUE `https://github.com/abap2UI5/samples-stack`,
+      END OF cs_url.
+
     DATA client TYPE REF TO z2ui5_if_client.
     DATA:
       BEGIN OF s_scroll,
@@ -32,8 +58,42 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
       END OF s_scroll.
 
     METHODS on_event.
+    METHODS app_call
+      IMPORTING
+        classname TYPE string.
     METHODS scroll_restore.
     METHODS view_display.
+    "! The header every abap2UI5 overview app shares: one icon button per
+    "! sibling repository - it jumps into that repository's overview app when
+    "! the app is on this system and opens the repository on GitHub when it is
+    "! not - followed by the documentation and this repository. The entry of
+    "! the repository you are looking at stays visible but disabled, so the
+    "! header reads the same everywhere.
+    METHODS render_header
+      IMPORTING
+        page TYPE REF TO z2ui5_cl_xml_view.
+    METHODS header_button
+      IMPORTING
+        toolbar TYPE REF TO z2ui5_cl_xml_view
+        icon    TYPE string
+        tooltip TYPE string
+        href    TYPE string
+        class   TYPE string OPTIONAL
+        here    TYPE abap_bool DEFAULT abap_false.
+    "! the press wire of a button whose target is EXTERNAL: a Button carries no
+    "! href, and cs_event-open_new_tab is same-origin only, so the new tab is
+    "! opened by the URLHELPER frontend action - client-side, inside the click
+    "! handler, which is what keeps the popup blocker quiet
+    METHODS open_url
+      IMPORTING
+        href          TYPE string
+      RETURNING
+        VALUE(result) TYPE string.
+    METHODS class_installed
+      IMPORTING
+        val           TYPE string
+      RETURNING
+        VALUE(result) TYPE abap_bool.
     METHODS get_catalog
       RETURNING
         VALUE(result) TYPE ty_t_tile.
@@ -96,7 +156,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
   METHOD on_event.
 
     CASE client->get_event( ).
-      WHEN `SEARCH`.
+      WHEN cs_event-search.
 
         view_display( ).
         client->follow_up_action(
@@ -105,18 +165,32 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
                              ( |{ strlen( search ) }| )
                              ( |{ strlen( search ) }| ) ) ).
 
+      WHEN cs_event-nav.
+
+        " a header button - the app to jump to travels as the event argument
+        app_call( client->get_event_arg( ) ).
+
       WHEN OTHERS.
 
-        TRY.
-            DATA(classname) = to_upper( client->get_event( ) ).
-            DATA li_app TYPE REF TO z2ui5_if_app.
-            CREATE OBJECT li_app TYPE (classname).
-            s_scroll = CORRESPONDING #( client->get( )-s_scroll-main ).
-            client->nav_app_call( li_app ).
-          CATCH cx_root ##NO_HANDLER.
-        ENDTRY.
+        " a tile - the event IS the class name of the sample
+        app_call( client->get_event( ) ).
 
     ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD app_call.
+
+    DATA(name) = to_upper( classname ).
+
+    TRY.
+        DATA li_app TYPE REF TO z2ui5_if_app.
+        CREATE OBJECT li_app TYPE (name).
+        s_scroll = CORRESPONDING #( client->get( )-s_scroll-main ).
+        client->nav_app_call( li_app ).
+      CATCH cx_root ##NO_HANDLER.
+    ENDTRY.
 
   ENDMETHOD.
 
@@ -150,11 +224,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
         navbuttonpress = client->_event_nav_app_leave( )
         shownavbutton  = client->check_app_prev_stack( ) ).
 
-    page->header_content(
-       )->link(
-           text   = `GitHub`
-           target = `_blank`
-           href   = `https://github.com/abap2UI5/samples` ).
+    render_header( page ).
 
     page->message_strip(
         text     = |All { lines( t_catalog_all ) } abap2UI5 samples - bindings, events, popups, tables, trees | &&
@@ -167,7 +237,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
     page->search_field(
         id          = `search`
         value       = client->_bind( search )
-        search      = client->_event( `SEARCH` )
+        search      = client->_event( cs_event-search )
         width       = `17.5rem`
         placeholder = `Filter samples`
         class       = `sapUiSmallMarginBegin sapUiSmallMarginBottom` ).
@@ -234,6 +304,112 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
     page->vbox( height = `4rem` ).
 
     client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+
+  METHOD render_header.
+
+    DATA(toolbar) = page->header_content( ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://home`
+                   tooltip = `abap2UI5 - the start page of the framework`
+                   class   = cs_class-startup
+                   href    = cs_url-framework ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://lightbulb`
+                   tooltip = `Samples - binding, events, popups, tables and much more`
+                   class   = cs_class-samples
+                   href    = cs_url-samples
+                   here    = abap_true ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://palette`
+                   tooltip = `Controls - the UI5 Demo Kit, rebuilt with abap2UI5`
+                   class   = cs_class-controls
+                   href    = cs_url-controls ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://database`
+                   tooltip = `Stack - OData, RAP, WebSockets and the Fiori Launchpad`
+                   class   = cs_class-stack
+                   href    = cs_url-stack ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://learning-assistant`
+                   tooltip = `Documentation - guides, tutorials and the API reference`
+                   href    = cs_url-docs ).
+
+    header_button( toolbar = toolbar
+                   icon    = `sap-icon://source-code`
+                   tooltip = `GitHub - the source code of this repository`
+                   href    = cs_url-samples ).
+
+  ENDMETHOD.
+
+
+  METHOD header_button.
+
+    IF here = abap_true.
+
+      " where you are: the button stays, so every overview shows the same row,
+      " but there is nowhere to go
+      toolbar->button( icon    = icon
+                       type    = `Transparent`
+                       enabled = abap_false
+                       tooltip = |{ tooltip } - you are here| ).
+      RETURN.
+
+    ENDIF.
+
+    IF class IS NOT INITIAL AND class_installed( class ) = abap_true.
+
+      " installed on this system: jump right into it, the back button returns
+      toolbar->button( icon    = icon
+                       type    = `Transparent`
+                       tooltip = tooltip
+                       press   = client->_event( val   = cs_event-nav
+                                                 t_arg = VALUE #( ( class ) ) ) ).
+      RETURN.
+
+    ENDIF.
+
+    toolbar->button(
+        icon    = icon
+        type    = `Transparent`
+        tooltip = COND #( WHEN class IS INITIAL
+                          THEN tooltip
+                          ELSE |{ tooltip } - not installed, opens GitHub| )
+        press   = open_url( href ) ).
+
+  ENDMETHOD.
+
+
+  METHOD open_url.
+
+    " REDIRECT takes a { URL, NEW_WINDOW } object literal - NEW_WINDOW true is
+    " what target="_blank" does on a Link
+    result = client->follow_up_action(
+        val   = z2ui5_if_client=>cs_event-urlhelper
+        t_arg = VALUE #( ( `REDIRECT` )
+                         ( |\{ URL: '{ href }', NEW_WINDOW: true \}| ) ) ).
+
+  ENDMETHOD.
+
+
+  METHOD class_installed.
+
+    " the same question the framework's start page asks: an absent, inactive
+    " or not-activatable class raises here, it does not return a flag
+    TRY.
+        DATA obj TYPE REF TO object ##NEEDED.
+        CREATE OBJECT obj TYPE (val).
+        result = abap_true.
+      CATCH cx_root ##CATCH_ALL.
+        result = abap_false.
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -402,10 +402,14 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
   METHOD class_installed.
 
     " the same question the framework's start page asks: an absent, inactive
-    " or not-activatable class raises here, it does not return a flag
+    " or not-activatable class raises here, it does not return a flag. The name
+    " has to be upper case - the repository stores it that way, and the class
+    " constants above follow the repository's lower-case spelling rule.
+    DATA(name) = to_upper( val ).
+
     TRY.
         DATA obj TYPE REF TO object ##NEEDED.
-        CREATE OBJECT obj TYPE (val).
+        CREATE OBJECT obj TYPE (name).
         result = abap_true.
       CATCH cx_root ##CATCH_ALL.
         result = abap_false.

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -34,10 +34,13 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
     " header asks per entry whether its overview app is on THIS system
     CONSTANTS:
       BEGIN OF cs_class,
-        startup  TYPE string VALUE `z2ui5_cl_app_startup`,
-        samples  TYPE string VALUE `z2ui5_cl_smp_app_000`,
-        controls TYPE string VALUE `z2ui5_cl_dmo_app_overview`,
-        stack    TYPE string VALUE `z2ui5_cl_smpe_app_00`,
+        startup      TYPE string VALUE `z2ui5_cl_app_startup`,
+        samples      TYPE string VALUE `z2ui5_cl_smp_app_000`,
+        controls     TYPE string VALUE `z2ui5_cl_smpc_app_overview`,
+        " the overview app of samples-controls before its 2026-08 rename - an
+        " installation that predates it still answers to this name
+        controls_old TYPE string VALUE `z2ui5_cl_dmo_app_overview`,
+        stack        TYPE string VALUE `z2ui5_cl_smpe_app_00`,
       END OF cs_class.
 
     CONSTANTS:
@@ -74,12 +77,16 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
         page TYPE REF TO z2ui5_cl_xml_view.
     METHODS header_button
       IMPORTING
-        toolbar TYPE REF TO z2ui5_cl_xml_view
-        icon    TYPE string
-        tooltip TYPE string
-        href    TYPE string
-        class   TYPE string OPTIONAL
-        here    TYPE abap_bool DEFAULT abap_false.
+        toolbar   TYPE REF TO z2ui5_cl_xml_view
+        icon      TYPE string
+        tooltip   TYPE string
+        href      TYPE string
+        class     TYPE string OPTIONAL
+        "! the overview app's PREVIOUS name, tried when CLASS is not on the
+        "! system: a repository that renamed its overview app is installed
+        "! under both names in the wild for a while
+        class_old TYPE string OPTIONAL
+        here      TYPE abap_bool DEFAULT abap_false.
     "! the press wire of a button whose target is EXTERNAL: a Button carries no
     "! href, and cs_event-open_new_tab is same-origin only, so the new tab is
     "! opened by the URLHELPER frontend action - client-side, inside the click
@@ -325,11 +332,12 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
                    href    = cs_url-samples
                    here    = abap_true ).
 
-    header_button( toolbar = toolbar
-                   icon    = `sap-icon://palette`
-                   tooltip = `Controls - the UI5 Demo Kit, rebuilt with abap2UI5`
-                   class   = cs_class-controls
-                   href    = cs_url-controls ).
+    header_button( toolbar   = toolbar
+                   icon      = `sap-icon://palette`
+                   tooltip   = `Controls - the UI5 Demo Kit, rebuilt with abap2UI5`
+                   class     = cs_class-controls
+                   class_old = cs_class-controls_old
+                   href      = cs_url-controls ).
 
     header_button( toolbar = toolbar
                    icon    = `sap-icon://database`
@@ -364,14 +372,24 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
     ENDIF.
 
+    DATA target TYPE string.
+
     IF class IS NOT INITIAL AND class_installed( class ) = abap_true.
+      target = class.
+
+    ELSEIF class_old IS NOT INITIAL AND class_installed( class_old ) = abap_true.
+      target = class_old.
+
+    ENDIF.
+
+    IF target IS NOT INITIAL.
 
       " installed on this system: jump right into it, the back button returns
       toolbar->button( icon    = icon
                        type    = `Transparent`
                        tooltip = tooltip
                        press   = client->_event( val   = cs_event-nav
-                                                 t_arg = VALUE #( ( class ) ) ) ).
+                                                 t_arg = VALUE #( ( target ) ) ) ).
       RETURN.
 
     ENDIF.


### PR DESCRIPTION
## Summary

Introduces a shared header component that appears consistently across all abap2UI5 overview apps (samples, controls, stack). The header provides unified navigation between repositories and external resources, with intelligent handling of installed vs. missing components.

## Key Changes

- **New constants** for event types, class names, and URLs:
  - `cs_event`: `SEARCH` and `NAV_APP` event identifiers
  - `cs_class`: Class names for startup, samples, controls, and stack overview apps
  - `cs_url`: GitHub repository URLs and documentation link

- **New methods for header rendering and navigation**:
  - `render_header()`: Renders the six-button shared header with consistent ordering and styling
  - `header_button()`: Renders individual header buttons with three behaviors:
    - Disabled button when viewing the current app
    - Navigation event when target class is installed
    - External GitHub link when target class is not installed
  - `open_url()`: Opens external URLs via `URLHELPER` frontend action to bypass popup blockers
  - `class_installed()`: Checks if a target class exists on the current system
  - `app_call()`: Extracted common app navigation logic from `on_event()`

- **Updated event handling**:
  - Refactored `on_event()` to use named constants and delegate to `app_call()`
  - Added `NAV_APP` event handling for header button navigation
  - Simplified tile click handling

- **Documentation**:
  - Updated `AGENTS.md` with detailed explanation of the shared header pattern
  - Documents the three-repository sync requirement and button behavior matrix

## Implementation Details

The header maintains consistency across repositories by:
- Using identical icon/tooltip/order in all three overview apps
- Checking class installation at runtime to decide between navigation and external links
- Disabling the current app's button so the header layout remains stable
- Using `URLHELPER` REDIRECT action for external links to avoid popup blocker issues

The `app_call()` method centralizes app instantiation and navigation, replacing inline logic in `on_event()`.

https://claude.ai/code/session_01MmiNtUQfzS2yQ7v7NHH6ob