### PR TITLE
Clarify binding terminology: remove "two-way" qualifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,7 +821,7 @@ Use a `CASE` statement (inside an `ELSEIF client->check_on_event( )` block) only
 | Nested views | `nest_view_display/destroy`, `nest2_view_*` | Embedded sub-views |
 | Popups | `popup_display`, `popup_destroy` | Modal dialogs |
 | Popovers | `popover_display`, `popover_destroy` | Context popovers |
-| Binding | `_bind(val)` | Two-way binding (`_bind_edit` is an obsolete alias) |
+| Binding | `_bind(val)` | Data binding, values travel in both directions (`_bind_edit` is an obsolete alias) |
 | Events | `_event(val)`, `follow_up_action(val)`, `check_on_event(val)` | Event registration and checking (`_event_client` is an obsolete alias — `follow_up_action` covers both roles: returned into a view attribute it binds the frontend action to a control, called on `client` it queues the action after the current response renders) |
 | Navigation | `nav_app_call(app)`, `nav_app_leave()`, `get_app_prev()` | App stack navigation |
 | Lifecycle | `check_on_init()`, `check_on_navigated()`, `check_app_prev_stack()` | State checks |
@@ -957,13 +957,21 @@ value (human find 2026-07-18 in samples 456/457). Compose raw binding-info
 strings with the bare path from
 `client->_bind( val = x path = abap_true )`.
 
-**Always `_bind( )`, never `_bind_edit( )`.** Both bind two-way into the same
-root model — the one-way/two-way split disappeared with the `XX/` view-model
-node — so `_bind_edit` is only an obsolete alias and is slated for removal.
+**Always `_bind( )`, never `_bind_edit( )`.** Both bind into the same root
+model — the split between them disappeared with the `XX/` view-model node — so
+`_bind_edit` is only an obsolete alias and is slated for removal.
 The single exception is a mapping that differs per direction, because `_bind`
 has no `custom_mapper_back` / `custom_filter_back` parameters; no sample in
 this repository currently needs that — one that does must say so in a comment
 at the call.
+
+**Call it "binding", never "one-way"/"two-way" binding** — in sample titles,
+message strips, comments and `@keywords` alike. With only `_bind( )` left, and
+values always travelling in both directions, the qualifier distinguishes
+nothing and makes readers look for a second mode that does not exist. Say
+"bound attribute", "the value is written back before the event handler runs".
+"One-way" is correct only for a real UI5 one-way model that is not `_bind( )`
+— the `device>` JSONModel in `z2ui5_cl_smp_app_445`, for example.
 
 Key rules for `_generic( )`:
 - `_generic( name = ... ns = ... t_prop = ... )` adds one element and

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -85,7 +85,7 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
 
     page->message_strip(
         text     = `Changes a control INSIDE an open popup from the backend. The ` &&
-                   `label text is an ordinary two-way binding; the style class has ` &&
+                   `label text is an ordinary binding; the style class has ` &&
                    `no bindable equivalent and is applied with follow_up_action( ` &&
                    `control_by_id ) scoped to the popup view. No custom JavaScript ` &&
                    `is involved.`

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -1,4 +1,4 @@
-" @keywords customtreeitem rename input two way write back
+" @keywords customtreeitem rename input binding write back
 CLASS z2ui5_cl_smp_app_463 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
@@ -59,7 +59,7 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
     CASE client->get_event( ).
 
       WHEN `SHOW_MODEL`.
-        " the two-way bound inputs have already written the edits back into
+        " the bound inputs have already written the edits back into
         " t_nodes before on_event runs - read the (possibly renamed) roots
         " back and echo them, proving the round-trip
         DATA(lv_roots) = ``.
@@ -84,7 +84,7 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
             shownavbutton  = client->check_app_prev_stack( ) ).
 
     page->message_strip(
-        text     = `Each node is a CustomTreeItem holding an Input bound two-way to the node text. ` &&
+        text     = `Each node is a CustomTreeItem holding an Input bound to the node text. ` &&
                    `Rename any node and press "Show model": the edits have already written back into ` &&
                    `the nested ABAP table. The expand state is preserved across the roundtrip.`
         type     = `Information`
@@ -97,7 +97,7 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
                    press = client->_event( `SHOW_MODEL` ) ).
 
     " CustomTreeItem is not a typed builder method - build it via _generic;
