### PR TITLE
Stop sample 322 from using the removed HISTORY_BACK event

### DIFF
--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
       client->view_display( view->shell(
              )->page(
                      title          = `abap2UI5 - Navigation with app state`
-                     navbuttonpress = client->follow_up_action( `HISTORY_BACK` )
+                     navbuttonpress = client->_event_nav_app_leave( )
                      shownavbutton  = client->check_app_prev_stack( )
           )->message_strip(
               text     = `set_push_state( ) pushes an app-owned suffix onto the browser URL, so the app can `
@@ -40,7 +40,7 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
                              press = client->_event( `BUTTON_POST` )
                          )->button(
                              text  = `back`
-                             press = client->follow_up_action( `HISTORY_BACK` )
+                             press = client->_event( `BUTTON_BACK` )
               )->stringify( ) ).
 
       IF client->check_app_prev_stack( ).
@@ -52,8 +52,16 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
     CASE client->get_event( ).
       WHEN `BUTTON_POST`.
         client->set_push_state( `/head/pos/` && client->get( )-s_draft-id ).
+        client->message_toast_display( `data updated` ).
+
+      WHEN `BUTTON_BACK`.
+        " step back through the entries set_push_state( ) pushed - the same
+        " thing the browser back button does. follow_up_action( ) runs a raw
+        " JavaScript expression when what it gets is not a framework event
+        " name, which is how a browser capability without its own event is
+        " reached
+        client->follow_up_action( |history.back()| ).
     ENDCASE.
-    client->message_toast_display( `data updated` ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## What changed

`cs_event-history_back` is being removed from the framework (abap2UI5/abap2UI5#2561), and `z2ui5_cl_smp_app_322` was its last caller anywhere in the ecosystem.

The sample itself is not about that event, though — it demonstrates `set_push_state( )`, and it is the **only** app that does, so it stays. The two back buttons were doing different jobs behind the same call and are now separated:

- the page nav button belongs to the app stack (it is already gated on `check_app_prev_stack( )`), so it becomes `_event_nav_app_leave( )`
- the form's back button is part of the demo — it steps back through the entries `set_push_state( )` pushed, exactly like the browser back button. It now runs the raw JavaScript expression through `follow_up_action( )`, which is the documented replacement for the removed event

The "data updated" toast moved into the post branch; it used to fire after any event, including a back press.

## How to test

Run `Z2UI5_CL_SMP_APP_322` (it lives in `src/00/97`, so it is on `main` only, not the `702` branch). Enter a quantity, press **post** — the URL gains a `/head/pos/<draft id>` suffix. Do it a few times, then use the form's **back** button and the browser's back button alternately: both walk the same pushed entries.

Needs the framework PR merged first, since the sample now relies on `follow_up_action( )` taking a raw JS expression — that path already exists today, so it works either way, but the event it replaces only disappears with that PR.

## Verified

`npm run lint` (309 files), `npm run check:agents`, `npm run check:strip` — all clean. Merged `origin/main` in (sample 197 FacetFilter fix) and re-verified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLqG5572QgSgbhfAWm7RAp)_