-    " its content aggregation holds the editable Input, bound two-way to
+    " its content aggregation holds the editable Input, bound to
     " {TEXT} because the items aggregation itself is bound with _bind
     DATA(tree) = page->tree( id         = `tree1`
                              headertext = `Files (editable)`

--- a/src/01/z2ui5_cl_smp_app_494.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_494.clas.abap
@@ -1,4 +1,4 @@
-" @keywords two way binding _bind model attribute value input button serialize
+" @keywords binding _bind model attribute value input button serialize
 CLASS z2ui5_cl_smp_app_494 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
@@ -38,7 +38,7 @@ CLASS z2ui5_cl_smp_app_494 IMPLEMENTATION.
           class    = `sapUiSmallMargin` ).
 
       page->simple_form(
-          title    = `Two-Way Binding`
+          title    = `Data Binding`
           editable = abap_true
           )->content( `form`
           )->label( `your name`

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -618,7 +618,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
     result = VALUE #(
       ( group = `samples` header = `Basics I` sub = `Hello World, the Smallest App` keywords = `hello world smallest first app minimal start here template` path = `src/01` app = `z2ui5_cl_smp_app_493` )
-      ( group = `samples` header = `Basics II` sub = `Data Binding: Input and Button` keywords = `two way binding _bind model attribute value input button serialize` path = `src/01` app = `z2ui5_cl_smp_app_494` )
+      ( group = `samples` header = `Basics II` sub = `Data Binding: Input and Button` keywords = `binding _bind model attribute value input button serialize` path = `src/01` app = `z2ui5_cl_smp_app_494` )
       ( group = `samples` header = `Basics III` sub = `Lifecycle: Init, Event, Navigated` keywords = `lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated` path = `src/01` app = `z2ui5_cl_smp_app_495` )
       ( group = `samples` header = `Basics IV` sub = `Events, Views and Roundtrips` keywords = `roundtrip restart second view uncaught error controller basics` path = `src/01` app = `z2ui5_cl_smp_app_004` )
       ( group = `samples` header = `Basics V`
@@ -714,7 +714,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       ( group = `samples` header = `Timer` sub = `Progress Indicator during a Backend Call (A)` keywords = `progressindicator busy wait long running backend` path = `src/01` app = `z2ui5_cl_smp_app_064` )
       ( group = `samples` header = `Timer` sub = `Refresh the View Every n Seconds (A)` keywords = `interval polling auto refresh follow_up_action seconds` path = `src/01` app = `z2ui5_cl_smp_app_028` )
       ( group = `samples` header = `Tree` sub = `Drag and Drop Nodes (A,C)` keywords = `dnd move node hierarchy binding context` path = `src/01` app = `z2ui5_cl_smp_app_461` )
-      ( group = `samples` header = `Tree` sub = `Editable Nodes with CustomTreeItem (C)` keywords = `customtreeitem rename input two way write back` path = `src/01` app = `z2ui5_cl_smp_app_463` )
+      ( group = `samples` header = `Tree` sub = `Editable Nodes with CustomTreeItem (C)` keywords = `customtreeitem rename input binding write back` path = `src/01` app = `z2ui5_cl_smp_app_463` )
       ( group = `samples` header = `Tree` sub = `Inside a Dialog (C)` keywords = `popup expand state hierarchy nodes` path = `src/01` app = `z2ui5_cl_smp_app_462` )
       ( group = `samples` header = `Tree` sub = `Nested ABAP Table in a sap.m.Tree` keywords = `hierarchy nodes nested json items` path = `src/01` app = `z2ui5_cl_smp_app_460` ) ).
 


### PR DESCRIPTION
## Summary
Updates documentation and code comments to clarify binding terminology by removing the "two-way" and "one-way" qualifiers. Since the codebase now uses only `_bind()` (with `_bind_edit()` as an obsolete alias), and values always travel in both directions, the directional qualifier is unnecessary and confuses readers.

## Changes Made

- **AGENTS.md**: 
  - Clarified the Binding row description to say "Data binding, values travel in both directions" instead of "Two-way binding"
  - Added a new guidance section explaining that binding should be called "binding" (not "one-way"/"two-way" binding) in sample titles, message strips, comments, and `@keywords`
  - Removed the one-way/two-way distinction from the `_bind()` vs `_bind_edit()` explanation since that split no longer exists

- **Sample apps** (z2ui5_cl_smp_app_463, z2ui5_cl_smp_app_494, z2ui5_cl_smp_app_141):
  - Updated `@keywords` to use `binding` instead of `two way binding`
  - Changed comments from "two-way bound" to "bound"
  - Updated UI text from "Two-Way Binding" to "Data Binding"

- **Sample registry** (z2ui5_cl_smp_app_000):
  - Updated keywords in the sample catalog entries to match the new terminology

## Implementation Details
The changes are purely terminological and do not affect functionality. The guidance clarifies that "one-way" is only correct when referring to actual UI5 one-way models (like the `device>` JSONModel) that are not created with `_bind()`.

https://claude.ai/code/session_01HzHBXbRjKGA5rLRYPJKGX9