### PR TITLE
Move the samples onto z2ui5_cl_ui5_view_builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,10 +337,10 @@ GitHub) still open their site directly through `open_url( )`.
 five icons with their separator on the right, the two colour states and the
 install popover. samples-controls builds it in
 `scripts/generate-overview.mjs` (its overview class is generated — never edit
-the class), samples-stack in `z2ui5_cl_smps_app_00`, both with
-`z2ui5_cl_ai_xml` instead of `z2ui5_cl_xml_view`; in that builder an empty
-attribute is still rendered (`color=""` is no valid `IconColor`), so the
-optional ones are added under an `IF`. What stays local to a repository is
+the class), samples-stack in `z2ui5_cl_smps_app_00`. All three build it with
+`z2ui5_cl_ui5_view_builder`, which renders an empty attribute rather than
+skipping it (`color=""` is no valid `IconColor`), so the optional ones are
+added under an `IF`. What stays local to a repository is
 what sits *around* the family entries — this one's `SearchField` sub-header,
 samples-controls' filter toolbar, samples-stack's Regenerate Demo Data button
 (first in its `contentRight`, before a separator). **A change to an icon, the
@@ -659,11 +659,15 @@ newline). **Run `abaplint` — 0 issues — before committing.**
 - Run: `npm run check:abap2ui5`
 - CI: `abap2UI5` — as opposed to `abap-standard` / `abap-cloud` /
   `abap-702`, which lint ABAP itself against three target releases
-- **It currently reports nothing in this repository.** It inspects classes
-  built with `z2ui5_cl_ai_xml`, while every sample here still uses
-  `z2ui5_cl_xml_view` (§10). The gate becomes effective as samples move to
-  the new builder — until then a green `abap2UI5` badge means "nothing
-  was checkable", not "the apps are clean".
+- **It currently reports nothing in this repository.** The samples are on
+  `z2ui5_cl_ui5_view_builder` (§10), but the pinned linter still looks for the
+  builder's former name `z2ui5_cl_ai_xml`, so it finds no checkable file. The
+  gate becomes effective when the pin moves to a version that reads the
+  released builder **and** spells its attribute verb `a( )` (the first version
+  that reads the new builder at all still spelled it `att( )`, which drops
+  every attribute including the namespace declarations — see
+  abap2UI5/samples-controls#89). Until then a green `abap2UI5` badge means
+  "nothing was checkable", not "the apps are clean".
 
 ### abapGit file consistency
 
@@ -838,12 +842,17 @@ Use a `CASE` statement (inside an `ELSEIF client->check_on_event( )` block) only
 ```abap
 METHOD view_display.
 
-  DATA(view) = z2ui5_cl_xml_view=>factory( ).
-  DATA(page) = view->shell(
-      )->page(
-          title          = `My App`
-          shownavbutton  = client->check_app_prev_stack( )
-          navbuttonpress = client->_event_nav_app_leave( ) ).
+  DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+      )->a( n = `displayBlock` v = `true`
+      )->a( n = `height`       v = `100%`
+      )->a( n = `xmlns`        v = `sap.m`
+      )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+      )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+
+  DATA(page) = view->ele( `Shell` )->ele( `Page`
+      )->a( n = `title`          v = `My App`
+      )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+      )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
   " ...
   client->view_display( view->stringify( ) ).
 
@@ -869,83 +878,113 @@ ENDMETHOD.
 
 ## 10. Building Views
 
-Views are XML strings passed to `client->view_display()`, built with the
-`z2ui5_cl_xml_view` fluent API — typed methods where they exist, `_generic( )`
-for the rest.
+Views are XML strings passed to `client->view_display()`, built with
+`z2ui5_cl_ui5_view_builder` — the released builder in the framework's `src/02`.
+It is generic: eight methods build any UI5 view 1:1, so there is no list of
+supported controls and nothing to wait for when UI5 adds one. Element and
+property names come straight from the
+[UI5 API Reference](https://ui5.sap.com/#/api) and are written exactly as
+documented there.
 
-### 1. `z2ui5_cl_xml_view` — typed fluent API
-Pre-built methods for common UI5 controls (`shell`, `page`, `simple_form`, `input`, `button`, etc.). Use this for standard layouts.
+### 1. The builder — `factory`, `ele`, `tag`, `a`, `end`, `stringify`
+
+- `factory( )` returns an **empty root**. Unlike the retired builder it opens
+  no `mvc:View` for you: you open it and declare the namespaces yourself, which
+  is why they are visible in every sample.
+- `ele( n = ns = )` adds a child element and **descends into it** — the chain
+  now points at the new element.
+- `tag( n = ns = )` adds a child element and **stays** on the current one, so
+  the next `tag( )`/`ele( )` becomes its sibling and no `end( )` is needed.
+  This is the form for a leaf, whatever its attributes are.
+- `a( n = v = )` sets an attribute on the element the chain points at — the
+  child just added by `ele( )`/`tag( )`, or the node itself while it has no
+  children. So `a( )` always follows the control it belongs to.
+- `a( n = b = )` takes an **ABAP boolean** and renders `true`/`false` itself:
+  write `a( n = `editable` b = mv_edit_mode )`, never a conversion of your own.
+  Pass either `v` or `b`, never both.
+- `end( )` ascends to the parent element.
+- `stringify( )` renders the whole view, always from the root, no matter which
+  element the reference currently points at.
+
+#### Empty attributes are rendered
+
+The builder writes every attribute you add, including an empty one — and
+`type=""` or `color=""` is not a valid UI5 enum value. An attribute whose value
+may be empty at runtime therefore goes under an `IF`, it is not simply passed:
+
+```abap
+DATA(button) = toolbar->tag( `Button` )->a( n = `text` v = name ).
+IF icon IS NOT INITIAL.
+  button->a( n = `icon` v = icon ).
+ENDIF.
+```
 
 #### View structure and indentation
 
-Always add 1 blank line before `DATA(view) = z2ui5_cl_xml_view=>factory( ).` to visually separate view construction from preceding logic.
+Always add 1 blank line before `DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).`
+to visually separate view construction from preceding logic.
 
-Always build the view in `view_display` and call `client->view_display( view->stringify( ) )` as a **standalone statement at the end** — never nested inside the chain.
+Always build the view in `view_display` and call
+`client->view_display( view->stringify( ) )` as a **standalone statement at the
+end** — never nested inside the chain.
 
-Indent the fluent chain to reflect the XML hierarchy:
-- Each method that **navigates into a child element** (returns a child node) is indented **4 spaces deeper** than its parent call.
-- Methods that **add a sibling** within the same container (and return the container) stay at the **same indentation level**.
-
-#### Parameter formatting
-
-- **Single parameter**: write inline — `)->label( `Quantity` )` or `)->input( client->_bind( qty ) )`.
-- **More than one parameter**: always split across multiple lines — one parameter per line, aligned below the opening `(`, closing `)` on its own line:
-
-```abap
-)->input(
-    value   = product
-    enabled = abap_false
-)->button(
-    text  = `Post`
-    press = client->_event( `POST` ) ).
-```
-
-Never put two or more named parameters on the same line.
+The chain layout carries the XML hierarchy: the closing paren rides with the
+next arrow, one indent level per container, and the `v =` column is aligned.
 
 ```abap
 METHOD view_display.
 
-  DATA(view) = z2ui5_cl_xml_view=>factory( ).
-  view->shell(
-      )->page(
-          title          = `My App`
-          navbuttonpress = client->_event_nav_app_leave( )
-          shownavbutton  = client->check_app_prev_stack( )
-          )->simple_form(
-              title    = `Form Title`
-              editable = abap_true
-              )->content( `form`
-              )->label( `Quantity`
-              )->input( client->_bind( quantity )
-              )->label( `Product`
-              )->input(
-                  value   = product
-                  enabled = abap_false
-              )->button(
-                  text  = `Post`
-                  press = client->_event( `POST` ) ).
+  DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+      )->a( n = `displayBlock` v = `true`
+      )->a( n = `height`       v = `100%`
+      )->a( n = `xmlns`        v = `sap.m`
+      )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+      )->a( n = `xmlns:core`   v = `sap.ui.core`
+      )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+
+  view->ele( `Shell` )->ele( `Page`
+      )->a( n = `title`          v = `My App`
+      )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+      )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+          )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `title`    v = `Form Title`
+              )->a( n = `editable` b = abap_true
+              )->ele( n = `content` ns = `form`
+                  )->tag( `Label` )->a( n = `text` v = `Quantity`
+                  )->tag( `Input` )->a( n = `value` v = client->_bind( quantity )
+                  )->tag( `Button`
+                      )->a( n = `text`  v = `Post`
+                      )->a( n = `press` v = client->_event( `POST` ) ).
+
   client->view_display( view->stringify( ) ).
 
 ENDMETHOD.
 ```
 
-The hierarchy above is: `shell` → `page` → `simple_form` → `content` → (leaf elements).
-`label`, `input`, `button` are siblings inside `content`, so they stay at the same indent level as `)->content(`.
+The hierarchy is `mvc:View` → `Shell` → `Page` → `form:SimpleForm` →
+`form:content` → leaves. `Label`, `Input` and `Button` are siblings inside
+`content`, so they are added with `tag( )` and stay at the same indent.
 
-### 2. `_generic( )` — controls without a typed method
+#### Namespaces
 
-When a control or aggregation has no typed wrapper method (yet), stay inside
-the `z2ui5_cl_xml_view` chain and add the element generically. **Look up the
-control in the [UI5 API Reference](https://ui5.sap.com/#/api) and translate
-1:1** — element name, namespace and properties exactly as documented:
+Every namespace prefix a view uses must be declared on the view element —
+the builder does not collect them for you. Declare only the ones the view
+actually uses, and use the prefixes the UI5 documentation uses
+(`form` for `sap.ui.layout.form`, `layout` for `sap.ui.layout`, `f` for
+`sap.f`, `table` for `sap.ui.table`).
+
+#### Popups
+
+A popup is a `core:FragmentDefinition` root you build the same way, and hand
+to `client->popup_display( )`:
 
 ```abap
-header_title->_generic(
-    name   = `breadcrumbs`
-    ns     = `f`
-    )->breadcrumbs(
-        )->link( text = `Home` ).
+DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+    )->a( n = `xmlns`      v = `sap.m`
+    )->a( n = `xmlns:core` v = `sap.ui.core` ).
 ```
+
+### 2. Bindings
 
 **Binding paths always come from a bind call — never hardcode them.** Every
 model value a view references must be registered through
@@ -973,25 +1012,22 @@ nothing and makes readers look for a second mode that does not exist. Say
 "One-way" is correct only for a real UI5 one-way model that is not `_bind( )`
 — the `device>` JSONModel in `z2ui5_cl_smp_app_445`, for example.
 
-Key rules for `_generic( )`:
-- `_generic( name = ... ns = ... t_prop = ... )` adds one element and
-  navigates **into** it; typed methods continue the chain below it.
-- **Navigation is per-method, not uniform — check `result =` in
-  `z2ui5_cl_xml_view` before chaining siblings.** Methods returning
-  `result = me` stay on the current node (leaf controls like `text`,
-  `button`, `object_number`, `search_field`, `standard_list_item`,
-  `message_strip`) — siblings chain directly. Methods returning
-  `result = _generic( ... )` navigate INTO the new element (all containers
-  and aggregations, but also child-less controls like `object_status`) —
-  a following sibling needs `->get_parent( )` first, or it silently nests
-  inside and UI5 fails view creation with "Cannot add direct child
-  without default aggregation" (bit sample 453: two chained
-  `object_status` cells).
-- Attributes go into `t_prop = VALUE #( ( n = `...` v = `...` ) ... )`.
-- `ns` is registered on the view automatically — only pass namespaces that
-  are actually used.
-- Raw embedded content (e.g. an inline `<style>` body) goes through
-  `_cc_plain_xml( )`.
+### 3. Two things the builder does not do
+
+- **There is no raw-text node.** An element cannot carry text content, so an
+  inline `<style>` body or any other raw markup goes into the `content`
+  attribute of a `core:HTML` leaf. Write the **decoded** markup — the builder
+  escapes it on stringify:
+
+  ```abap
+  page->tag( n = `HTML` ns = `core` )->a( n = `content` v = `<style>` && css && `</style>` ).
+  ```
+
+- **There is no way back up to a named ancestor.** `end( )` climbs exactly one
+  level, so a view is built the way it nests. When a helper method needs a
+  container the caller owns, the caller passes that reference — see the
+  nested-view samples in `src/00/98`, which take the Page they render into
+  (`mo_parent_page`) rather than searching for it.
 
 > The former standalone XML builder `z2ui5_cl_util_xml` is retired in the
 > framework (obsolete package, no new consumers) and is no longer used by any
@@ -1003,7 +1039,8 @@ Key rules for `_generic( )`:
 > (human decision 2026-08-12; the last two usages — `z2ui5_cl_pop_to_confirm`
 > in sample 279, `z2ui5_cl_pop_image_editor` in sample 306 — were removed the
 > same day). A sample that needs a dialog builds it itself with
-> `z2ui5_cl_xml_view=>factory_popup( )` + `client->popup_display( )`.
+> `z2ui5_cl_ui5_view_builder=>factory( )` with a `core:FragmentDefinition`
+> root + `client->popup_display( )`.
 
 #### VALUE #( ) formatting
 
@@ -1111,7 +1148,7 @@ CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
     " ...
     client->view_display( view->stringify( ) ).
 
@@ -1158,8 +1195,8 @@ new/edited samples stay consistent:
 - **DESCRIPTs of framework-action / custom-control samples carry a
   capability marker** appended to the `<DESCRIPT>`
   (leading space), surfaced in the overview:
-  - `(C)` — uses an abap2UI5 **custom control** (`view->_z2ui5( )->…`, or the
-    `z2ui5` cc namespace: `_generic( … ns = `z2ui5` … )`, `z2ui5.cc`, `xmlns:z2ui5`).
+  - `(C)` — uses an abap2UI5 **custom control** (the `z2ui5` cc namespace:
+    `ele( n = … ns = `z2ui5` )`, `z2ui5.cc`, `xmlns:z2ui5`).
   - `(A)` — performs a **frontend action**: `client->follow_up_action( )`
     (including the `cs_event-control_by_id` / `cs_event-control_global` /
     `cs_event-binding_call` events), or a

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#8de79537a714adc34088afeea00fbea13c207a64",
+        "@abap2ui5/linter": "github:abap2UI5/linter#51cce10ae74be2b1da20d346f0cdce4cc8b7b5f9",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,30 +18,30 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#8de79537a714adc34088afeea00fbea13c207a64",
-      "integrity": "sha512-FuJjsDhg/Z006L+hKrseJpv1nVF9kPlFmfKt7zeVGrsjxr3XJYDJwp/9IXnlfV3d9AeMrd/UESdF6SyaMi2gww==",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#51cce10ae74be2b1da20d346f0cdce4cc8b7b5f9",
+      "integrity": "sha512-1LhUM9alQ7y/Huo7hUdYykIVandta6M9deZWyAX8DIfVG8KTr0eAqEkfjnA0B+zbNv6JbtfMHY4YDG8H26+luA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@openui5/sap.f": "1.150.0",
-        "@openui5/sap.m": "1.150.0",
-        "@openui5/sap.tnt": "1.150.0",
-        "@openui5/sap.ui.codeeditor": "1.150.0",
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.integration": "1.150.0",
-        "@openui5/sap.ui.layout": "1.150.0",
-        "@openui5/sap.ui.table": "1.150.0",
-        "@openui5/sap.ui.unified": "1.150.0",
-        "@openui5/sap.uxap": "1.150.0",
-        "@openui5/themelib_sap_horizon": "1.150.0",
-        "playwright": "^1.61.1"
-      },
       "bin": {
         "abap2ui5-linter": "cli.mjs",
         "abap2ui5lint": "cli.mjs"
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@openui5/sap.f": "1.151.0",
+        "@openui5/sap.m": "1.151.0",
+        "@openui5/sap.tnt": "1.151.0",
+        "@openui5/sap.ui.codeeditor": "1.151.0",
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.integration": "1.151.0",
+        "@openui5/sap.ui.layout": "1.151.0",
+        "@openui5/sap.ui.table": "1.151.0",
+        "@openui5/sap.ui.unified": "1.151.0",
+        "@openui5/sap.uxap": "1.151.0",
+        "@openui5/themelib_sap_horizon": "1.151.0",
+        "playwright": "^1.61.1"
       }
     },
     "node_modules/@abaplint/cli": {
@@ -61,121 +61,132 @@
       }
     },
     "node_modules/@openui5/sap.f": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.f/-/sap.f-1.150.0.tgz",
-      "integrity": "sha512-PL/4BFQEv6kA+eP+ISfVBghFFiibICBplpxLA4lk1xnSMd4Bi0eXvuvLGVmOeV2zlVQYK2Zun5LoawNS+6eITQ==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.f/-/sap.f-1.151.0.tgz",
+      "integrity": "sha512-nSNAM+/Gqniqk53rakq0heM2dJ0I14ert6s3sA93DjHBZpQOcaAchfY5idzI2OSU3G7OHtbOZKCrfwSZ2eSVZQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.m": "1.150.0",
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.layout": "1.150.0"
+        "@openui5/sap.m": "1.151.0",
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.layout": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.m": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.m/-/sap.m-1.150.0.tgz",
-      "integrity": "sha512-1e7WhA8YkDmsoIJPgqGY5sAe2EkrwMU3ZEjbvW+Gzu/REt5yg3oR/HzYLCi5fTPWxH7G7rc8ksfXK0sskQBEhw==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.m/-/sap.m-1.151.0.tgz",
+      "integrity": "sha512-CzGB4/ckoCHrlpSvsah2seGYvb/nOqoWqYtKHI0TncGaQ/bKq0omqsa3Z0rGApqXWv/wWS6O1EYBgDlv5NWFPQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.layout": "1.150.0",
-        "@openui5/sap.ui.unified": "1.150.0"
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.layout": "1.151.0",
+        "@openui5/sap.ui.unified": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.tnt": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.tnt/-/sap.tnt-1.150.0.tgz",
-      "integrity": "sha512-k5mT/En66prNehJ2u+FcPsStQleyGKFpTNJzd3i+3f+Y8tYcxkECL3/7jdVCnN0b7RRB6yA/VDLbhSZ13HHopQ==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.tnt/-/sap.tnt-1.151.0.tgz",
+      "integrity": "sha512-BEV7fShRmvq+mroDZASzT+jYyWPxNQI1k0y1ZXG/fYUhQ1pJYSphm1ZL0b+QCcc13o+m5jGQyy2WNJdiFJPnLw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.m": "1.150.0",
-        "@openui5/sap.ui.core": "1.150.0"
+        "@openui5/sap.m": "1.151.0",
+        "@openui5/sap.ui.core": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.ui.codeeditor": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.codeeditor/-/sap.ui.codeeditor-1.150.0.tgz",
-      "integrity": "sha512-KOxcwCq35FBnrarHiZfPT48Ha1YWsWY2zO8s8YK+fQUH8clfQao0d3mf4ZPDr60A3CDS3y4h0B7GItjC9Nuecw==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.codeeditor/-/sap.ui.codeeditor-1.151.0.tgz",
+      "integrity": "sha512-rQ0Hdv+0HJLHrPjXMV1MC13QTa7z0OsG9nwxY5Rdk4GuFIfd0QM1IcQISFg77Jl+ng+SIJS09frIjz4oO/a8/g==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.ui.core": "1.150.0"
+        "@openui5/sap.ui.core": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.ui.core": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.core/-/sap.ui.core-1.150.0.tgz",
-      "integrity": "sha512-rJjHCRrm6oLWopf0by6ydzsnLO5fDsA80uJYIpIUvvo7oxBpa+Ks9t2r3lmA4QRZ6GsPK6uz0+KuZXaET6C2kA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@openui5/sap.ui.integration": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.integration/-/sap.ui.integration-1.150.0.tgz",
-      "integrity": "sha512-Qwo0pkq9mgnJ7rLNC8pigOTDvZJLuGHoMCLRdF6pO3+cNNUlPH1W8mwesczMlgIqJwBAEzBtZhgidcpPyjvDrg==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.core/-/sap.ui.core-1.151.0.tgz",
+      "integrity": "sha512-0cIWVWZ4mmsAl+b+HKiK50mY0Pq4mBE10wC79xIwvK904f7yTUQW+TIqAmYIsXm0TrcxCqGY7DvfHnrVJTao5Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/@openui5/sap.ui.integration": {
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.integration/-/sap.ui.integration-1.151.0.tgz",
+      "integrity": "sha512-dOUbakjdziJRIE+jy2S363A5W+1BqoPWJwbJ9IQDHq6VCoNDTYCaol+YXN2mpUH5IZfYCNMaW8OpBdDaZ7kBng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.f": "1.150.0",
-        "@openui5/sap.m": "1.150.0",
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.layout": "1.150.0",
-        "@openui5/sap.ui.unified": "1.150.0"
+        "@openui5/sap.f": "1.151.0",
+        "@openui5/sap.m": "1.151.0",
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.layout": "1.151.0",
+        "@openui5/sap.ui.unified": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.ui.layout": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.layout/-/sap.ui.layout-1.150.0.tgz",
-      "integrity": "sha512-4VAYnh9x33yOK/fYFB8MGv4Zv5nXA9uXGRBTo1FdIoWw1Dc4UhL5DtJKa1jGTej3JV0hRFgOvyejyYkzUpP9Zg==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.layout/-/sap.ui.layout-1.151.0.tgz",
+      "integrity": "sha512-TNhwtKkZLDcSfhxa5p6dpw7NvJ0qb9K70lq0fa15ahTi/RQKE3AAH4lz8Y40UwtJwtRGZN6TPz/hhBrfCvqC0A==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.ui.core": "1.150.0"
+        "@openui5/sap.ui.core": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.ui.table": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.table/-/sap.ui.table-1.150.0.tgz",
-      "integrity": "sha512-FDFcdf55iKuGQom6fRn135OmbcYEYclo/SsCoPVfXzsxrO/eVb+ju0cMI4AAZaRfZ950172G/xxkoYZtTAMbjw==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.table/-/sap.ui.table-1.151.0.tgz",
+      "integrity": "sha512-TmSLiL/FclgO1k0cjMbBn1zYW1D4eE1Nw3D0gcCeWBX+Ph080TWaPkULBAyO+ZLrsFD/YPeDIqHru92JJbOdGA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.unified": "1.150.0"
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.unified": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.ui.unified": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.unified/-/sap.ui.unified-1.150.0.tgz",
-      "integrity": "sha512-6Eew5gk6U9Vsv0mj8Km7NVFE0ENZs/lyttdBCoIayLKGyOWj6c8EAAeg60/oedDddsNIGhs04eqk/0umUV3uMw==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.ui.unified/-/sap.ui.unified-1.151.0.tgz",
+      "integrity": "sha512-GPnsaXfLwXfgBt0pT1WvbXXZL5xwCz2D2BcFbupHn51abz9FGZsiroASnbZLuP3XFoxXGBJBbNLAbAoWOfX+bQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.ui.core": "1.150.0"
+        "@openui5/sap.ui.core": "1.151.0"
       }
     },
     "node_modules/@openui5/sap.uxap": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/sap.uxap/-/sap.uxap-1.150.0.tgz",
-      "integrity": "sha512-3LThcaP5BuMjCLmolmkRDZ0oe4nyDBGm+9k5HLMsRuPGVksg+GKrwmh78YnnGWnMW70Tb5uUqzFPI6JcmVd8jA==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/sap.uxap/-/sap.uxap-1.151.0.tgz",
+      "integrity": "sha512-VqdvIaSbGX3Ex7hI3GuTrH33OmWiBhg8/HECNTVSmsVQTwesRYR6lPjZANzKmwPd5k1tL0JanXgSmgt7Akn2yA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@openui5/sap.f": "1.150.0",
-        "@openui5/sap.m": "1.150.0",
-        "@openui5/sap.ui.core": "1.150.0",
-        "@openui5/sap.ui.layout": "1.150.0"
+        "@openui5/sap.f": "1.151.0",
+        "@openui5/sap.m": "1.151.0",
+        "@openui5/sap.ui.core": "1.151.0",
+        "@openui5/sap.ui.layout": "1.151.0"
       }
     },
     "node_modules/@openui5/themelib_sap_horizon": {
-      "version": "1.150.0",
-      "resolved": "https://registry.npmjs.org/@openui5/themelib_sap_horizon/-/themelib_sap_horizon-1.150.0.tgz",
-      "integrity": "sha512-4wwuNTDqcGeEe9HFw1Vi5jKGNakoK8F7RifMW94agZbXHolmk9i/T1epcIo7TEARqHvoq5zwlxOH9GUL+4tPUA==",
+      "version": "1.151.0",
+      "resolved": "https://registry.npmjs.org/@openui5/themelib_sap_horizon/-/themelib_sap_horizon-1.151.0.tgz",
+      "integrity": "sha512-kyNiL/WlEQV1WrYneI8KZBpPmHzwpaPVLn0kqOS61XUgWz0z97ESmarAT3JuX7gzNAx4vxEaV5bXSYZ1VDxWng==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -198,6 +209,7 @@
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "playwright-core": "1.62.1"
       },
@@ -217,6 +229,7 @@
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#8de79537a714adc34088afeea00fbea13c207a64",
+    "@abap2ui5/linter": "github:abap2UI5/linter#51cce10ae74be2b1da20d346f0cdce4cc8b7b5f9",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -59,11 +59,18 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell( )->page( title          = `abap2UI5 - Popups`
-                                       navbuttonpress = client->_event_nav_app_leave( )
-                                       shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Popups`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     " A style class the app owns. There is no bindable property for "carry
     " this CSS class", so the class itself is declared here and put on the
@@ -78,25 +85,24 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
     " The literal CSS braces must be escaped \{ \} in a BACKTICK literal - the
     " XMLView binding parser reads an unescaped { in any attribute value as a
     " binding and crashes, and a |...| template would collapse \{ back to {.
-    page->_generic( name   = `HTML`
-                    ns     = `core`
-                    t_prop = VALUE #( ( n = `content`
-                                        v = `<style>.demoHighlight \{ color: #bb0000 !important; font-size: 1.5rem !important; \}</style>` ) ) ).
+    page->ele( n = `HTML` ns = `core`
+        )->a( n = `content` v = `<style>.demoHighlight \{ color: #bb0000 !important; font-size: 1.5rem !important; \}</style>` ).
 
-    page->message_strip(
-        text     = `Changes a control INSIDE an open popup from the backend. The ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Changes a control INSIDE an open popup from the backend. The ` &&
                    `label text is an ordinary binding; the style class has ` &&
                    `no bindable equivalent and is applied with follow_up_action( ` &&
                    `control_by_id ) scoped to the popup view. No custom JavaScript ` &&
                    `is involved.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( `Inputs` )->content( `form`
-        )->label( `01`
-        )->button( text  = `Popup Get Input Values`
-                   press = client->_event( `POPUP_OPEN` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Inputs` )->ele( n = `content` ns = `form` )->tag( `Label`
+            )->a( n = `text` v = `01` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPUP_OPEN` )
+            )->a( n = `text`  v = `Popup Get Input Values` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -105,36 +111,33 @@ CLASS z2ui5_cl_smp_app_141 IMPLEMENTATION.
 
   METHOD popup_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    DATA(dialog) = popup->dialog( title         = `Title`
-                                  contentheight = `500px`
-                                  contentwidth  = `500px` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title`         v = `Title`
+        )->a( n = `contentWidth`  v = `500px`
+        )->a( n = `contentHeight` v = `500px` ).
 
-    dialog->content(
-        )->simple_form( editable = abap_true
-            )->content( `form`
-                )->label( id   = `lbl1`
-                          text = client->_bind( s_input-hint )
-                )->label( `Input1`
-                )->input( client->_bind( s_input-value1 )
-                )->label( `Input2`
-                )->input( client->_bind( s_input-value2 )
-                )->label( `Checkbox`
-                )->checkbox( selected = client->_bind( s_input-is_active )
-                             text     = `this is a checkbox`
-                             enabled  = abap_true )->get_parent( )->get_parent( )->get_parent(
-        " the `buttons` aggregation, not `footer`: sap.m.Dialog only got a
-        " public footer around UI5 1.110, and an aggregation tag the parent
-        " does not have is resolved as a CONTROL CLASS - it 404s and takes the
-        " whole view with it (abap2UI5 AGENTS rule 15). `buttons` exists since
-        " 1.21.1 and right-aligns them the same way.
-        )->buttons(
-            )->button( text  = `Cancel`
-                       press = client->follow_up_action( client->cs_event-popup_close )
-            )->button( text  = `Confirm`
-                       type  = `Emphasized`
-                       press = client->_event( `POPUP_CONFIRM` ) ).
+    dialog->ele( `content` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                    )->a( n = `text` v = client->_bind( s_input-hint )
+                    )->a( n = `id`   v = `lbl1` )->tag( `Label`
+                    )->a( n = `text` v = `Input1` )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( s_input-value1 ) )->tag( `Label`
+                    )->a( n = `text` v = `Input2` )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( s_input-value2 ) )->tag( `Label`
+                    )->a( n = `text` v = `Checkbox` )->tag( `CheckBox`
+                    )->a( n = `text`     v = `this is a checkbox`
+                    )->a( n = `selected` v = client->_bind( s_input-is_active )
+                    )->a( n = `enabled`  b = abap_true )->end( )->end( )->end( )->ele( `buttons` )->tag( `Button`
+                )->a( n = `press` v = client->follow_up_action( client->cs_event-popup_close )
+                )->a( n = `text`  v = `Cancel` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `POPUP_CONFIRM` )
+                )->a( n = `text`  v = `Confirm`
+                )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/00/97/z2ui5_cl_smp_app_321.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_321.clas.abap
@@ -15,30 +15,30 @@ CLASS z2ui5_cl_smp_app_321 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_navigated( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( view->shell(
-             )->page(
-                     title          = `abap2UI5 - Navigation with app state`
-                     navbuttonpress = client->_event( `BACK` )
-                     shownavbutton  = client->check_app_prev_stack( )
-          )->message_strip(
-              text     = `set_app_state_active( ) carries the app state id in the URL, so the page can be `
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      client->view_display( view->ele( `Shell` )->ele( `Page`
+                 )->a( n = `title`          v = `abap2UI5 - Navigation with app state`
+                 )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                 )->a( n = `navButtonPress` v = client->_event( `BACK` ) )->tag( `MessageStrip`
+              )->a( n = `text`     v = `set_app_state_active( ) carries the app state id in the URL, so the page can be `
                       && `bookmarked and the entered data is restored when the bookmark is opened again. `
                       && `Enter a quantity, press the button and reload the page.`
-              type     = `Information`
-              showicon = abap_true
-              class    = `sapUiSmallMargin`
-          )->simple_form(
-              title    = `Form Title`
-              editable = abap_true
-                     )->content( `form`
-                         )->title( `Input`
-                         )->label( `quantity`
-                         )->input( client->_bind( mv_quantity )
-                         )->button(
-                             text  = `post with state`
-                             press = client->_event( `BUTTON_POST` )
-              )->stringify( ) ).
+              )->a( n = `type`     v = `Information`
+              )->a( n = `showIcon` b = abap_true
+              )->a( n = `class`    v = `sapUiSmallMargin` )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `title`    v = `Form Title`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                             )->a( n = `text` v = `Input` )->tag( `Label`
+                             )->a( n = `text` v = `quantity` )->tag( `Input`
+                             )->a( n = `value` v = client->_bind( mv_quantity ) )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                             )->a( n = `text`  v = `post with state` )->stringify( ) ).
     ENDIF.
 
     CASE client->get_event( ).

--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -15,33 +15,32 @@ CLASS z2ui5_cl_smp_app_322 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_navigated( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( view->shell(
-             )->page(
-                     title          = `abap2UI5 - Navigation with app state`
-                     navbuttonpress = client->_event_nav_app_leave( )
-                     shownavbutton  = client->check_app_prev_stack( )
-          )->message_strip(
-              text     = `set_push_state( ) pushes an app-owned suffix onto the browser URL, so the app can `
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      client->view_display( view->ele( `Shell` )->ele( `Page`
+                 )->a( n = `title`          v = `abap2UI5 - Navigation with app state`
+                 )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                 )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->tag( `MessageStrip`
+              )->a( n = `text`     v = `set_push_state( ) pushes an app-owned suffix onto the browser URL, so the app can `
                       && `write its own hash (here /head/pos/<draft id>) and the browser back button `
                       && `navigates through those entries.`
-              type     = `Information`
-              showicon = abap_true
-              class    = `sapUiSmallMargin`
-          )->simple_form(
-              title    = `Form Title`
-              editable = abap_true
-                     )->content( `form`
-                         )->title( `Input`
-                         )->label( `quantity`
-                         )->input( client->_bind( mv_quantity )
-                         )->button(
-                             text  = `post`
-                             press = client->_event( `BUTTON_POST` )
-                         )->button(
-                             text  = `back`
-                             press = client->_event( `BUTTON_BACK` )
-              )->stringify( ) ).
+              )->a( n = `type`     v = `Information`
+              )->a( n = `showIcon` b = abap_true
+              )->a( n = `class`    v = `sapUiSmallMargin` )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `title`    v = `Form Title`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                             )->a( n = `text` v = `Input` )->tag( `Label`
+                             )->a( n = `text` v = `quantity` )->tag( `Input`
+                             )->a( n = `value` v = client->_bind( mv_quantity ) )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                             )->a( n = `text`  v = `post` )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON_BACK` )
+                             )->a( n = `text`  v = `back` )->stringify( ) ).
 
       IF client->check_app_prev_stack( ).
         client->set_push_state( `/head/pos/` && client->get( )-s_draft-id ).

--- a/src/00/97/z2ui5_cl_smp_app_323.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_323.clas.abap
@@ -15,30 +15,30 @@ CLASS z2ui5_cl_smp_app_323 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_navigated( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( view->shell(
-             )->page(
-                     title          = `abap2UI5 - Navigation with app state`
-                     navbuttonpress = client->_event( `BACK` )
-                     shownavbutton  = client->check_app_prev_stack( )
-          )->message_strip(
-              text     = `The clipboard_app_state front-end action copies a link to the CURRENT app state `
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      client->view_display( view->ele( `Shell` )->ele( `Page`
+                 )->a( n = `title`          v = `abap2UI5 - Navigation with app state`
+                 )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                 )->a( n = `navButtonPress` v = client->_event( `BACK` ) )->tag( `MessageStrip`
+              )->a( n = `text`     v = `The clipboard_app_state front-end action copies a link to the CURRENT app state `
                       && `into the clipboard, so the state can be shared with someone else. Enter a `
                       && `quantity, press share and open the copied link.`
-              type     = `Information`
-              showicon = abap_true
-              class    = `sapUiSmallMargin`
-          )->simple_form(
-              title    = `Form Title`
-              editable = abap_true
-                     )->content( `form`
-                         )->title( `Input`
-                         )->label( `quantity`
-                         )->input( client->_bind( mv_quantity )
-                         )->button(
-                             text  = `share`
-                             press = client->_event( `BUTTON_POST` )
-              )->stringify( ) ).
+              )->a( n = `type`     v = `Information`
+              )->a( n = `showIcon` b = abap_true
+              )->a( n = `class`    v = `sapUiSmallMargin` )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `title`    v = `Form Title`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                             )->a( n = `text` v = `Input` )->tag( `Label`
+                             )->a( n = `text` v = `quantity` )->tag( `Input`
+                             )->a( n = `value` v = client->_bind( mv_quantity ) )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                             )->a( n = `text`  v = `share` )->stringify( ) ).
     ENDIF.
 
     CASE client->get_event( ).

--- a/src/00/97/z2ui5_cl_smp_app_468.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_468.clas.abap
@@ -72,44 +72,54 @@ CLASS z2ui5_cl_smp_app_468 IMPLEMENTATION.
                                 t_arg = VALUE #( ( client->cs_nav_mode-fresh ) ) ).
     ENDIF.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Navigation - Routing Mode fresh`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Navigation - Routing Mode fresh`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Add some state (type / raise the counter), open the detail page, then press your ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Add some state (type / raise the counter), open the detail page, then press your ` &&
                    `BROWSER Back button and watch this page.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form( `Routing mode fresh`
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title` v = `Routing mode fresh` )->ele( n = `content` ns = `form` ).
 
-    form->label( `1. Some state - type here` ).
-    form->input( client->_bind( input ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `1. Some state - type here` ).
+    form->tag( `Input`
+        )->a( n = `value` v = client->_bind( input ) ).
 
-    form->label( `and raise a counter` ).
-    form->button(
-        text  = |increment ({ counter })|
-        press = client->_event( `INC` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `and raise a counter` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `INC` )
+        )->a( n = `text`  v = |increment ({ counter })| ).
 
-    form->label( `2. Navigate forward` ).
-    form->button(
-        text  = `go to the detail page (nav_app_call)`
-        type  = `Emphasized`
-        press = client->_event( `GO_DETAIL` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `2. Navigate forward` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO_DETAIL` )
+        )->a( n = `text`  v = `go to the detail page (nav_app_call)`
+        )->a( n = `type`  v = `Emphasized` ).
 
-    page->message_strip(
-        text     = `fresh: the URL carries the class only (#/app/<CLASS>). After the detail page, the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `fresh: the URL carries the class only (#/app/<CLASS>). After the detail page, the ` &&
                    `browser Back button starts this app FRESH - input and counter are reset.`
-        type     = `Success`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Success`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/00/97/z2ui5_cl_smp_app_480.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_480.clas.abap
@@ -71,44 +71,54 @@ CLASS z2ui5_cl_smp_app_480 IMPLEMENTATION.
                                 t_arg = VALUE #( ( client->cs_nav_mode-keep ) ) ).
     ENDIF.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Navigation - Routing Mode keep`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Navigation - Routing Mode keep`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Add some state (type / raise the counter), open the detail page, then press your ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Add some state (type / raise the counter), open the detail page, then press your ` &&
                    `BROWSER Back button and watch this page.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form( `Routing mode keep`
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title` v = `Routing mode keep` )->ele( n = `content` ns = `form` ).
 
-    form->label( `1. Some state - type here` ).
-    form->input( client->_bind( input ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `1. Some state - type here` ).
+    form->tag( `Input`
+        )->a( n = `value` v = client->_bind( input ) ).
 
-    form->label( `and raise a counter` ).
-    form->button(
-        text  = |increment ({ counter })|
-        press = client->_event( `INC` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `and raise a counter` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `INC` )
+        )->a( n = `text`  v = |increment ({ counter })| ).
 
-    form->label( `2. Navigate forward` ).
-    form->button(
-        text  = `go to the detail page (nav_app_call)`
-        type  = `Emphasized`
-        press = client->_event( `GO_DETAIL` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `2. Navigate forward` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO_DETAIL` )
+        )->a( n = `text`  v = `go to the detail page (nav_app_call)`
+        )->a( n = `type`  v = `Emphasized` ).
 
-    page->message_strip(
-        text     = `keep: the URL carries the app-state draft (#/app/<CLASS>/<DRAFT>). After the detail ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `keep: the URL carries the app-state draft (#/app/<CLASS>/<DRAFT>). After the detail ` &&
                    `page, the browser Back button restores this page EXACTLY - input and counter come back.`
-        type     = `Success`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Success`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_086.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_086.clas.abap
@@ -24,18 +24,25 @@ CLASS z2ui5_cl_smp_app_086 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-               title          = `abap2UI5 - Flow Logic - APP 85`
-               navbuttonpress = client->_event_nav_app_leave( )
-               shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Flow Logic - APP 85`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->grid( `L6 M12 S12` )->content( `layout`
-      )->simple_form( `Supplier` )->content( `form`
-      )->label( `Value set by previous app`
-           )->input( value    = ls_detail_supplier-suppliername
-                     editable = `false` ).
+    page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `title` v = `Supplier` )->ele( n = `content` ns = `form` )->tag( `Label`
+          )->a( n = `text` v = `Value set by previous app` )->tag( `Input`
+               )->a( n = `editable` v = `false`
+               )->a( n = `value`    v = ls_detail_supplier-suppliername ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_094.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_094.clas.abap
@@ -27,7 +27,7 @@ CLASS z2ui5_cl_smp_app_094 DEFINITION PUBLIC.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA page TYPE REF TO z2ui5_cl_xml_view.
+    DATA page TYPE REF TO z2ui5_cl_ui5_view_builder.
 
   PRIVATE SECTION.
 ENDCLASS.
@@ -71,48 +71,52 @@ CLASS z2ui5_cl_smp_app_094 IMPLEMENTATION.
 
     ASSIGN mr_screen->* TO <screen>.
 
-    page = z2ui5_cl_xml_view=>factory( )->shell(
-          )->page( title          = `test`
-                   navbuttonpress = client->_event_nav_app_leave( )
-                   shownavbutton  = client->check_app_prev_stack( ) ).
+    page = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` )->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `test`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    DATA(o_grid) = page->grid( `L6 M12 S12`
-        )->content( `layout` ).
+    DATA(o_grid) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` ).
 
-    DATA(content) = o_grid->simple_form( `Input`
-          )->content( `form` ).
+    DATA(content) = o_grid->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Input` )->ele( n = `content` ns = `form` ).
 
-    content->label( `structure level 01`
-      )->input( client->_bind( ms_screen-input )
-      )->label( `ref data`
-      )->input( client->_bind( <input> )
-      )->label( `ref data struc field`
-      )->input( client->_bind( <screen>-input )
-      )->label( `struc deep dissolve`
-      )->input( client->_bind( ms_screen-ty_s_02-input )
-      )->label( `struc deep switch guid name`
-      )->input( client->_bind( ms_screen-ty_s_02-ty_s_03-ty_s_04-input )
-      )->label( `instance attribute val`
-      )->input( client->_bind( mo_app->mv_val )
-      )->label( `instance attribute struc`
-      )->input( client->_bind( mo_app->ms_screen-input ) ).
+    content->tag( `Label`
+        )->a( n = `text` v = `structure level 01` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( ms_screen-input ) )->tag( `Label`
+          )->a( n = `text` v = `ref data` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( <input> ) )->tag( `Label`
+          )->a( n = `text` v = `ref data struc field` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( <screen>-input ) )->tag( `Label`
+          )->a( n = `text` v = `struc deep dissolve` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( ms_screen-ty_s_02-input ) )->tag( `Label`
+          )->a( n = `text` v = `struc deep switch guid name` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( ms_screen-ty_s_02-ty_s_03-ty_s_04-input ) )->tag( `Label`
+          )->a( n = `text` v = `instance attribute val` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( mo_app->mv_val ) )->tag( `Label`
+          )->a( n = `text` v = `instance attribute struc` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( mo_app->ms_screen-input ) ).
 
-    page->footer( )->overflow_toolbar(
-                   )->toolbar_spacer(
-                   )->button(
-                       text  = `Delete`
-                       press = client->_event( `BUTTON_DELETE` )
-                       type  = `Reject`
-                       icon  = `sap-icon://delete`
-                   )->button(
-                       text  = `Add`
-                       press = client->_event( `BUTTON_ADD` )
-                       type  = `Default`
-                       icon  = `sap-icon://add`
-                   )->button(
-                       text  = `Save`
-                       press = client->_event( `BUTTON_SAVE` )
-                       type  = `Success` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                       )->a( n = `press` v = client->_event( `BUTTON_DELETE` )
+                       )->a( n = `text`  v = `Delete`
+                       )->a( n = `icon`  v = `sap-icon://delete`
+                       )->a( n = `type`  v = `Reject` )->tag( `Button`
+                       )->a( n = `press` v = client->_event( `BUTTON_ADD` )
+                       )->a( n = `text`  v = `Add`
+                       )->a( n = `icon`  v = `sap-icon://add`
+                       )->a( n = `type`  v = `Default` )->tag( `Button`
+                       )->a( n = `press` v = client->_event( `BUTTON_SAVE` )
+                       )->a( n = `text`  v = `Save`
+                       )->a( n = `type`  v = `Success` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_117.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_117.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_117 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -64,23 +64,30 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_118.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_118.clas.abap
@@ -41,63 +41,59 @@ CLASS z2ui5_cl_smp_app_118 IMPLEMENTATION.
 
     ENDIF.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Weird Behavior Showcase`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( )
-            showheader     = abap_true ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Weird Behavior Showcase`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `showHeader`     b = abap_true ).
 
-    DATA(tab_ko) = page->table(
-                        mode  = `MultiSelect`
-                        items = client->_bind( problematic_rows ) ).
+    DATA(tab_ko) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( problematic_rows )
+        )->a( n = `mode`  v = `MultiSelect` ).
 
-    tab_ko->header_toolbar(
-            )->toolbar(
-                )->title( |This table has the weird behavior|
-                )->toolbar_spacer(
-                )->button(
-                    text  = |Go|
-                    icon  = `sap-icon://blur`
-                    press = client->_event( `ON_BTN_GO` ) ).
+    tab_ko->ele( `headerToolbar` )->ele( `Toolbar` )->tag( `Title`
+                    )->a( n = `text` v = |This table has the weird behavior| )->tag( `ToolbarSpacer` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `ON_BTN_GO` )
+                    )->a( n = `text`  v = |Go|
+                    )->a( n = `icon`  v = `sap-icon://blur` ).
 
-    tab_ko->columns(
-            )->column( )->text( `ID` )->get_parent(
-            )->column( )->text( `Description` )->get_parent(
-            )->column( )->text( `Date ` )->get_parent(
-            )->column( )->text( `Time` ).
+    tab_ko->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `ID` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Date ` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Time` ).
 
-    tab_ko->items(
-         )->column_list_item(
-             )->cells(
-                 )->object_identifier( title = `{ID}` )->get_parent(
-                 )->text( `{DESCR}`
-                 )->text( `{ADATE}`
-                 )->text( `{ATIME}` ).
+    tab_ko->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->ele( `ObjectIdentifier`
+                     )->a( n = `title` v = `{ID}` )->end( )->tag( `Text`
+                     )->a( n = `text` v = `{DESCR}` )->tag( `Text`
+                     )->a( n = `text` v = `{ADATE}` )->tag( `Text`
+                     )->a( n = `text` v = `{ATIME}` ).
 
-    DATA(tab_ok) = page->table(
-                        mode  = `MultiSelect`
-                        items = client->_bind( these_are_fine_rows ) ).
+    DATA(tab_ok) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( these_are_fine_rows )
+        )->a( n = `mode`  v = `MultiSelect` ).
 
-    tab_ok->header_toolbar(
-            )->toolbar(
-                )->title( |This table is fine| ).
+    tab_ok->ele( `headerToolbar` )->ele( `Toolbar` )->tag( `Title`
+                    )->a( n = `text` v = |This table is fine| ).
 
-    tab_ok->columns(
-            )->column( )->text( `ID` )->get_parent(
-            )->column( )->text( `Description` )->get_parent(
-            )->column( )->text( `Date ` )->get_parent(
-            )->column( )->text( `Time` ).
+    tab_ok->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `ID` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Date ` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Time` ).
 
-    tab_ok->items(
-         )->column_list_item(
-             )->cells(
-                 )->object_identifier( title = `{ID}` )->get_parent(
-                 )->text( `{DESCR}`
-                 )->text( `{ADATE}`
-                 )->text( `{ATIME}` ).
+    tab_ok->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->ele( `ObjectIdentifier`
+                     )->a( n = `title` v = `{ID}` )->end( )->tag( `Text`
+                     )->a( n = `text` v = `{DESCR}` )->tag( `Text`
+                     )->a( n = `text` v = `{ADATE}` )->tag( `Text`
+                     )->a( n = `text` v = `{ATIME}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_126.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_126.clas.abap
@@ -5,7 +5,9 @@ CLASS z2ui5_cl_smp_app_126 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     DATA mv_perc         TYPE string.
     DATA mt_table        TYPE REF TO data.
@@ -120,26 +122,32 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
 
   METHOD view_display.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
     ENDIF.
 
-    page->message_strip(
-        text     = `This sample shows the ProgressIndicator control, which renders a ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample shows the ProgressIndicator control, which renders a ` &&
                    `completion percentage as a labeled progress bar.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->label( `ProgressIndicator`
-        )->progress_indicator( percentvalue = mv_perc
-                               displayvalue = `0,44GB of 32GB used`
-                               showvalue    = abap_true
-                               state        = `Success` ).
+    page->tag( `Label`
+        )->a( n = `text` v = `ProgressIndicator` )->tag( `ProgressIndicator`
+            )->a( n = `percentValue` v = mv_perc
+            )->a( n = `displayValue` v = `0,44GB of 32GB used`
+            )->a( n = `showValue`    b = abap_true
+            )->a( n = `state`        v = `Success` ).
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_131.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_131.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_131 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -66,23 +66,30 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_132.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_132.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_132 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_perc         TYPE string.
 
     METHODS set_app_data
@@ -73,21 +75,27 @@ CLASS z2ui5_cl_smp_app_132 IMPLEMENTATION.
 
   METHOD view_display.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
 
     ENDIF.
 
-    page->label( `ProgressIndicator`
-        )->progress_indicator( percentvalue = mv_perc
-                               displayvalue = `0,44GB of 32GB used`
-                               showvalue    = abap_true
-                               state        = `Success` ).
+    page->tag( `Label`
+        )->a( n = `text` v = `ProgressIndicator` )->tag( `ProgressIndicator`
+            )->a( n = `percentValue` v = mv_perc
+            )->a( n = `displayValue` v = `0,44GB of 32GB used`
+            )->a( n = `showValue`    b = abap_true
+            )->a( n = `state`        v = `Success` ).
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_138.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_138.clas.abap
@@ -42,24 +42,26 @@ CLASS z2ui5_cl_smp_app_138 IMPLEMENTATION.
       ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val  = `tomato`.
       quantity = `500`.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( view->shell(
-            )->page(
-                    title          = `abap2UI5 - First Example`
-                    navbuttonpress = client->_event_nav_app_leave( )
-                    shownavbutton  = client->check_app_prev_stack( )
-                )->simple_form( title    = `Form Title`
-                                editable = abap_true
-                    )->content( `form`
-                        )->title( `Input`
-                        )->label( `quantity`
-                        )->input( client->_bind( quantity )
-                        )->label( `product`
-                        )->input( client->_bind( ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val )
-                        )->button(
-                            text  = `post`
-                            press = client->_event( `BUTTON_POST` )
-             )->stringify( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      client->view_display( view->ele( `Shell` )->ele( `Page`
+                )->a( n = `title`          v = `abap2UI5 - First Example`
+                )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( n = `SimpleForm` ns = `form`
+                    )->a( n = `title`    v = `Form Title`
+                    )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                            )->a( n = `text` v = `Input` )->tag( `Label`
+                            )->a( n = `text` v = `quantity` )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( quantity ) )->tag( `Label`
+                            )->a( n = `text` v = `product` )->tag( `Input`
+                            )->a( n = `value` v = client->_bind( ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val ) )->tag( `Button`
+                            )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                            )->a( n = `text`  v = `post` )->stringify( ) ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_184.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_184.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_184 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     DATA mv_table        TYPE string.
     DATA mt_table        TYPE REF TO data.
@@ -49,38 +51,44 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
 
     FIELD-SYMBOLS <tab> TYPE data.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
     ENDIF.
 
     ASSIGN mt_table->* TO <tab>.
 
-    DATA(table) = page->table( growing = `true`
-                               width   = `auto`
-                               items   = client->_bind( <tab> )
-                               ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`   v = client->_bind( <tab> )
+        )->a( n = `growing` v = `true`
+        )->a( n = `width`   v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mt_comp INTO DATA(comp).
 
-      columns->column( )->text( comp-name ).
+      columns->ele( `Column` )->tag( `Text`
+          )->a( n = `text` v = comp-name ).
 
     ENDLOOP.
 
-    DATA(cells) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Navigation`
-                                       )->cells( ).
+    DATA(cells) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Navigation` )->ele( `cells` ).
 
     LOOP AT mt_comp INTO comp.
-      cells->object_identifier( text = |\{{ comp-name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ comp-name }\}| ).
     ENDLOOP.
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_185.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_185.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_185 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -66,23 +66,30 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_190.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_190.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_190 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     DATA mv_table        TYPE string.
     DATA mt_table        TYPE REF TO data.
@@ -52,44 +54,49 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
 
     FIELD-SYMBOLS <tab> TYPE data.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
     ENDIF.
 
     ASSIGN mt_table->* TO <tab>.
 
-    DATA(table) = page->table( growing = `true`
-                               width   = `auto`
-                               items   = client->_bind( <tab> )
-                               ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`   v = client->_bind( <tab> )
+        )->a( n = `growing` v = `true`
+        )->a( n = `width`   v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mt_comp INTO DATA(comp).
 
-      columns->column( )->text( comp-name ).
+      columns->ele( `Column` )->tag( `Text`
+          )->a( n = `text` v = comp-name ).
 
     ENDLOOP.
 
-    DATA(cells) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Navigation`
-                                       )->cells( ).
+    DATA(cells) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Navigation` )->ele( `cells` ).
 
     LOOP AT mt_comp INTO comp.
-      cells->object_identifier( text = `{` && comp-name && `}` ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = `{` && comp-name && `}` ).
     ENDLOOP.
 
-    page->footer( )->overflow_toolbar(
-                         )->toolbar_spacer(
-                         )->button( text  = `Save`
-                                    press = client->_event( `BUTTON` )
-                                    type  = `Success` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON` )
+                             )->a( n = `text`  v = `Save`
+                             )->a( n = `type`  v = `Success` ).
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_191.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_191.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_191 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -66,23 +66,30 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_192.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_192.clas.abap
@@ -47,12 +47,16 @@ CLASS z2ui5_cl_smp_app_192 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->shell(
-        )->page( title          = `xxx`
-                 navbuttonpress = client->_event_nav_app_leave( )
-                 shownavbutton  = client->check_app_prev_stack( )
-            )->header_content( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `xxx`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( `headerContent` ).
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_194.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_194.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_194 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     DATA mv_table        TYPE string.
     DATA mt_table        TYPE REF TO data.
@@ -77,44 +79,49 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
 
     FIELD-SYMBOLS <tab> TYPE data.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
     ENDIF.
 
     ASSIGN mt_table->* TO <tab>.
 
-    DATA(table) = page->table( growing = `true`
-                               width   = `auto`
-                               items   = client->_bind( <tab> )
-                               ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`   v = client->_bind( <tab> )
+        )->a( n = `growing` v = `true`
+        )->a( n = `width`   v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mt_comp INTO DATA(comp).
 
-      columns->column( )->text( comp-name ).
+      columns->ele( `Column` )->tag( `Text`
+          )->a( n = `text` v = comp-name ).
 
     ENDLOOP.
 
-    DATA(cells) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Navigation`
-                                       )->cells( ).
+    DATA(cells) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Navigation` )->ele( `cells` ).
 
     LOOP AT mt_comp INTO comp.
-      cells->object_identifier( text = |\{{ comp-name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ comp-name }\}| ).
     ENDLOOP.
 
-    page->footer( )->overflow_toolbar(
-                         )->toolbar_spacer(
-                         )->button( text  = `Save`
-                                    press = client->_event( `BUTTON` )
-                                    type  = `Success` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                             )->a( n = `press` v = client->_event( `BUTTON` )
+                             )->a( n = `text`  v = `Save`
+                             )->a( n = `type`  v = `Success` ).
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_195.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_195.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_195 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -66,23 +66,30 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_199.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_199.clas.abap
@@ -47,40 +47,48 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     FIELD-SYMBOLS <tab> TYPE data.
     ASSIGN mt_table->* TO <tab>.
 
-    DATA(page) = view->shell( )->page(
-        id             = `page_main`
-        title          = `Refresh`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( )
-        class          = `sapUiContentPadding` ).
-    DATA(table) = page->table( growing = `true`
-                               width   = `auto`
-                               items   = client->_bind( <tab> ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `Refresh`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`   v = client->_bind( <tab> )
+        )->a( n = `growing` v = `true`
+        )->a( n = `width`   v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mt_comp INTO DATA(comp).
-      columns->column( )->text( comp-name ).
+      columns->ele( `Column` )->tag( `Text`
+          )->a( n = `text` v = comp-name ).
     ENDLOOP.
 
-    DATA(cells) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Navigation`
-                                       )->cells( ).
+    DATA(cells) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Navigation` )->ele( `cells` ).
 
     LOOP AT mt_comp INTO comp.
-      cells->object_identifier( text = |\{{ comp-name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ comp-name }\}| ).
     ENDLOOP.
 
-    page->button( text  = `Clear`
-                  press = client->_event( `CLEAR` )
-                  )->button( text  = `Add`
-                             press = client->_event( `ADD` ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `CLEAR` )
+        )->a( n = `text`  v = `Clear` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `ADD` )
+                      )->a( n = `text`  v = `Add` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_211.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_211.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_211 DEFINITION PUBLIC.
     DATA mo_app             TYPE REF TO object.
 
   PROTECTED SECTION.
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     DATA client            TYPE REF TO z2ui5_if_client.
 
@@ -66,32 +66,39 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
 
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Customizing`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Customizing`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
 
       DATA(text) = line->descr.
       DATA(with_icon) = line->icon.
 
-      lo_items->icon_tab_filter( icon      = line->icon
-                                 iconcolor = `Positive`
-                                 count     = line->count
-                                 text      = text
-                                 key       = line->id
-                                 showall   = with_icon ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `icon`      v = line->icon
+          )->a( n = `iconColor` v = `Positive`
+          )->a( n = `showAll`   v = with_icon
+          )->a( n = `count`     v = line->count
+          )->a( n = `text`      v = text
+          )->a( n = `key`       v = line->id ).
 
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabSeparator` ).
 
     ENDLOOP.
 

--- a/src/00/98/z2ui5_cl_smp_app_212.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_212.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_212 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mt_table        TYPE REF TO data.
     DATA mt_table_tmp    TYPE REF TO data.
     DATA ms_table_row    TYPE REF TO data.
@@ -118,12 +120,15 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
 
     FIELD-SYMBOLS <row> TYPE any.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    DATA(content) = popup->dialog( contentwidth = `60%`
-          )->simple_form( layout   = `ResponsiveGridLayout`
-                          editable = abap_true
-          )->content( `form` ).
+    DATA(content) = popup->ele( `Dialog`
+        )->a( n = `contentWidth` v = `60%` )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `layout`   v = `ResponsiveGridLayout`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
     " Walk through all comps — in edit mode the key fields are not editable.
     LOOP AT mt_dfies REFERENCE INTO DATA(dfies).
@@ -135,11 +140,13 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
         CONTINUE.
       ENDIF.
 
-      content->label( `text` ).
+      content->tag( `Label`
+          )->a( n = `text` v = `text` ).
 
-      content->input( value       = client->_bind( <val> )
-                    enabled       = abap_false
-                    showvaluehelp = abap_false ).
+      content->tag( `Input`
+          )->a( n = `enabled`       b = abap_false
+          )->a( n = `value`         v = client->_bind( <val> )
+          )->a( n = `showValueHelp` b = abap_false ).
 
     ENDLOOP.
 
@@ -163,24 +170,29 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
 
     FIELD-SYMBOLS <tab> TYPE data.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
     ENDIF.
 
     ASSIGN mt_table->* TO <tab>.
 
-    DATA(table) = page->table( growing = `true`
-                               width   = `auto`
-                               items   = client->_bind( val = <tab> ) ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`   v = client->_bind( val = <tab> )
+        )->a( n = `growing` v = `true`
+        )->a( n = `width`   v = `auto` ).
 
-    DATA(headder) = table->header_toolbar(
-               )->overflow_toolbar(
-                 )->toolbar_spacer( ).
+    DATA(headder) = table->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` ).
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_324.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_324.clas.abap
@@ -20,13 +20,16 @@ CLASS z2ui5_cl_smp_app_324 IMPLEMENTATION.
     me->client = client.
 
         IF client->check_on_init( ).
-          client->view_display( z2ui5_cl_xml_view=>factory(
-                                    )->shell(
-                                    )->page( shownavbutton  = client->check_app_prev_stack( )
-                                             navbuttonpress = client->_event_nav_app_leave( )
-                                    )->button( text  = `Call dynpro`
-                                               press = client->_event( `PRESS` )
-                                    )->stringify( ) ).
+          client->view_display( z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+              )->a( n = `displayBlock` v = `true`
+              )->a( n = `height`       v = `100%`
+              )->a( n = `xmlns`        v = `sap.m`
+              )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+              )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+                                        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                                        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->tag( `Button`
+                                        )->a( n = `press` v = client->_event( `PRESS` )
+                                        )->a( n = `text`  v = `Call dynpro` )->stringify( ) ).
         ENDIF.
 
         CASE client->get_event( ).

--- a/src/00/98/z2ui5_cl_smp_app_328.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_328.clas.abap
@@ -79,26 +79,30 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `GO`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `GO`
+        )->a( n = `type`  v = `Success` ).
 
     ASSIGN mt_table->* TO FIELD-SYMBOL(<table>).
-    page->table( headertext      = `Table`
-                 mode            = `MultiSelect`
-                 items           = client->_bind( <table> )
-                 selectionchange = client->_event( `SELECTION_CHANGE` )
-              )->columns(
-                  )->column( )->text( `id `
-              )->get_parent( )->get_parent(
-              )->items(
-                  )->column_list_item( selected = `{SELKZ}`
-                      )->cells(
-                          )->text( `{ID}` ).
+    page->ele( `Table`
+        )->a( n = `items`           v = client->_bind( <table> )
+        )->a( n = `headerText`      v = `Table`
+        )->a( n = `mode`            v = `MultiSelect`
+        )->a( n = `selectionChange` v = client->_event( `SELECTION_CHANGE` ) )->ele( `columns` )->ele( `Column` )->tag( `Text`
+                      )->a( n = `text` v = `id ` )->end( )->end( )->ele( `items` )->ele( `ColumnListItem`
+                      )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Text`
+                              )->a( n = `text` v = `{ID}` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_331.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_331.clas.abap
@@ -37,18 +37,26 @@ CLASS z2ui5_cl_smp_app_331 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `GO`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `GO`
+        )->a( n = `type`  v = `Success` ).
 
-    DATA(form) = page->simple_form( editable        = abap_true
-                                    layout          = `ResponsiveGridLayout`
-                                    adjustlabelspan = abap_true
-                              )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     ASSIGN mo_table_obj->mr_data->* TO FIELD-SYMBOL(<val>).
     ASSIGN COMPONENT `ID` OF STRUCTURE <val> TO FIELD-SYMBOL(<value>).
@@ -57,10 +65,12 @@ CLASS z2ui5_cl_smp_app_331 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    DATA(line) = form->label( wrapping = abap_false
-                              text     = `ID` ).
+    DATA(line) = form->tag( `Label`
+        )->a( n = `text`     v = `ID`
+        )->a( n = `wrapping` b = abap_false ).
 
-    line->input( client->_bind( <value> ) ).
+    line->tag( `Input`
+        )->a( n = `value` v = client->_bind( <value> ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_332.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_332.clas.abap
@@ -41,18 +41,26 @@ CLASS z2ui5_cl_smp_app_332 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `GO`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `GO`
+        )->a( n = `type`  v = `Success` ).
 
-    DATA(form) = page->simple_form( editable        = abap_true
-                                    layout          = `ResponsiveGridLayout`
-                                    adjustlabelspan = abap_true
-                              )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -68,14 +76,16 @@ CLASS z2ui5_cl_smp_app_332 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = layout->name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = layout->name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = client->_bind( <value> )
-                   visible = client->_bind( val       = layout->visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = client->_bind( val       = layout->visible
                                             tab       = mo_table_obj->ms_data-t_layout
                                             tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = client->_bind( <value> ) ).
     ENDLOOP.
 
     client->view_display( page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_334.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_334.clas.abap
@@ -56,18 +56,26 @@ CLASS z2ui5_cl_smp_app_334 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `GO`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `GO`
+        )->a( n = `type`  v = `Success` ).
 
-    DATA(form) = page->simple_form( editable        = abap_true
-                                    layout          = `ResponsiveGridLayout`
-                                    adjustlabelspan = abap_true
-                              )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -84,14 +92,16 @@ CLASS z2ui5_cl_smp_app_334 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = layout->name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = layout->name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = client->_bind( <value> )
-                   visible = client->_bind( val       = layout->visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = client->_bind( val       = layout->visible
                                             tab       = mo_layout_obj->ms_data-t_layout
                                             tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = client->_bind( <value> ) ).
     ENDLOOP.
 
     client->view_display( page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_335.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_335.clas.abap
@@ -85,22 +85,31 @@ CLASS z2ui5_cl_smp_app_335 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
-    page->button( text  = `Change Data`
-                  press = client->_event( `CHANGE` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `CHANGE` )
+        )->a( n = `text`  v = `Change Data`
+        )->a( n = `type`  v = `Success` ).
 
-    DATA(form) = page->simple_form( editable        = abap_true
-                                    layout          = `ResponsiveGridLayout`
-                                    adjustlabelspan = abap_true
-                              )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -116,14 +125,16 @@ CLASS z2ui5_cl_smp_app_335 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = layout->name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = layout->name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = client->_bind( <value> )
-                   visible = client->_bind( val       = layout->visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = client->_bind( val       = layout->visible
                                             tab       = mo_layout_obj->ms_data-t_layout
                                             tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = client->_bind( <value> ) ).
     ENDLOOP.
 
     client->view_display( page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_336.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_336.clas.abap
@@ -40,13 +40,20 @@ CLASS z2ui5_cl_smp_app_336 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `BACK`
-                  press = client->_event_nav_app_leave( )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event_nav_app_leave( )
+        )->a( n = `text`  v = `BACK`
+        )->a( n = `type`  v = `Success` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_337.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_337.clas.abap
@@ -17,12 +17,12 @@ CLASS z2ui5_cl_smp_app_337 DEFINITION PUBLIC.
   PROTECTED SECTION.
     METHODS xml_table
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
     METHODS xml_form
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
   PRIVATE SECTION.
@@ -79,13 +79,21 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
     xml_table( i_page   = page
                i_client = client ).
@@ -100,32 +108,35 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
 
   METHOD xml_table.
 
-    DATA(table) = i_page->table( width = `auto`
-                                 items = i_client->_bind( val = mt_data ) ).
+    DATA(table) = i_page->ele( `Table`
+        )->a( n = `items` v = i_client->_bind( val = mt_data )
+        )->a( n = `width` v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = i_client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                                   tab       = mo_layout_obj->ms_data-t_layout
-                                                  tab_index = lv_index )
-        )->text( layout->name ).
+                                                  tab_index = lv_index ) )->tag( `Text`
+            )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Inactive` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 
@@ -150,10 +161,10 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
 
   METHOD xml_form.
 
-    DATA(form) = i_page->simple_form( editable        = abap_true
-                                      layout          = `ResponsiveGridLayout`
-                                      adjustlabelspan = abap_true
-                                 )->content( `form` ).
+    DATA(form) = i_page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -168,14 +179,16 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = layout->name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = layout->name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = i_client->_bind( <value> )
-                   visible = i_client->_bind( val       = layout->visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                               tab       = mo_layout_obj->ms_data-t_layout
                                               tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = i_client->_bind( <value> ) ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_338.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_338.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_338 DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
-    DATA mo_main_page      TYPE REF TO z2ui5_cl_xml_view.
+    DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
     METHODS on_event.
@@ -65,23 +65,30 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
-    DATA(page) = view->page( id             = `page_main`
-                             title          = `Main App calling Subapps`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( )
-                             class          = `sapUiContentPadding` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `Main App calling Subapps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    DATA(lo_items) = page->icon_tab_bar( class       = `sapUiResponsiveContentPadding`
-                                         selectedkey = client->_bind( mv_selectedkey )
-                                         select      = client->_event( `ONSELECTICONTABBAR` )
-                                                       )->items( ).
+    DATA(lo_items) = page->ele( `IconTabBar`
+        )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
+        )->a( n = `selectedKey` v = client->_bind( mv_selectedkey ) )->ele( `items` ).
 
     LOOP AT mt_t002 REFERENCE INTO DATA(line).
-      lo_items->icon_tab_filter( text  = line->class
-                                 count = line->count
-                                 key   = line->id ).
-      lo_items->icon_tab_separator( ).
+      lo_items->ele( `IconTabFilter`
+          )->a( n = `count` v = line->count
+          )->a( n = `text`  v = line->class
+          )->a( n = `key`   v = line->id ).
+      lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
     mo_main_page = lo_items.

--- a/src/00/98/z2ui5_cl_smp_app_339.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_339.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_339 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_table        TYPE string.
 
     DATA mt_table_tmp    TYPE REF TO data.
@@ -98,11 +100,16 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
   METHOD view_display.
 
-    IF mo_parent_view IS INITIAL.
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+    IF mo_parent_page IS INITIAL.
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
 
     ENDIF.
 
@@ -110,39 +117,42 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
                                                 vis_cols = 5 ).
     ASSIGN mt_table->* TO FIELD-SYMBOL(<table>).
 
-    DATA(table) = page->table( width           = `auto`
-                               mode            = `SingleSelectLeft`
-                               selectionchange = client->_event( `SELECTION_CHANGE` )
-                               items           = client->_bind( val = <table> ) ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`           v = client->_bind( val = <table> )
+        )->a( n = `mode`            v = `SingleSelectLeft`
+        )->a( n = `width`           v = `auto`
+        )->a( n = `selectionChange` v = client->_event( `SELECTION_CHANGE` ) ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mo_layout->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = client->_bind( val       = layout->visible
                                                 tab       = mo_layout->ms_data-t_layout
-                                                tab_index = lv_index )
-       )->text( layout->name ).
+                                                tab_index = lv_index ) )->tag( `Text`
+           )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign   = `Middle`
-                                                            type     = `Inactive`
-                                                            selected = `{SELKZ}` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign`   v = `Middle`
+                                           )->a( n = `selected` v = `{SELKZ}`
+                                           )->a( n = `type`     v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT mo_layout->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
       client->view_display( page->stringify( ) ).
 
     ELSE.

--- a/src/00/98/z2ui5_cl_smp_app_340.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_340.clas.abap
@@ -39,15 +39,20 @@ CLASS z2ui5_cl_smp_app_340 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    DATA(simple_form) = popup->dialog( title        = `Test`
-                                       contentwidth = `60%`
-                                       afterclose   = client->_event( `POPUP_CLOSE` )
-          )->simple_form( title    = ``
-                          layout   = `ResponsiveGridLayout`
-                          editable = abap_true
-          )->content( `form` )->label( `Test` )->input( `TEST` ).
+    DATA(simple_form) = popup->ele( `Dialog`
+        )->a( n = `title`        v = `Test`
+        )->a( n = `contentWidth` v = `60%`
+        )->a( n = `afterClose`   v = client->_event( `POPUP_CLOSE` ) )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `title`    v = ``
+              )->a( n = `layout`   v = `ResponsiveGridLayout`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `Test` )->tag( `Input`
+              )->a( n = `value` v = `TEST` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -4,7 +4,9 @@ CLASS z2ui5_cl_smp_app_342 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     DATA mv_view_display TYPE abap_bool.
-    DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
+    "! the Page this app renders into when it is embedded in another app's
+    "! view; left empty the app builds a view of its own and displays it
+    DATA mo_parent_page  TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_init         TYPE abap_bool.
     DATA mv_table        TYPE string.
 
@@ -100,13 +102,18 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
   METHOD render_main.
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
 
-      DATA(page) = z2ui5_cl_xml_view=>factory( ).
+      DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     ELSE.
 
-      page = mo_parent_view->get( `Page` ).
+      page = mo_parent_page.
 
     ENDIF.
 
@@ -115,41 +122,44 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
     ASSIGN mt_data->* TO FIELD-SYMBOL(<table>).
 
-    DATA(table) = page->table( width = `auto`
-                               mode  = `SingleSelectLeft`
-                               selectionchange  = client->_event( `SELECTION_CHANGE` )
-                               items = client->_bind( val = <table> ) ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`           v = client->_bind( val = <table> )
+        )->a( n = `mode`            v = `SingleSelectLeft`
+        )->a( n = `width`           v = `auto`
+        )->a( n = `selectionChange` v = client->_event( `SELECTION_CHANGE` ) ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mo_lay->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = client->_bind( val       = layout->visible
                                                 tab       = mo_lay->ms_data-t_layout
-                                                tab_index = lv_index )
-       )->text( layout->name ).
+                                                tab_index = lv_index ) )->tag( `Text`
+           )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign   = `Middle`
-                                                            type     = `Inactive`
-                                                            selected = `{SELKZ}` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign`   v = `Middle`
+                                           )->a( n = `selected` v = `{SELKZ}`
+                                           )->a( n = `type`     v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT mo_lay->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 
-    IF mo_parent_view IS INITIAL.
+    IF mo_parent_page IS INITIAL.
 
-      client->view_display( page->get_root( )->xml_get( ) ).
+      client->view_display( page->stringify( ) ).
 
     ELSE.
 

--- a/src/00/98/z2ui5_cl_smp_app_343.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_343.clas.abap
@@ -80,14 +80,21 @@ CLASS z2ui5_cl_smp_app_343 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     TRY.
 
-        DATA(table) = page->table( width   = `auto`
-                                     items = client->_bind( mt_data1 ) ).
+        DATA(table) = page->ele( `Table`
+            )->a( n = `items` v = client->_bind( mt_data1 )
+            )->a( n = `width` v = `auto` ).
 
         client->message_box_display( `error - reference processed in binding without error` ).
       CATCH cx_root.

--- a/src/00/98/z2ui5_cl_smp_app_344.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_344.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_344 DEFINITION PUBLIC.
   PROTECTED SECTION.
     METHODS xml_table
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client
         i_data   TYPE REF TO data
         i_layout TYPE REF TO z2ui5_cl_smp_app_333.
@@ -88,13 +88,20 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
     xml_table( i_page   = page
                i_client = client
@@ -114,32 +121,35 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
   METHOD xml_table.
 
     ASSIGN i_data->* TO FIELD-SYMBOL(<table>).
-    DATA(table) = i_page->table( width = `auto`
-                                 items = i_client->_bind( val = <table> ) ).
+    DATA(table) = i_page->ele( `Table`
+        )->a( n = `items` v = i_client->_bind( val = <table> )
+        )->a( n = `width` v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT i_layout->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = i_client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                                   tab       = i_layout->ms_data-t_layout
-                                                  tab_index = lv_index )
-        )->text( layout->name ).
+                                                  tab_index = lv_index ) )->tag( `Text`
+            )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Inactive` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT i_layout->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 

--- a/src/00/98/z2ui5_cl_smp_app_345.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_345.clas.abap
@@ -16,7 +16,7 @@ CLASS z2ui5_cl_smp_app_345 DEFINITION PUBLIC.
   PROTECTED SECTION.
     METHODS xml_table
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client
         i_data   TYPE REF TO data
         i_layout TYPE REF TO z2ui5_cl_smp_app_333.
@@ -92,13 +92,20 @@ CLASS z2ui5_cl_smp_app_345 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
     xml_table( i_page = page
       i_client        = client
@@ -114,31 +121,33 @@ CLASS z2ui5_cl_smp_app_345 IMPLEMENTATION.
 
     ASSIGN i_data->* TO FIELD-SYMBOL(<data>).
 
-    DATA(table) = i_page->table( width = `auto`
-                                 items = i_client->_bind( <data> ) ).
+    DATA(table) = i_page->ele( `Table`
+        )->a( n = `items` v = i_client->_bind( <data> )
+        )->a( n = `width` v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT i_layout->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = i_client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                                   tab       = i_layout->ms_data-t_layout
-                                                  tab_index = lv_index )
-        )->text( layout->name ).
+                                                  tab_index = lv_index ) )->tag( `Text`
+            )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT i_layout->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 

--- a/src/00/98/z2ui5_cl_smp_app_347.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_347.clas.abap
@@ -15,7 +15,7 @@ CLASS z2ui5_cl_smp_app_347 DEFINITION PUBLIC.
   PROTECTED SECTION.
     METHODS xml_table
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
   PRIVATE SECTION.
@@ -66,13 +66,20 @@ CLASS z2ui5_cl_smp_app_347 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
     xml_table( i_page   = page
                i_client = client ).
@@ -84,32 +91,35 @@ CLASS z2ui5_cl_smp_app_347 IMPLEMENTATION.
 
   METHOD xml_table.
 
-    DATA(table) = i_page->table( width = `auto`
-                                 items = i_client->_bind( val = mt_data ) ).
+    DATA(table) = i_page->ele( `Table`
+        )->a( n = `items` v = i_client->_bind( val = mt_data )
+        )->a( n = `width` v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = i_client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                                   tab       = mo_layout_obj->ms_data-t_layout
-                                                  tab_index = lv_index )
-        )->text( layout->name ).
+                                                  tab_index = lv_index ) )->tag( `Text`
+            )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Inactive` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 

--- a/src/00/98/z2ui5_cl_smp_app_348.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_348.clas.abap
@@ -17,7 +17,7 @@ CLASS z2ui5_cl_smp_app_348 DEFINITION PUBLIC.
     METHODS xml_form
       IMPORTING
         i_data   TYPE REF TO data
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
   PRIVATE SECTION.
@@ -75,17 +75,26 @@ CLASS z2ui5_cl_smp_app_348 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
-    page->button( text  = `Read from DB`
-                  press = client->_event( `GET_DATA` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GET_DATA` )
+        )->a( n = `text`  v = `Read from DB`
+        )->a( n = `type`  v = `Success` ).
 
     xml_form( i_data   = REF #( ms_struc )
               i_page   = page
@@ -133,10 +142,10 @@ CLASS z2ui5_cl_smp_app_348 IMPLEMENTATION.
     FIELD-SYMBOLS <data>   TYPE any.
     FIELD-SYMBOLS <value>  TYPE any.
 
-    DATA(form) = i_page->simple_form( editable        = abap_true
-                                      layout          = `ResponsiveGridLayout`
-                                      adjustlabelspan = abap_true
-                                 )->content( `form` ).
+    DATA(form) = i_page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -152,14 +161,16 @@ CLASS z2ui5_cl_smp_app_348 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = <layout>-name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = <layout>-name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = i_client->_bind( <value> )
-                   visible = i_client->_bind( val       = <layout>-visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = i_client->_bind( val       = <layout>-visible
                                               tab       = mo_layout_obj->ms_data-t_layout
                                               tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = i_client->_bind( <value> ) ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_349.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_349.clas.abap
@@ -17,12 +17,12 @@ CLASS z2ui5_cl_smp_app_349 DEFINITION PUBLIC.
   PROTECTED SECTION.
     METHODS xml_table
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
     METHODS xml_form
       IMPORTING
-        i_page   TYPE REF TO z2ui5_cl_xml_view
+        i_page   TYPE REF TO z2ui5_cl_ui5_view_builder
         i_client TYPE REF TO z2ui5_if_client.
 
   PRIVATE SECTION.
@@ -87,13 +87,21 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page( title          = `RTTI IV`
-                                                                navbuttonpress = client->_event_nav_app_leave( )
-                                                                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `RTTI IV`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->button( text  = `CALL Next App`
-                  press = client->_event( `GO` )
-                  type  = `Success` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `GO` )
+        )->a( n = `text`  v = `CALL Next App`
+        )->a( n = `type`  v = `Success` ).
 
     xml_table( i_page   = page
                i_client = client ).
@@ -108,32 +116,35 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
 
   METHOD xml_table.
 
-    DATA(table) = i_page->table( width = `auto`
-                                 items = i_client->_bind( val = mt_data ) ).
+    DATA(table) = i_page->ele( `Table`
+        )->a( n = `items` v = i_client->_bind( val = mt_data )
+        )->a( n = `width` v = `auto` ).
 
-    DATA(columns) = table->columns( ).
+    DATA(columns) = table->ele( `columns` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO DATA(layout).
       DATA(lv_index) = sy-tabix.
 
-      columns->column( visible = i_client->_bind( val       = layout->visible
+      columns->ele( `Column`
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                                   tab       = mo_layout_obj->ms_data-t_layout
-                                                  tab_index = lv_index )
-        )->text( layout->name ).
+                                                  tab_index = lv_index ) )->tag( `Text`
+            )->a( n = `text` v = layout->name ).
 
     ENDLOOP.
 
-    DATA(column_list_item) = columns->get_parent( )->items(
-                                       )->column_list_item( valign = `Middle`
-                                                            type   = `Inactive` ).
+    DATA(column_list_item) = columns->end( )->ele( `items` )->ele( `ColumnListItem`
+                                           )->a( n = `vAlign` v = `Middle`
+                                           )->a( n = `type`   v = `Inactive` ).
 
-    DATA(cells) = column_list_item->cells( ).
+    DATA(cells) = column_list_item->ele( `cells` ).
 
     LOOP AT mo_layout_obj->ms_data-t_layout REFERENCE INTO layout.
 
       lv_index = sy-tabix.
 
-      cells->object_identifier( text = |\{{ layout->name }\}| ).
+      cells->ele( `ObjectIdentifier`
+          )->a( n = `text` v = |\{{ layout->name }\}| ).
 
     ENDLOOP.
 
@@ -158,10 +169,10 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
 
   METHOD xml_form.
 
-    DATA(form) = i_page->simple_form( editable        = abap_true
-                                      layout          = `ResponsiveGridLayout`
-                                      adjustlabelspan = abap_true
-                                 )->content( `form` ).
+    DATA(form) = i_page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`          v = `ResponsiveGridLayout`
+        )->a( n = `adjustLabelSpan` b = abap_true
+        )->a( n = `editable`        b = abap_true )->ele( n = `content` ns = `form` ).
 
     DATA(index) = 0.
 
@@ -176,14 +187,16 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      DATA(line) = form->label( wrapping = abap_false
-                                text     = layout->name ).
+      DATA(line) = form->tag( `Label`
+          )->a( n = `text`     v = layout->name
+          )->a( n = `wrapping` b = abap_false ).
 
-      line->input( value   = i_client->_bind( <value> )
-                   visible = i_client->_bind( val       = layout->visible
+      line->tag( `Input`
+          )->a( n = `enabled` b = abap_false
+          )->a( n = `visible` v = i_client->_bind( val       = layout->visible
                                               tab       = mo_layout_obj->ms_data-t_layout
                                               tab_index = index )
-                   enabled = abap_false ).
+          )->a( n = `value`   v = i_client->_bind( <value> ) ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_353.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_353.clas.abap
@@ -51,33 +51,38 @@ CLASS z2ui5_cl_smp_app_353 IMPLEMENTATION.
 
   METHOD render.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-          )->page(
-              title          = `abap2UI5 - Multiple Timers`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Multiple Timers`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    DATA(form) = page->simple_form(
-                      editable = abap_true
-                 )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `device_browser`
-        )->input( client->_bind( device_browser )
-        )->label( `device_os`
-        )->input( client->_bind( device_os )
-        )->label( `device_systemtype`
-        )->input( client->_bind( device_systemtype )
-        )->label( `device_height`
-        )->input( client->_bind( device_height )
-        )->label( `device_width`
-        )->input( client->_bind( device_width )
-        )->label( `ui5_version`
-        )->input( client->_bind( ui5_version )
-        )->label( `ui5_theme`
-        )->input( client->_bind( ui5_theme )
-        )->label( `Cursor here ->` )->input(
-            id    = `IdOne`
-            value = client->_bind( one ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `device_browser` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( device_browser ) )->tag( `Label`
+            )->a( n = `text` v = `device_os` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( device_os ) )->tag( `Label`
+            )->a( n = `text` v = `device_systemtype` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( device_systemtype ) )->tag( `Label`
+            )->a( n = `text` v = `device_height` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( device_height ) )->tag( `Label`
+            )->a( n = `text` v = `device_width` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( device_width ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_version` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( ui5_version ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_theme` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( ui5_theme ) )->tag( `Label`
+            )->a( n = `text` v = `Cursor here ->` )->tag( `Input`
+            )->a( n = `id`    v = `IdOne`
+            )->a( n = `value` v = client->_bind( one ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_443.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_443.clas.abap
@@ -21,27 +21,30 @@ CLASS z2ui5_cl_smp_app_443 IMPLEMENTATION.
       value   = `86801398`.
       info    = `Step 1: Lock the field. Step 2: Re-enable + SET_CURSOR in the same roundtrip.`.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->shell(
-        )->page( `abap2UI5 - SET_CURSOR after enabled binding`
-          )->simple_form( editable = abap_true
-            )->content( `form`
-              )->title( ns   = `core`
-                        text = client->_bind( info )
-              )->label( `Document Number`
-              )->input( id      = `inpDocNum`
-                        value   = client->_bind( value )
-                        enabled = client->_bind( enabled )
-              )->label( ``
-              )->button( text  = `1 - Lock field (enabled = false)`
-                         press = client->_event( `LOCK` )
-              )->label( ``
-              )->button( text  = `2 - Re-enable field + SET_CURSOR (one roundtrip)`
-                         type  = `Emphasized`
-                         press = client->_event( `UNLOCK_AND_SET_CURSOR` )
-              )->label( ``
-              )->button( text  = `Reference: SET_CURSOR only (no enabled change)`
-                         press = client->_event( `SET_CURSOR_ONLY` ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+            )->a( n = `title` v = `abap2UI5 - SET_CURSOR after enabled binding` )->ele( n = `SimpleForm` ns = `form`
+              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( n = `Title` ns = `core`
+                  )->a( n = `text` v = client->_bind( info ) )->tag( `Label`
+                  )->a( n = `text` v = `Document Number` )->tag( `Input`
+                  )->a( n = `id`      v = `inpDocNum`
+                  )->a( n = `enabled` v = client->_bind( enabled )
+                  )->a( n = `value`   v = client->_bind( value ) )->tag( `Label`
+                  )->a( n = `text` v = `` )->tag( `Button`
+                  )->a( n = `press` v = client->_event( `LOCK` )
+                  )->a( n = `text`  v = `1 - Lock field (enabled = false)` )->tag( `Label`
+                  )->a( n = `text` v = `` )->tag( `Button`
+                  )->a( n = `press` v = client->_event( `UNLOCK_AND_SET_CURSOR` )
+                  )->a( n = `text`  v = `2 - Re-enable field + SET_CURSOR (one roundtrip)`
+                  )->a( n = `type`  v = `Emphasized` )->tag( `Label`
+                  )->a( n = `text` v = `` )->tag( `Button`
+                  )->a( n = `press` v = client->_event( `SET_CURSOR_ONLY` )
+                  )->a( n = `text`  v = `Reference: SET_CURSOR only (no enabled change)` ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `LOCK` ).

--- a/src/00/98/z2ui5_cl_smp_app_446.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_446.clas.abap
@@ -64,41 +64,47 @@ CLASS z2ui5_cl_smp_app_446 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Action - CONTROL_GLOBAL`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Action - CONTROL_GLOBAL`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Each button lets the backend call a whitelisted method on a global frontend object ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Each button lets the backend call a whitelisted method on a global frontend object ` &&
                    `(MessageToast, MessageBox, Theming) via follow_up_action( cs_event-control_global ) - ` &&
                    `client-side, after the response renders, without wiring a control event.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        " message-information, not information: the plain `information` glyph
-        " reached the SAP icon font after 1.71, so on the oldest release the
-        " samples must run on the button renders with no icon at all
-        )->button( text  = `MessageToast.show`
-                   icon  = `sap-icon://message-information`
-                   press = client->_event( `TOAST` )
-        )->button( text  = `MessageBox.show`
-                   icon  = `sap-icon://message-popup`
-                   press = client->_event( `MSGBOX` )
-                   class = `sapUiTinyMarginTop`
-        )->button( text  = `Theming.setTheme( dark )`
-                   icon  = `sap-icon://palette`
-                   press = client->_event( `THEME_DARK` )
-                   class = `sapUiTinyMarginTop`
-        )->button( text  = `Theming.setTheme( light )`
-                   icon  = `sap-icon://palette`
-                   press = client->_event( `THEME_LIGHT` )
-                   class = `sapUiTinyMarginTop` ).
+    " message-information, not information: the plain `information` glyph
+    " reached the SAP icon font after 1.71, so on the oldest release the
+    " samples must run on the button renders with no icon at all
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin`
+        )->tag( `Button`
+            )->a( n = `press` v = client->_event( `TOAST` )
+            )->a( n = `text`  v = `MessageToast.show`
+            )->a( n = `icon`  v = `sap-icon://message-information` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `MSGBOX` )
+            )->a( n = `text`  v = `MessageBox.show`
+            )->a( n = `icon`  v = `sap-icon://message-popup`
+            )->a( n = `class` v = `sapUiTinyMarginTop` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `THEME_DARK` )
+            )->a( n = `text`  v = `Theming.setTheme( dark )`
+            )->a( n = `icon`  v = `sap-icon://palette`
+            )->a( n = `class` v = `sapUiTinyMarginTop` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `THEME_LIGHT` )
+            )->a( n = `text`  v = `Theming.setTheme( light )`
+            )->a( n = `icon`  v = `sap-icon://palette`
+            )->a( n = `class` v = `sapUiTinyMarginTop` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/00/98/z2ui5_cl_smp_app_447.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_447.clas.abap
@@ -70,46 +70,50 @@ CLASS z2ui5_cl_smp_app_447 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Action - CONTROL_BY_ID`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Action - CONTROL_BY_ID`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The backend calls a whitelisted method on a control resolved by id via ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The backend calls a whitelisted method on a control resolved by id via ` &&
                    `follow_up_action( cs_event-control_by_id ), after the response renders: ` &&
                    `focus() on the input, scrollToIndex() on the table.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->input( id          = `nameInput`
-                  placeholder = `this input can be focused from the backend`
-        )->button( text  = `focus( ) the input`
-                   icon  = `sap-icon://edit`
-                   press = client->_event( `FOCUS` )
-                   class = `sapUiTinyMarginTop`
-        )->button( text  = `scrollToIndex( 150 ) on the table`
-                   icon  = `sap-icon://down`
-                   press = client->_event( `SCROLL` )
-                   class = `sapUiTinyMarginTop` ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Input`
+            )->a( n = `id`          v = `nameInput`
+            )->a( n = `placeholder` v = `this input can be focused from the backend` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `FOCUS` )
+            )->a( n = `text`  v = `focus( ) the input`
+            )->a( n = `icon`  v = `sap-icon://edit`
+            )->a( n = `class` v = `sapUiTinyMarginTop` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `SCROLL` )
+            )->a( n = `text`  v = `scrollToIndex( 150 ) on the table`
+            )->a( n = `icon`  v = `sap-icon://down`
+            )->a( n = `class` v = `sapUiTinyMarginTop` ).
 
-    DATA(tab) = page->table( id    = `bigTable`
-                             items = client->_bind( t_rows ) ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_rows )
+        )->a( n = `id`    v = `bigTable` ).
 
-    tab->columns(
-        )->column( )->text( `Index` )->get_parent(
-        )->column( )->text( `Text` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Index` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Text` )->end( ).
 
-    tab->items(
-        )->column_list_item(
-            )->cells(
-                )->text( `{INDEX}`
-                )->text( `{TEXT}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{INDEX}` )->tag( `Text`
+                    )->a( n = `text` v = `{TEXT}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_004.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_004.clas.abap
@@ -64,42 +64,42 @@ CLASS z2ui5_cl_smp_app_004 IMPLEMENTATION.
 
     view_main = `MAIN`.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Basics IV - Events, Views and Roundtrips`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics IV - Events, Views and Roundtrips`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Controller basics: the buttons trigger a server roundtrip, restart the app, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Controller basics: the buttons trigger a server roundtrip, restart the app, ` &&
                    `switch to a second view, or raise an uncaught error.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form(
-            title    = `Controller`
-            editable = abap_true
-            )->content( `form`
-            )->label( `Roundtrip`
-            )->button(
-                text  = `Client/Server Interaction`
-                press = client->_event( `BUTTON_ROUNDTRIP` )
-            )->label( `System`
-            )->button(
-                text  = `Restart App`
-                press = client->_event( `BUTTON_RESTART` )
-            )->label( `Change View`
-            )->button(
-                text  = `Display View SECOND`
-                press = client->_event( `BUTTON_CHANGE_VIEW` )
-            )->label( `CX_SY_ZERO_DIVIDE`
-            )->button(
-                text  = `Error not catched by the user`
-                press = client->_event( `BUTTON_ERROR` ) ).
+    page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title`    v = `Controller`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Roundtrip` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_ROUNDTRIP` )
+                )->a( n = `text`  v = `Client/Server Interaction` )->tag( `Label`
+                )->a( n = `text` v = `System` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_RESTART` )
+                )->a( n = `text`  v = `Restart App` )->tag( `Label`
+                )->a( n = `text` v = `Change View` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_CHANGE_VIEW` )
+                )->a( n = `text`  v = `Display View SECOND` )->tag( `Label`
+                )->a( n = `text` v = `CX_SY_ZERO_DIVIDE` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_ERROR` )
+                )->a( n = `text`  v = `Error not catched by the user` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -110,21 +110,25 @@ CLASS z2ui5_cl_smp_app_004 IMPLEMENTATION.
 
     view_main = `SECOND`.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Basics IV - Events, Views and Roundtrips`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics IV - Events, Views and Roundtrips`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->grid( `L12 M12 S12`
-        )->content( `layout`
-        )->simple_form( `View Second`
-            )->content( `form`
-            )->label( `Change View`
-            )->button(
-                text  = `Display View MAIN`
-                press = client->_event( `BUTTON_CHANGE_VIEW` ) ).
+    page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L12 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title` v = `View Second` )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Change View` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_CHANGE_VIEW` )
+                )->a( n = `text`  v = `Display View MAIN` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_006.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_006.clas.abap
@@ -86,80 +86,65 @@ CLASS z2ui5_cl_smp_app_006 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Table - Large Table with Growing and ScrollContainer`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Table - Large Table with Growing and ScrollContainer`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A large table (10,000 rows) is rendered inside a ScrollContainer using growing / ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A large table (10,000 rows) is rendered inside a ScrollContainer using growing / ` &&
                    `scroll-to-load, with a sticky header toolbar offering sort buttons and a segmented button.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->scroll_container(
-        height   = `70%`
-        vertical = abap_true
-        )->table(
-            growing             = abap_true
-            growingthreshold    = `20`
-            growingscrolltoload = abap_true
-            items               = client->_bind( t_tab )
-            sticky              = `ColumnHeaders,HeaderToolbar` ).
+    DATA(tab) = page->ele( `ScrollContainer`
+        )->a( n = `height`   v = `70%`
+        )->a( n = `vertical` b = abap_true )->ele( `Table`
+            )->a( n = `items`               v = client->_bind( t_tab )
+            )->a( n = `growing`             b = abap_true
+            )->a( n = `growingThreshold`    v = `20`
+            )->a( n = `growingScrollToLoad` b = abap_true
+            )->a( n = `sticky`              v = `ColumnHeaders,HeaderToolbar` ).
 
-    tab->header_toolbar(
-        )->toolbar(
-            )->title( `title of the table`
-            )->button(
-                text  = `left side button`
-                icon  = `sap-icon://account`
-                press = client->_event( `BUTTON_SORT` )
-            )->segmented_button( key
-                )->items(
-                    )->segmented_button_item(
-                        key  = `BLUE`
-                        icon = `sap-icon://accept`
-                        text = `blue`
-                    )->segmented_button_item(
-                        key  = `GREEN`
-                        icon = `sap-icon://add-favorite`
-                        text = `green`
-            )->get_parent( )->get_parent(
-            )->toolbar_spacer(
-            )->button(
-                icon  = `sap-icon://sort-descending`
-                press = client->_event( `SORT_DESCENDING` )
-            )->button(
-                icon  = `sap-icon://sort-ascending`
-                press = client->_event( `SORT_ASCENDING` ) ).
+    tab->ele( `headerToolbar` )->ele( `Toolbar` )->tag( `Title`
+                )->a( n = `text` v = `title of the table` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_SORT` )
+                )->a( n = `text`  v = `left side button`
+                )->a( n = `icon`  v = `sap-icon://account` )->ele( `SegmentedButton`
+                )->a( n = `selectedKey` v = key )->ele( `items` )->tag( `SegmentedButtonItem`
+                        )->a( n = `icon` v = `sap-icon://accept`
+                        )->a( n = `key`  v = `BLUE`
+                        )->a( n = `text` v = `blue` )->tag( `SegmentedButtonItem`
+                        )->a( n = `icon` v = `sap-icon://add-favorite`
+                        )->a( n = `key`  v = `GREEN`
+                        )->a( n = `text` v = `green` )->end( )->end( )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `SORT_DESCENDING` )
+                )->a( n = `icon`  v = `sap-icon://sort-descending` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `SORT_ASCENDING` )
+                )->a( n = `icon`  v = `sap-icon://sort-ascending` ).
 
-    tab->columns(
-        )->column(
-            )->text( `Color` )->get_parent(
-        )->column(
-            )->text( `Info` )->get_parent(
-        )->column(
-            )->text( `Description` )->get_parent(
-        )->column(
-            )->text( `Checkbox` )->get_parent(
-        )->column(
-            )->text( `Counter` )->get_parent(
-        )->column(
-            )->text( `Radial Micro Chart` ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Info` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Checkbox` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Counter` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Radial Micro Chart` ).
 
-    tab->items(
-        )->column_list_item(
-            )->cells(
-                )->text( `{VALUE}`
-                )->text( `{INFO}`
-                )->text( `{DESCR}`
-                )->checkbox(
-                    selected = `{CHECKBOX}`
-                    enabled  = abap_false
-                )->text( `{COUNT}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+                    )->a( n = `text` v = `{INFO}` )->tag( `Text`
+                    )->a( n = `text` v = `{DESCR}` )->tag( `CheckBox`
+                    )->a( n = `selected` v = `{CHECKBOX}`
+                    )->a( n = `enabled`  b = abap_false )->tag( `Text`
+                    )->a( n = `text` v = `{COUNT}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_008.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_008.clas.abap
@@ -59,38 +59,37 @@ CLASS z2ui5_cl_smp_app_008 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Message - MessageBox from SY, BAPIRET2 or Exception`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( )
-            )->header_content(
-                )->link(
-            )->get_parent( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Message - MessageBox from SY, BAPIRET2 or Exception`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( `headerContent` )->tag( `Link` )->end( ).
 
-    page->message_strip(
-        text     = `The three buttons feed a MessageBox with the message objects ABAP ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The three buttons feed a MessageBox with the message objects ABAP ` &&
                    `produces: a SY message read from T100, a BAPIRET2 structure and a ` &&
                    `caught CX_ROOT exception. message_box_display( ) accepts each of them ` &&
                    `directly, no conversion in the app.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->grid( `L6 M12 S12`
-        )->content( `layout`
-            )->simple_form( `Message Box from ABAP Object`
-                )->content( `form`
-                )->button(
-                    text  = `SY Message`
-                    press = client->_event( `BUTTON_MESSAGE_BOX_SY` )
-                )->button(
-                    text  = `BAPIRET2`
-                    press = client->_event( `BUTTON_MESSAGE_BOX_BAPIRET` )
-                )->button(
-                    text  = `CX_ROOT`
-                    press = client->_event( `BUTTON_MESSAGE_BOX_CX_ROOT` ) ).
+    page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+                )->a( n = `title` v = `Message Box from ABAP Object` )->ele( n = `content` ns = `form` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_MESSAGE_BOX_SY` )
+                    )->a( n = `text`  v = `SY Message` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_MESSAGE_BOX_BAPIRET` )
+                    )->a( n = `text`  v = `BAPIRET2` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_MESSAGE_BOX_CX_ROOT` )
+                    )->a( n = `text`  v = `CX_ROOT` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_009.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_009.clas.abap
@@ -162,77 +162,73 @@ CLASS z2ui5_cl_smp_app_009 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popup - Value Help: Suggestions and F4 Dialog`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popup - Value Help: Suggestions and F4 Dialog`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Four value-help patterns: inline suggestions, numeric-only input, a value-help popup with a selectable table, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Four value-help patterns: inline suggestions, numeric-only input, a value-help popup with a selectable table, ` &&
                    `and a custom popup with a city search. Fill the fields, then Clear resets the view and Send simulates a submit.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->grid( `L7 M7 S7`
-        )->content( `layout`
-            )->simple_form(
-                    title    = `Input with Value Help`
-                    editable = abap_true
-                )->content( `form` ).
+    DATA(form) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L7 M7 S7` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+                )->a( n = `title`    v = `Input with Value Help`
+                )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Input with suggestion items`
-        )->input(
-            value           = client->_bind( s_screen-color_01 )
-            placeholder     = `fill in your favorite colour`
-            suggestionitems = client->_bind( t_suggestion )
-            showsuggestion  = abap_true
-        )->get(
-        )->suggestion_items( )->get(
-            )->list_item(
-                text           = `{VALUE}`
-                additionaltext = `{DESCR}` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Input with suggestion items` )->ele( `Input`
+            )->a( n = `placeholder`     v = `fill in your favorite colour`
+            )->a( n = `value`           v = client->_bind( s_screen-color_01 )
+            )->a( n = `suggestionItems` v = client->_bind( t_suggestion )
+            )->a( n = `showSuggestion`  b = abap_true )->ele( `suggestionItems` )->tag( n = `ListItem` ns = `core`
+                )->a( n = `text`           v = `{VALUE}`
+                )->a( n = `additionalText` v = `{DESCR}` ).
 
-    form->label( `Input only numbers allowed`
-        )->input(
-            value       = client->_bind( s_screen-quantity )
-            type        = `Number`
-            placeholder = `quantity` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Input only numbers allowed` )->tag( `Input`
+            )->a( n = `placeholder` v = `quantity`
+            )->a( n = `type`        v = `Number`
+            )->a( n = `value`       v = client->_bind( s_screen-quantity ) ).
 
-    form->label( `Input with value`
-        )->input(
-            value            = client->_bind( s_screen-color_02 )
-            placeholder      = `fill in your favorite colour`
-            showvaluehelp    = abap_true
-            valuehelprequest = client->_event( `POPUP_TABLE_VALUE` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Input with value` )->tag( `Input`
+            )->a( n = `placeholder`      v = `fill in your favorite colour`
+            )->a( n = `value`            v = client->_bind( s_screen-color_02 )
+            )->a( n = `valueHelpRequest` v = client->_event( `POPUP_TABLE_VALUE` )
+            )->a( n = `showValueHelp`    b = abap_true ).
 
-    form->label( `Custom value Popup`
-        )->input(
-            value            = client->_bind( s_screen-name )
-            placeholder      = `name`
-            showvaluehelp    = abap_true
-            valuehelprequest = client->_event( `POPUP_TABLE_VALUE_CUSTOM` )
-        )->input(
-            value            = client->_bind( s_screen-lastname )
-            placeholder      = `lastname`
-            showvaluehelp    = abap_true
-            valuehelprequest = client->_event( `POPUP_TABLE_VALUE_CUSTOM` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Custom value Popup` )->tag( `Input`
+            )->a( n = `placeholder`      v = `name`
+            )->a( n = `value`            v = client->_bind( s_screen-name )
+            )->a( n = `valueHelpRequest` v = client->_event( `POPUP_TABLE_VALUE_CUSTOM` )
+            )->a( n = `showValueHelp`    b = abap_true )->tag( `Input`
+            )->a( n = `placeholder`      v = `lastname`
+            )->a( n = `value`            v = client->_bind( s_screen-lastname )
+            )->a( n = `valueHelpRequest` v = client->_event( `POPUP_TABLE_VALUE_CUSTOM` )
+            )->a( n = `showValueHelp`    b = abap_true ).
 
-    page->footer(
-        )->overflow_toolbar(
-            )->toolbar_spacer(
-            )->button(
-                text  = `Clear`
-                press = client->_event( `BUTTON_CLEAR` )
-                type  = `Reject`
-                icon  = `sap-icon://delete`
-            )->button(
-                text  = `Send to Server`
-                press = client->_event( `BUTTON_SEND` )
-                type  = `Accept`
-                icon  = `sap-icon://paper-plane` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_CLEAR` )
+                )->a( n = `text`  v = `Clear`
+                )->a( n = `icon`  v = `sap-icon://delete`
+                )->a( n = `type`  v = `Reject` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_SEND` )
+                )->a( n = `text`  v = `Send to Server`
+                )->a( n = `icon`  v = `sap-icon://paper-plane`
+                )->a( n = `type`  v = `Accept` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -241,28 +237,31 @@ CLASS z2ui5_cl_smp_app_009 IMPLEMENTATION.
 
   METHOD popup_value_suggestion.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( `abap2UI5 - Value Help` ).
-    DATA(tab) = dialog->table(
-        mode  = `SingleSelectLeft`
-        items = client->_bind( t_suggestion_sel ) ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = `abap2UI5 - Value Help` ).
+    DATA(tab) = dialog->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_suggestion_sel )
+        )->a( n = `mode`  v = `SingleSelectLeft` ).
 
-    tab->columns(
-        )->column( `20rem`
-            )->text( `Color` )->get_parent(
-        )->column(
-            )->text( `Description` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column`
+            )->a( n = `width` v = `20rem` )->tag( `Text`
+                )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( ).
 
-    tab->items( )->column_list_item( selected = `{SELKZ}`
-        )->cells(
-            )->text( `{VALUE}`
-            )->text( `{DESCR}` ).
+    tab->ele( `items` )->ele( `ColumnListItem`
+        )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Text`
+                )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+                )->a( n = `text` v = `{DESCR}` ).
 
-    dialog->buttons(
-        )->button(
-            text  = `continue`
-            press = client->_event( `POPUP_TABLE_VALUE_CONTINUE` )
-            type  = `Emphasized` ).
+    dialog->ele( `buttons` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPUP_TABLE_VALUE_CONTINUE` )
+            )->a( n = `text`  v = `continue`
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -271,52 +270,51 @@ CLASS z2ui5_cl_smp_app_009 IMPLEMENTATION.
 
   METHOD popup_value_employee.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( `abap2UI5 - Value Help` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = `abap2UI5 - Value Help` ).
 
-    dialog->simple_form( editable = abap_true
-        )->label( `Location`
-        )->input(
-            value           = client->_bind( s_screen-city )
-            suggestionitems = client->_bind( t_cities )
-            showsuggestion  = abap_true
-        )->get(
-        )->suggestion_items( )->get(
-            )->list_item(
-                text           = `{VALUE}`
-                additionaltext = `{DESCR}`
-        )->get_parent( )->get_parent(
-        )->button(
-            text  = `search...`
-            press = client->_event( `SEARCH` ) ).
+    dialog->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` b = abap_true )->tag( `Label`
+            )->a( n = `text` v = `Location` )->ele( `Input`
+            )->a( n = `value`           v = client->_bind( s_screen-city )
+            )->a( n = `suggestionItems` v = client->_bind( t_cities )
+            )->a( n = `showSuggestion`  b = abap_true )->ele( `suggestionItems` )->tag( n = `ListItem` ns = `core`
+                )->a( n = `text`           v = `{VALUE}`
+                )->a( n = `additionalText` v = `{DESCR}` )->end( )->end( )->tag( `Button`
+            )->a( n = `press` v = client->_event( `SEARCH` )
+            )->a( n = `text`  v = `search...` ).
 
-    DATA(tab) = dialog->table(
-        headertext = `Employees`
-        mode       = `SingleSelectLeft`
-        items      = client->_bind( t_employees_sel ) ).
+    DATA(tab) = dialog->ele( `Table`
+        )->a( n = `items`      v = client->_bind( t_employees_sel )
+        )->a( n = `headerText` v = `Employees`
+        )->a( n = `mode`       v = `SingleSelectLeft` ).
 
-    tab->columns(
-        )->column( `10rem`
-            )->text( `City` )->get_parent(
-        )->column( `10rem`
-            )->text( `Nr` )->get_parent(
-        )->column( `15rem`
-            )->text( `Name` )->get_parent(
-        )->column( `30rem`
-            )->text( `Lastname` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column`
+            )->a( n = `width` v = `10rem` )->tag( `Text`
+                )->a( n = `text` v = `City` )->end( )->ele( `Column`
+            )->a( n = `width` v = `10rem` )->tag( `Text`
+                )->a( n = `text` v = `Nr` )->end( )->ele( `Column`
+            )->a( n = `width` v = `15rem` )->tag( `Text`
+                )->a( n = `text` v = `Name` )->end( )->ele( `Column`
+            )->a( n = `width` v = `30rem` )->tag( `Text`
+                )->a( n = `text` v = `Lastname` )->end( ).
 
-    tab->items( )->column_list_item( selected = `{SELKZ}`
-        )->cells(
-            )->text( `{CITY}`
-            )->text( `{NR}`
-            )->text( `{NAME}`
-            )->text( `{LASTNAME}` ).
+    tab->ele( `items` )->ele( `ColumnListItem`
+        )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Text`
+                )->a( n = `text` v = `{CITY}` )->tag( `Text`
+                )->a( n = `text` v = `{NR}` )->tag( `Text`
+                )->a( n = `text` v = `{NAME}` )->tag( `Text`
+                )->a( n = `text` v = `{LASTNAME}` ).
 
-    dialog->buttons(
-        )->button(
-            text  = `continue`
-            press = client->_event( `POPUP_TABLE_VALUE_CUSTOM_CONTINUE` )
-            type  = `Emphasized` ).
+    dialog->ele( `buttons` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPUP_TABLE_VALUE_CUSTOM_CONTINUE` )
+            )->a( n = `text`  v = `continue`
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_011.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_011.clas.abap
@@ -33,75 +33,61 @@ CLASS z2ui5_cl_smp_app_011 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Table - Editable Cells, Add and Delete Rows`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( )
-            id             = `test2` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Table - Editable Cells, Add and Delete Rows`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `id`             v = `test2` ).
 
-    page->message_strip(
-        text     = `A MultiSelect table whose input cells switch between display and edit mode via the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A MultiSelect table whose input cells switch between display and edit mode via the ` &&
                    `toolbar, which also adds new rows and deletes the currently selected ones.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table(
-            items = |\{path: '{ client->_bind( val = t_tab path = abap_true ) }', templateShareable: false\}|
-            mode  = `MultiSelect`
-        )->header_toolbar(
-            )->overflow_toolbar(
-                )->title( `title of the table`
-                )->button(
-                    text  = `test`
-                    press = client->_event( `BUTTON_TEST` )
-                )->toolbar_spacer(
-                )->button(
-                    icon  = `sap-icon://delete`
-                    text  = `delete selected row`
-                    press = client->_event( `BUTTON_DELETE` )
-                )->button(
-                    icon  = `sap-icon://add`
-                    text  = `add`
-                    press = client->_event( `BUTTON_ADD` )
-                )->button(
-                    icon  = `sap-icon://edit`
-                    text  = SWITCH #( check_editable_active WHEN abap_true THEN `display` ELSE `edit` )
-                    press = client->_event( `BUTTON_EDIT` )
-        )->get_parent( )->get_parent( ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = |\{path: '{ client->_bind( val = t_tab path = abap_true ) }', templateShareable: false\}|
+        )->a( n = `mode`  v = `MultiSelect` )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                    )->a( n = `text` v = `title of the table` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_TEST` )
+                    )->a( n = `text`  v = `test` )->tag( `ToolbarSpacer` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_DELETE` )
+                    )->a( n = `text`  v = `delete selected row`
+                    )->a( n = `icon`  v = `sap-icon://delete` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_ADD` )
+                    )->a( n = `text`  v = `add`
+                    )->a( n = `icon`  v = `sap-icon://add` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON_EDIT` )
+                    )->a( n = `text`  v = SWITCH #( check_editable_active WHEN abap_true THEN `display` ELSE `edit` )
+                    )->a( n = `icon`  v = `sap-icon://edit` )->end( )->end( ).
 
-    tab->columns(
-        )->column(
-            )->text( `Title` )->get_parent(
-        )->column(
-            )->text( `Color` )->get_parent(
-        )->column(
-            )->text( `Info` )->get_parent(
-        )->column(
-            )->text( `Description` )->get_parent(
-        )->column(
-            )->text( `Checkbox` ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Info` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Checkbox` ).
 
-    tab->items( )->column_list_item( selected = `{SELKZ}`
-        )->cells(
-            )->input(
-                value   = `{TITLE}`
-                enabled = `{EDITABLE}`
-                id      = `test`
-            )->input(
-                value   = `{VALUE}`
-                enabled = `{EDITABLE}`
-            )->input(
-                value   = `{INFO}`
-                enabled = `{EDITABLE}`
-            )->input(
-                value   = `{DESCR}`
-                enabled = `{EDITABLE}`
-            )->checkbox(
-                selected = `{CHECKBOX}`
-                enabled  = `{EDITABLE}` ).
+    tab->ele( `items` )->ele( `ColumnListItem`
+        )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Input`
+                )->a( n = `id`      v = `test`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{TITLE}` )->tag( `Input`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{VALUE}` )->tag( `Input`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{INFO}` )->tag( `Input`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{DESCR}` )->tag( `CheckBox`
+                )->a( n = `selected` v = `{CHECKBOX}`
+                )->a( n = `enabled`  v = `{EDITABLE}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_012.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_012.clas.abap
@@ -80,55 +80,52 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popup - Ways to Open a Dialog`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popup - Ways to Open a Dialog`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Shows different ways to open a popup - inside the same app or as a sub-app - ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Shows different ways to open a popup - inside the same app or as a sub-app - ` &&
                    `and how the background view is kept, destroyed or re-rendered.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(grid) = page->grid( `L7 M12 S12` )->content( `layout`
-        )->simple_form(
-            title    = `Popup in same App`
-            editable = abap_true
-            )->content( `form`
-            )->label( `Demo`
-            )->button(
-                text  = `popup rendering, no background rendering`
-                press = client->_event( `BUTTON_POPUP_01` )
-            )->label( `Demo`
-            )->button(
-                text  = `popup rendering, background destroyed and rerendering`
-                press = client->_event( `BUTTON_POPUP_02` )
-            )->label( `Demo`
-            )->button(
-                text  = `popup, background unchanged (default) - close (no roundtrip)`
-                press = client->_event( `BUTTON_POPUP_03` )
-            )->label( `Demo`
-            )->button(
-                text  = `popup, background unchanged (default) - close with server`
-                press = client->_event( `BUTTON_POPUP_04` )
-        )->get_parent( )->get_parent( ).
+    DATA(grid) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L7 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title`    v = `Popup in same App`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_POPUP_01` )
+                )->a( n = `text`  v = `popup rendering, no background rendering` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_POPUP_02` )
+                )->a( n = `text`  v = `popup rendering, background destroyed and rerendering` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_POPUP_03` )
+                )->a( n = `text`  v = `popup, background unchanged (default) - close (no roundtrip)` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_POPUP_04` )
+                )->a( n = `text`  v = `popup, background unchanged (default) - close with server` )->end( )->end( ).
 
-    grid->simple_form(
-        title    = `Popup in new App`
-        editable = abap_true
-        )->content( `form`
-        )->label( `Demo`
-        )->button(
-            text  = `popup rendering, no background`
-            press = client->_event( `BUTTON_POPUP_05` )
-        )->label( `Demo`
-        )->button(
-            text  = `popup rendering, hold previous view`
-            press = client->_event( `BUTTON_POPUP_06` ) ).
+    grid->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Popup in new App`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `BUTTON_POPUP_05` )
+            )->a( n = `text`  v = `popup rendering, no background` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `BUTTON_POPUP_06` )
+            )->a( n = `text`  v = `popup rendering, hold previous view` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -137,19 +134,19 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
 
   METHOD popup_decide.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    popup->dialog( `Popup - Decide`
-            )->vbox(
-                )->text( `this is a popup to decide, you have to make a decision now...`
-            )->get_parent(
-            )->buttons(
-                )->button(
-                    text  = `Cancel`
-                    press = client->_event( `POPUP_DECIDE_CANCEL` )
-                )->button(
-                    text  = `Continue`
-                    press = client->_event( `POPUP_DECIDE_CONTINUE` )
-                    type  = `Emphasized` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    popup->ele( `Dialog`
+        )->a( n = `title` v = `Popup - Decide` )->ele( `VBox` )->tag( `Text`
+                    )->a( n = `text` v = `this is a popup to decide, you have to make a decision now...` )->end( )->ele( `buttons` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `POPUP_DECIDE_CANCEL` )
+                    )->a( n = `text`  v = `Cancel` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `POPUP_DECIDE_CONTINUE` )
+                    )->a( n = `text`  v = `Continue`
+                    )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -158,16 +155,18 @@ CLASS z2ui5_cl_smp_app_012 IMPLEMENTATION.
 
   METHOD popup_info.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    popup->dialog( `Popup - Info`
-            )->vbox(
-                )->text( `this is an information, press close to go back to the main view without a server roundtrip`
-            )->get_parent(
-            )->buttons(
-                )->button(
-                    text  = `close`
-                    press = client->follow_up_action( client->cs_event-popup_close )
-                    type  = `Emphasized` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    popup->ele( `Dialog`
+        )->a( n = `title` v = `Popup - Info` )->ele( `VBox` )->tag( `Text`
+                    )->a( n = `text` v = `this is an information, press close to go back to the main view without a server roundtrip` 
+                    )->end( )->ele( `buttons` )->tag( `Button`
+                    )->a( n = `press` v = client->follow_up_action( client->cs_event-popup_close )
+                    )->a( n = `text`  v = `close`
+                    )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_019.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_019.clas.abap
@@ -29,74 +29,62 @@ CLASS z2ui5_cl_smp_app_019 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-            )->page(
-                title          = `abap2UI5 - Table - Selection Modes: Single and Multi Select`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+                )->a( n = `title`          v = `abap2UI5 - Table - Selection Modes: Single and Multi Select`
+                )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A SegmentedButton switches the table's selection mode (None, Single, Multi) at ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A SegmentedButton switches the table's selection mode (None, Single, Multi) at ` &&
                    `runtime; a second table below collects the rows selected in the first.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->segmented_button(
-            selected_key     = client->_bind( sel_mode )
-            selection_change = client->_event( `BUTTON_SEGMENT_CHANGE` ) )->get(
-                )->items( )->get(
-                    )->segmented_button_item(
-                        key  = `None`
-                        text = `None`
-                    )->segmented_button_item(
-                        key  = `SingleSelect`
-                        text = `SingleSelect`
-                    )->segmented_button_item(
-                        key  = `SingleSelectLeft`
-                        text = `SingleSelectLeft`
-                    )->segmented_button_item(
-                        key  = `SingleSelectMaster`
-                        text = `SingleSelectMaster`
-                    )->segmented_button_item(
-                        key  = `MultiSelect`
-                        text = `MultiSelect` ).
+    page->ele( `SegmentedButton`
+        )->a( n = `selectedKey`     v = client->_bind( sel_mode )
+        )->a( n = `selectionChange` v = client->_event( `BUTTON_SEGMENT_CHANGE` ) )->ele( `items` )->tag( `SegmentedButtonItem`
+                        )->a( n = `key`  v = `None`
+                        )->a( n = `text` v = `None` )->tag( `SegmentedButtonItem`
+                        )->a( n = `key`  v = `SingleSelect`
+                        )->a( n = `text` v = `SingleSelect` )->tag( `SegmentedButtonItem`
+                        )->a( n = `key`  v = `SingleSelectLeft`
+                        )->a( n = `text` v = `SingleSelectLeft` )->tag( `SegmentedButtonItem`
+                        )->a( n = `key`  v = `SingleSelectMaster`
+                        )->a( n = `text` v = `SingleSelectMaster` )->tag( `SegmentedButtonItem`
+                        )->a( n = `key`  v = `MultiSelect`
+                        )->a( n = `text` v = `MultiSelect` ).
 
-    page->table(
-            headertext = `Table`
-            mode       = sel_mode
-            items      = client->_bind( t_tab )
-            )->columns(
-                )->column( )->text( `Title` )->get_parent(
-                )->column( )->text( `Value` )->get_parent(
-                )->column( )->text( `Description`
-            )->get_parent( )->get_parent(
-            )->items(
-                )->column_list_item( selected = `{SELKZ}`
-                    )->cells(
-                        )->text( `{TITLE}`
-                        )->text( `{VALUE}`
-                        )->text( `{DESCR}` ).
+    page->ele( `Table`
+        )->a( n = `items`      v = client->_bind( t_tab )
+        )->a( n = `headerText` v = `Table`
+        )->a( n = `mode`       v = sel_mode )->ele( `columns` )->ele( `Column` )->tag( `Text`
+                    )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+                    )->a( n = `text` v = `Value` )->end( )->ele( `Column` )->tag( `Text`
+                    )->a( n = `text` v = `Description` )->end( )->end( )->ele( `items` )->ele( `ColumnListItem`
+                    )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Text`
+                            )->a( n = `text` v = `{TITLE}` )->tag( `Text`
+                            )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+                            )->a( n = `text` v = `{DESCR}` ).
 
-    page->table( client->_bind( t_tab_sel )
-            )->header_toolbar(
-                )->overflow_toolbar(
-                    )->title( `Selected Entries`
-                    )->button(
-                        icon  = `sap-icon://pull-down`
-                        text  = `copy selected entries`
-                        press = client->_event( `BUTTON_READ_SEL` )
-          )->get_parent( )->get_parent(
-          )->columns(
-            )->column( )->text( `Title` )->get_parent(
-            )->column( )->text( `Value` )->get_parent(
-            )->column( )->text( `Description`
-            )->get_parent( )->get_parent(
-            )->items( )->column_list_item( )->cells(
-                )->text( `{TITLE}`
-                )->text( `{VALUE}`
-                )->text( `{DESCR}` ).
+    page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_tab_sel ) )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                        )->a( n = `text` v = `Selected Entries` )->tag( `Button`
+                        )->a( n = `press` v = client->_event( `BUTTON_READ_SEL` )
+                        )->a( n = `text`  v = `copy selected entries`
+                        )->a( n = `icon`  v = `sap-icon://pull-down` )->end( )->end( )->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Value` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->end( )->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{TITLE}` )->tag( `Text`
+                    )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+                    )->a( n = `text` v = `{DESCR}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_020.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_020.clas.abap
@@ -49,26 +49,26 @@ CLASS z2ui5_cl_smp_app_020 IMPLEMENTATION.
         RETURN.
     ENDCASE.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( `abap2UI5 - Popup to decide` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = `abap2UI5 - Popup to decide` ).
 
-    dialog->message_strip(
-        text     = `A reusable decision popup opened as a sub-app: its text, button labels and events ` &&
+    dialog->tag( `MessageStrip`
+        )->a( n = `text`     v = `A reusable decision popup opened as a sub-app: its text, button labels and events ` &&
                    `are passed in by the caller, and the pressed event is sent back.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    dialog->vbox(
-            )->text( text )->get_parent(
-        )->buttons(
-                )->button(
-                    text  = cancel_text
-                    press = client->_event( cancel_event )
-                )->button(
-                    text  = confirm_text
-                    press = client->_event( confirm_event )
-                    type  = `Emphasized` ).
+    dialog->ele( `VBox` )->tag( `Text`
+                )->a( n = `text` v = text )->end( )->ele( `buttons` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( cancel_event )
+                    )->a( n = `text`  v = cancel_text )->tag( `Button`
+                    )->a( n = `press` v = client->_event( confirm_event )
+                    )->a( n = `text`  v = confirm_text
+                    )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_024.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_024.clas.abap
@@ -77,45 +77,45 @@ CLASS z2ui5_cl_smp_app_024 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Navigation - Call and Leave Apps (nav_app_call)`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Navigation - Call and Leave Apps (nav_app_call)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `App-to-app navigation: calls a second app in different ways - open a view, raise ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `App-to-app navigation: calls a second app in different ways - open a view, raise ` &&
                    `an event or pass data - and reads the input it returns.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form(
-            title    = `Controller`
-            editable = abap_true
-        )->content( `form`
-        )->label( `Demo`
-        )->button(
-            text  = `call new app (first View)`
-            press = client->_event( `CALL_NEW_APP` )
-        )->label( `Demo`
-        )->button(
-            text  = `call new app (second View)`
-            press = client->_event( `CALL_NEW_APP_VIEW` )
-        )->label( `Demo`
-        )->button(
-            text  = `call new app (set Event)`
-            press = client->_event( `CALL_NEW_APP_EVENT` )
-        )->label( `Demo`
-        )->input( client->_bind( input )
-        )->button(
-            text  = `call new app (set data)`
-            press = client->_event( `CALL_NEW_APP_READ` )
-        )->label( `some data, you can read in the next app`
-        )->input( client->_bind( input2 ) ).
+    page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title`    v = `Controller`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CALL_NEW_APP` )
+            )->a( n = `text`  v = `call new app (first View)` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CALL_NEW_APP_VIEW` )
+            )->a( n = `text`  v = `call new app (second View)` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CALL_NEW_APP_EVENT` )
+            )->a( n = `text`  v = `call new app (set Event)` )->tag( `Label`
+            )->a( n = `text` v = `Demo` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input ) )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CALL_NEW_APP_READ` )
+            )->a( n = `text`  v = `call new app (set data)` )->tag( `Label`
+            )->a( n = `text` v = `some data, you can read in the next app` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input2 ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_025.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_025.clas.abap
@@ -70,57 +70,55 @@ CLASS z2ui5_cl_smp_app_025 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - flow logic - APP 02`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - flow logic - APP 02`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The second app in the app-to-app flow: it reads the caller's data, returns to it ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The second app in the app-to-app flow: it reads the caller's data, returns to it ` &&
                    `optionally raising an event, and switches between two views.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     CASE show_view.
 
       WHEN `MAIN` OR ``.
-        page->grid( `L6 M12 S12`
-            )->content( `layout`
-            )->simple_form(
-                title    = `View: FIRST`
-                editable = abap_true
-            )->content( `form`
-            )->label( `Input set by previous app`
-            )->input( input_previous_set
-            )->label( `Data of previous app`
-            )->input( input_previous
-            )->button(
-                text  = `read`
-                press = client->_event( `BUTTON_READ_PREVIOUS` )
-            )->label( `Call previous app and show data of this app`
-            )->input( client->_bind( input )
-            )->button(
-                text  = `back`
-                press = client->_event( `BACK_WITH_EVENT` ) ).
+        page->ele( n = `Grid` ns = `layout`
+            )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+                )->a( n = `title`    v = `View: FIRST`
+                )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Input set by previous app` )->tag( `Input`
+                )->a( n = `value` v = input_previous_set )->tag( `Label`
+                )->a( n = `text` v = `Data of previous app` )->tag( `Input`
+                )->a( n = `value` v = input_previous )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_READ_PREVIOUS` )
+                )->a( n = `text`  v = `read` )->tag( `Label`
+                )->a( n = `text` v = `Call previous app and show data of this app` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( input ) )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BACK_WITH_EVENT` )
+                )->a( n = `text`  v = `back` ).
 
       WHEN `SECOND`.
-        page->grid( `L6 M12 S12`
-            )->content( `layout`
-            )->simple_form(
-                title    = `View: SECOND`
-                editable = abap_true
-            )->content( `form`
-            )->label( `Demo`
-            )->button(
-                text  = `leave to previous app`
-                press = client->_event_nav_app_leave( )
-            )->label( `Demo`
-            )->button(
-                text  = `show view main`
-                press = client->_event( `SHOW_VIEW_MAIN` ) ).
+        page->ele( n = `Grid` ns = `layout`
+            )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+                )->a( n = `title`    v = `View: SECOND`
+                )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event_nav_app_leave( )
+                )->a( n = `text`  v = `leave to previous app` )->tag( `Label`
+                )->a( n = `text` v = `Demo` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `SHOW_VIEW_MAIN` )
+                )->a( n = `text`  v = `show view main` ).
 
     ENDCASE.
 

--- a/src/01/z2ui5_cl_smp_app_026.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_026.clas.abap
@@ -54,23 +54,20 @@ CLASS z2ui5_cl_smp_app_026 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
-    view->popover(
-            title     = `Popover Title`
-            placement = placement
-        )->footer(
-        )->overflow_toolbar(
-            )->toolbar_spacer(
-            )->button(
-                text  = `Cancel`
-                press = client->_event( `BUTTON_CANCEL` )
-            )->button(
-                text  = `Confirm`
-                press = client->_event( `BUTTON_CONFIRM` )
-                type  = `Emphasized`
-        )->get_parent( )->get_parent(
-        )->text( `make an input here:`
-        )->input( `abcd` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
+    view->ele( `Popover`
+        )->a( n = `title`     v = `Popover Title`
+        )->a( n = `placement` v = placement )->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_CANCEL` )
+                )->a( n = `text`  v = `Cancel` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_CONFIRM` )
+                )->a( n = `text`  v = `Confirm`
+                )->a( n = `type`  v = `Emphasized` )->end( )->end( )->tag( `Text`
+            )->a( n = `text` v = `make an input here:` )->tag( `Input`
+            )->a( n = `value` v = `abcd` ).
 
     client->popover_display(
         xml   = view->stringify( )
@@ -81,60 +78,54 @@ CLASS z2ui5_cl_smp_app_026 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popover - Basic Example with Placement`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popover - Basic Example with Placement`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Popover demo: choose a placement with the segmented button, then open a popover ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Popover demo: choose a placement with the segmented button, then open a popover ` &&
                    `anchored to a control, with confirm and cancel actions.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Popover`
-        editable = abap_true
-        )->content( `form`
-        )->title( `Input`
-        )->label( `Link`
-        )->link(
-            text = `Documentation UI5 Popover Control`
-            href = `https://openui5.hana.ondemand.com/entity/sap.m.Popover`
-        )->label( `placement`
-        )->segmented_button( client->_bind( placement )
-            )->items(
-            )->segmented_button_item(
-                key  = `Left`
-                icon = `sap-icon://add-favorite`
-                text = `Left`
-            )->segmented_button_item(
-                key  = `Top`
-                icon = `sap-icon://accept`
-                text = `Top`
-            )->segmented_button_item(
-                key  = `Bottom`
-                icon = `sap-icon://accept`
-                text = `Bottom`
-            )->segmented_button_item(
-                key  = `Right`
-                icon = `sap-icon://attachment`
-                text = `Right`
-        )->get_parent( )->get_parent(
-        )->label( `popover`
-        )->button(
-            text  = `show`
-            press = client->_event( `POPOVER` )
-            id    = `TEST`
-        )->button(
-            text  = `cancel`
-            press = client->_event( `POPOVER` )
-        )->button(
-            text  = `post`
-            press = client->_event( `POPOVER` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Popover`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+            )->a( n = `text` v = `Input` )->tag( `Label`
+            )->a( n = `text` v = `Link` )->tag( `Link`
+            )->a( n = `text` v = `Documentation UI5 Popover Control`
+            )->a( n = `href` v = `https://openui5.hana.ondemand.com/entity/sap.m.Popover` )->tag( `Label`
+            )->a( n = `text` v = `placement` )->ele( `SegmentedButton`
+            )->a( n = `selectedKey` v = client->_bind( placement ) )->ele( `items` )->tag( `SegmentedButtonItem`
+                )->a( n = `icon` v = `sap-icon://add-favorite`
+                )->a( n = `key`  v = `Left`
+                )->a( n = `text` v = `Left` )->tag( `SegmentedButtonItem`
+                )->a( n = `icon` v = `sap-icon://accept`
+                )->a( n = `key`  v = `Top`
+                )->a( n = `text` v = `Top` )->tag( `SegmentedButtonItem`
+                )->a( n = `icon` v = `sap-icon://accept`
+                )->a( n = `key`  v = `Bottom`
+                )->a( n = `text` v = `Bottom` )->tag( `SegmentedButtonItem`
+                )->a( n = `icon` v = `sap-icon://attachment`
+                )->a( n = `key`  v = `Right`
+                )->a( n = `text` v = `Right` )->end( )->end( )->tag( `Label`
+            )->a( n = `text` v = `popover` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPOVER` )
+            )->a( n = `text`  v = `show`
+            )->a( n = `id`    v = `TEST` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPOVER` )
+            )->a( n = `text`  v = `cancel` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPOVER` )
+            )->a( n = `text`  v = `post` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_027.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_027.clas.abap
@@ -57,66 +57,62 @@ CLASS z2ui5_cl_smp_app_027 IMPLEMENTATION.
     bind_input51  = client->_bind( val = input51 path = abap_true ).
     bind_input52  = client->_bind( val = input52 path = abap_true ).
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Binding - Expression Binding, Types and Composite Parts`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Expression Binding, Types and Composite Parts`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Advanced binding syntax: expression binding, typed bindings, conditional enabling ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Advanced binding syntax: expression binding, typed bindings, conditional enabling ` &&
                    `with RegExp checks, and composite (parts) bindings.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->simple_form(
-        title    = `Binding Syntax`
-        editable = abap_true
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Binding Syntax`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->title( `Expression Binding`
-        )->label( `Documentation`
-        )->link(
-            text = `Expression Binding`
-            href = `https://sapui5.hana.ondemand.com/sdk/#/topic/daf6852a04b44d118963968a1239d2c0`
-        )->label( `input in uppercase`
-        )->input( client->_bind( input2 )
-        )->input(
-            value   = |\{= ${ client->_bind( input2 ) }.toUpperCase() \}|
-            enabled = abap_false
-        )->label( `max value of the first two inputs`
-        )->input(
-            `{ type : "sap.ui.model.type.Integer",` &&
-            `  path:"` && bind_input31 && `" }`
-        )->input(
-            `{ type : "sap.ui.model.type.Integer",` && |\n| &&
-            `  path:"` && bind_input32 && `" }`
-        )->input(
-            value   = |\{= Math.max(${ client->_bind( input31 ) }, ${ client->_bind( input32 ) }) \}|
-            enabled = abap_false
-        )->label( `only enabled when the quantity equals 500`
-        )->input(
-            `{ type : "sap.ui.model.type.Integer",` &&
-            `  path:"` && bind_quantity && `" }`
-        )->input(
-            value   = product
-            enabled = |\{= 500===${ client->_bind( quantity ) } \}|
-        )->label( `RegExp Set to enabled if the input contains VIP, ignoring the case.`
-        )->input( client->_bind( input41 )
-        )->button(
-            text    = `VIP`
-            enabled = |\{= RegExp('vip', 'i').test(${ client->_bind( input41 ) }) \}|
-        )->label( `concatenate both inputs`
-        )->input( client->_bind( input51 )
-        )->input( client->_bind( input52 )
-        )->input(
-            value   = `{ parts: [` && |\n| &&
+    form->tag( `Title`
+        )->a( n = `text` v = `Expression Binding` )->tag( `Label`
+            )->a( n = `text` v = `Documentation` )->tag( `Link`
+            )->a( n = `text` v = `Expression Binding`
+            )->a( n = `href` v = `https://sapui5.hana.ondemand.com/sdk/#/topic/daf6852a04b44d118963968a1239d2c0` )->tag( `Label`
+            )->a( n = `text` v = `input in uppercase` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input2 ) )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = |\{= ${ client->_bind( input2 ) }.toUpperCase() \}| )->tag( `Label`
+            )->a( n = `text` v = `max value of the first two inputs` )->tag( `Input`
+            )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` &&
+            `  path:"` && bind_input31 && `" }` )->tag( `Input`
+            )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` && |\n| &&
+            `  path:"` && bind_input32 && `" }` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = |\{= Math.max(${ client->_bind( input31 ) }, ${ client->_bind( input32 ) }) \}| )->tag( `Label`
+            )->a( n = `text` v = `only enabled when the quantity equals 500` )->tag( `Input`
+            )->a( n = `value` v = `{ type : "sap.ui.model.type.Integer",` &&
+            `  path:"` && bind_quantity && `" }` )->tag( `Input`
+            )->a( n = `enabled` v = |\{= 500===${ client->_bind( quantity ) } \}|
+            )->a( n = `value`   v = product )->tag( `Label`
+            )->a( n = `text` v = `RegExp Set to enabled if the input contains VIP, ignoring the case.` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input41 ) )->tag( `Button`
+            )->a( n = `text`    v = `VIP`
+            )->a( n = `enabled` v = |\{= RegExp('vip', 'i').test(${ client->_bind( input41 ) }) \}| )->tag( `Label`
+            )->a( n = `text` v = `concatenate both inputs` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input51 ) )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input52 ) )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = `{ parts: [` && |\n| &&
                       `                "` && bind_input51 && `",` && |\n| &&
                       `                "` && bind_input52 && `"` && |\n| &&
-                      `               ]  }`
-            enabled = abap_false ).
+                      `               ]  }` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_028.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_028.clas.abap
@@ -88,29 +88,32 @@ CLASS z2ui5_cl_smp_app_028 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Timer - Refresh the View Every n Seconds`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Timer - Refresh the View Every n Seconds`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The list refreshes itself automatically: a client-side timer (follow_up_action) fires ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The list refreshes itself automatically: a client-side timer (follow_up_action) fires ` &&
                    `every 2 seconds, appending a new entry on the server until three rows exist.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->list(
-        headertext = `Data auto refresh (2 sec)`
-        items      = client->_bind( t_tab )
-        )->standard_list_item(
-            title       = `{TITLE}`
-            description = `{DESCR}`
-            icon        = `{ICON}`
-            info        = `{INFO}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Data auto refresh (2 sec)`
+        )->a( n = `items`      v = client->_bind( t_tab ) )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{TITLE}`
+            )->a( n = `description` v = `{DESCR}`
+            )->a( n = `icon`        v = `{ICON}`
+            )->a( n = `info`        v = `{INFO}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_045.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_045.clas.abap
@@ -58,64 +58,58 @@ CLASS z2ui5_cl_smp_app_045 IMPLEMENTATION.
         client->message_box_display( `button post was pressed` ).
     ENDCASE.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-        )->page(
-            title          = `abap2UI5 - Table - Filter Rows in the Backend`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( )
-            )->header_content(
-                )->link(
-      )->get_parent( ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Table - Filter Rows in the Backend`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( `headerContent` )->tag( `Link` )->end( ).
 
-    page->message_strip(
-        text     = `A growing, scrollable table filtered on the backend: entering a value in the form and ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A growing, scrollable table filtered on the backend: entering a value in the form and ` &&
                    `pressing filter deletes the non-matching rows server-side before re-rendering.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( title    = `Form Title`
-                       editable = abap_true
-                )->content( `form`
-                    )->title( `Filter`
-                    )->label( `info`
-                    )->input( client->_bind( mv_info_filter )
-                    )->button(
-                        text  = `filter`
-                        press = client->_event( `FILTER_INFO` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Form Title`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                        )->a( n = `text` v = `Filter` )->tag( `Label`
+                        )->a( n = `text` v = `info` )->tag( `Input`
+                        )->a( n = `value` v = client->_bind( mv_info_filter ) )->tag( `Button`
+                        )->a( n = `press` v = client->_event( `FILTER_INFO` )
+                        )->a( n = `text`  v = `filter` ).
 
-    DATA(tab) = page->scroll_container( height   = `70%`
-                                        vertical = abap_true
-        )->table(
-            growing             = abap_true
-            growingthreshold    = `20`
-            growingscrolltoload = abap_true
-            items               = client->_bind( t_tab )
-            sticky              = `ColumnHeaders,HeaderToolbar` ).
+    DATA(tab) = page->ele( `ScrollContainer`
+        )->a( n = `height`   v = `70%`
+        )->a( n = `vertical` b = abap_true )->ele( `Table`
+            )->a( n = `items`               v = client->_bind( t_tab )
+            )->a( n = `growing`             b = abap_true
+            )->a( n = `growingThreshold`    v = `20`
+            )->a( n = `growingScrollToLoad` b = abap_true
+            )->a( n = `sticky`              v = `ColumnHeaders,HeaderToolbar` ).
 
-    tab->header_toolbar(
-        )->overflow_toolbar(
-            )->toolbar_spacer( ).
+    tab->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` ).
 
-    tab->columns(
-        )->column(
-            )->text( `Color` )->get_parent(
-        )->column(
-            )->text( `Info` )->get_parent(
-        )->column(
-            )->text( `Description` )->get_parent(
-        )->column(
-            )->text( `Checkbox` )->get_parent(
-         )->column(
-            )->text( `Counter` ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Info` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Description` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Checkbox` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Counter` ).
 
-    tab->items( )->column_list_item( )->cells(
-       )->text( `{VALUE}`
-       )->text( `{INFO}`
-       )->text( `{DESCR}`
-       )->checkbox( selected = `{CHECKBOX}`
-                    enabled  = abap_false
-       )->text( `{COUNT}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+           )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+           )->a( n = `text` v = `{INFO}` )->tag( `Text`
+           )->a( n = `text` v = `{DESCR}` )->tag( `CheckBox`
+           )->a( n = `selected` v = `{CHECKBOX}`
+           )->a( n = `enabled`  b = abap_false )->tag( `Text`
+           )->a( n = `text` v = `{COUNT}` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_047.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_047.clas.abap
@@ -51,60 +51,63 @@ CLASS z2ui5_cl_smp_app_047 IMPLEMENTATION.
         dec_sum = dec1 + dec2.
     ENDCASE.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-        )->page(
-                title          = `abap2UI5 - Binding - Types for Integer, Decimal, Date and Time`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Types for Integer, Decimal, Date and Time`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Numeric and date/time binding: integer and decimal fields use automatic type ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Numeric and date/time binding: integer and decimal fields use automatic type ` &&
                    `conversion, buttons calculate the sums, and a growing table lists the values.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( title    = `Integer and Decimals`
-                       editable = abap_true
-             )->content( `form`
-                 )->title( `Input`
-                 )->label( `integer`
-                 )->input( client->_bind( int1 )
-                 )->input( client->_bind( int2 )
-                 )->input( enabled = abap_false
-                           value   = client->_bind( int_sum )
-                 )->button( text  = `calc sum`
-                            press = client->_event( `BUTTON_INT` )
-                 )->label( `decimals`
-                 )->input( client->_bind( dec1 )
-                 )->input( client->_bind( dec2 )
-                 )->input( enabled = abap_false
-                           value   = client->_bind( dec_sum )
-                 )->button( text  = `calc sum`
-                            press = client->_event( `BUTTON_DEC` )
-                 )->label( `date`
-                 )->input( client->_bind( date )
-                 )->label( `time`
-                 )->input( client->_bind( time ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Integer and Decimals`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                     )->a( n = `text` v = `Input` )->tag( `Label`
+                     )->a( n = `text` v = `integer` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( int1 ) )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( int2 ) )->tag( `Input`
+                     )->a( n = `enabled` b = abap_false
+                     )->a( n = `value`   v = client->_bind( int_sum ) )->tag( `Button`
+                     )->a( n = `press` v = client->_event( `BUTTON_INT` )
+                     )->a( n = `text`  v = `calc sum` )->tag( `Label`
+                     )->a( n = `text` v = `decimals` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( dec1 ) )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( dec2 ) )->tag( `Input`
+                     )->a( n = `enabled` b = abap_false
+                     )->a( n = `value`   v = client->_bind( dec_sum ) )->tag( `Button`
+                     )->a( n = `press` v = client->_event( `BUTTON_DEC` )
+                     )->a( n = `text`  v = `calc sum` )->tag( `Label`
+                     )->a( n = `text` v = `date` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( date ) )->tag( `Label`
+                     )->a( n = `text` v = `time` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( time ) ).
 
-    DATA(tab) = page->scroll_container( height   = `70%`
-                                        vertical = abap_true
-        )->table(
-            growing             = abap_true
-            growingthreshold    = `20`
-            growingscrolltoload = abap_true
-            items               = client->_bind( mt_tab )
-            sticky              = `ColumnHeaders,HeaderToolbar` ).
+    DATA(tab) = page->ele( `ScrollContainer`
+        )->a( n = `height`   v = `70%`
+        )->a( n = `vertical` b = abap_true )->ele( `Table`
+            )->a( n = `items`               v = client->_bind( mt_tab )
+            )->a( n = `growing`             b = abap_true
+            )->a( n = `growingThreshold`    v = `20`
+            )->a( n = `growingScrollToLoad` b = abap_true
+            )->a( n = `sticky`              v = `ColumnHeaders,HeaderToolbar` ).
 
-    tab->columns(
-        )->column(
-            )->text( `Date` )->get_parent(
-        )->column(
-            )->text( `Time` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Date` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Time` )->end( ).
 
-    tab->items( )->column_list_item( )->cells(
-       )->text( `{DATE}`
-       )->text( `{TIME}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+           )->a( n = `text` v = `{DATE}` )->tag( `Text`
+           )->a( n = `text` v = `{TIME}` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_048.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_048.clas.abap
@@ -50,46 +50,45 @@ CLASS z2ui5_cl_smp_app_048 IMPLEMENTATION.
         client->message_box_display( |SELECTION_CHANGED - { lt_sel[ 1 ]-title }| ).
     ENDCASE.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-        )->page(
-            title          = `abap2UI5 - List - StandardListItem, Highlight and Events`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( )
-            ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - List - StandardListItem, Highlight and Events`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A List of generic StandardListItems showing highlight bars, colored infoState and ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A List of generic StandardListItems showing highlight bars, colored infoState and ` &&
                    `wrapping texts; the detail button and selection changes raise backend events with message boxes.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->list(
-        headertext      = `List Output`
-        items           = client->_bind( t_tab )
-        mode            = `SingleSelectMaster`
-        selectionchange = client->_event( `SELCHANGE` )
-      )->_generic(
-         name   = `StandardListItem`
-         t_prop = VALUE #(
-                ( n = `title`       v = `{TITLE}` )
-                ( n = `description` v = `{DESCR}` )
-                ( n = `icon`        v = `{ICON}` )
-                ( n = `iconInset`   v = `false` )
-                ( n = `highlight`   v = `{HIGHLIGHT}` )
-                ( n = `info`        v = `{INFO}` )
-                ( n = `infoState`   v = `{HIGHLIGHT}` )
-                ( n = `type`        v = `Detail` )
-                ( n = `wrapping`    v = `true` )
-                ( n = `selected`    v = `{SELECTED}` )
-                ( n = `detailPress` v = client->_event( val = `EDIT` t_arg = VALUE #( ( `${TITLE}` )
+    page->ele( `List`
+        )->a( n = `headerText`      v = `List Output`
+        )->a( n = `items`           v = client->_bind( t_tab )
+        )->a( n = `mode`            v = `SingleSelectMaster`
+        )->a( n = `selectionChange` v = client->_event( `SELCHANGE` ) )->ele( `StandardListItem`
+          )->a( n = `title`       v = `{TITLE}`
+          )->a( n = `description` v = `{DESCR}`
+          )->a( n = `icon`        v = `{ICON}`
+          )->a( n = `iconInset`   v = `false`
+          )->a( n = `highlight`   v = `{HIGHLIGHT}`
+          )->a( n = `info`        v = `{INFO}`
+          )->a( n = `infoState`   v = `{HIGHLIGHT}`
+          )->a( n = `type`        v = `Detail`
+          )->a( n = `wrapping`    v = `true`
+          )->a( n = `selected`    v = `{SELECTED}`
+          )->a( n = `detailPress` v = client->_event( val = `EDIT` t_arg = VALUE #( ( `${TITLE}` )
                                                                                       ( `${DESCR}` )
                                                                                       ( `${ICON}` )
                                                                                       ( `${HIGHLIGHT}` )
                                                                                       ( `${INFO}` )
                                                                                       ( `${SELECTED}` )
-                                                                                     ) ) )
-      ) ).
+                                                                                     ) ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_050.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_050.clas.abap
@@ -27,23 +27,28 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
         client->message_toast_display( |{ product } { quantity } - send to the server| ).
     ENDCASE.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - CSS - Ship Your Own CSS with the View`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - CSS - Ship Your Own CSS with the View`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `An inline html style element is sent to the frontend with the view, so the sample can restyle ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `An inline html style element is sent to the frontend with the view, so the sample can restyle ` &&
                    `standard UI5 controls - here the inputs are enlarged and the post button turns red.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->_generic( ns   = `html`
-                    name = `style` )->_cc_plain_xml(
-                    `.sapMInput {` && |\n| &&
+    page->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
+                        )->a( n = `VALUE` v = `.sapMInput {` && |\n| &&
                          `    height: 80px !important;` && |\n| &&
                          `    font-size: 2.5rem !important;` && |\n| &&
                          `}` && |\n| &&
@@ -75,26 +80,21 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
                          |\n| &&
                          `.sapMInputBaseInner::placeholder {` && |\n| &&
                          `    font-size: 1.4rem !important;` && |\n| &&
-                         `}`
-            )->get_parent(
-            )->button(
-                        text  = `post`
-                        press = client->_event( `BUTTON_POST` )
-                        class = `mySuperRedButton`
-            )->input( client->_bind( quantity )
-            )->simple_form( title    = `Form Title`
-                            editable = abap_true
-                )->content( `form`
-                    )->title( `Input`
-                    )->label( `quantity`
-                    )->input( client->_bind( quantity )
-                    )->label( `product`
-                    )->input(
-                        value   = product
-                        enabled = abap_false
-                    )->button(
-                        text  = `post`
-                        press = client->_event( `BUTTON_POST` ) ).
+                         `}` )->end( )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                )->a( n = `text`  v = `post`
+                )->a( n = `class` v = `mySuperRedButton` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( quantity ) )->ele( n = `SimpleForm` ns = `form`
+                )->a( n = `title`    v = `Form Title`
+                )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                        )->a( n = `text` v = `Input` )->tag( `Label`
+                        )->a( n = `text` v = `quantity` )->tag( `Input`
+                        )->a( n = `value` v = client->_bind( quantity ) )->tag( `Label`
+                        )->a( n = `text` v = `product` )->tag( `Input`
+                        )->a( n = `enabled` b = abap_false
+                        )->a( n = `value`   v = product )->tag( `Button`
+                        )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                        )->a( n = `text`  v = `post` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_050.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_050.clas.abap
@@ -33,8 +33,7 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
-        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
     DATA(page) = view->ele( `Shell` )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - CSS - Ship Your Own CSS with the View`
             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
@@ -47,8 +46,10 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
         )->a( n = `showIcon` b = abap_true
         )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
-                        )->a( n = `VALUE` v = `.sapMInput {` && |\n| &&
+    " raw markup travels in the content attribute of a core:HTML leaf - the
+    " builder re-escapes it on stringify, so the literal markup is written here
+    page->tag( n = `HTML` ns = `core` )->a( n = `content` v = `<style>` && |\n| &&
+                         `.sapMInput {` && |\n| &&
                          `    height: 80px !important;` && |\n| &&
                          `    font-size: 2.5rem !important;` && |\n| &&
                          `}` && |\n| &&
@@ -80,7 +81,8 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
                          |\n| &&
                          `.sapMInputBaseInner::placeholder {` && |\n| &&
                          `    font-size: 1.4rem !important;` && |\n| &&
-                         `}` )->end( )->tag( `Button`
+                         `}` && |\n| &&
+                         `</style>` )->tag( `Button`
                 )->a( n = `press` v = client->_event( `BUTTON_POST` )
                 )->a( n = `text`  v = `post`
                 )->a( n = `class` v = `mySuperRedButton` )->tag( `Input`

--- a/src/01/z2ui5_cl_smp_app_052.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_052.clas.abap
@@ -35,29 +35,29 @@ CLASS z2ui5_cl_smp_app_052 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(lo_popover) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(lo_popover) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:f`    v = `sap.f`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    lo_popover->popover( placement    = `Right`
-                         title        = |abap2UI5 - Popover - { mv_product }|
-                         contentwidth = `20rem`
-      )->simple_form( editable = abap_false
-                      layout   = `ColumnLayout`
-      )->content( `form`
-          )->label( `Product`
-          )->text( mv_product
-          )->label( `info2`
-          )->text( `this is a text`
-          )->label( `info3`
-          )->text( `this is a text`
-          )->text( `this is a text`
-        )->get_parent( )->get_parent(
-        )->footer(
-         )->overflow_toolbar(
-            )->toolbar_spacer(
-            )->button(
-                text  = `details`
-                press = client->_event( `BUTTON_DETAILS` )
-                type  = `Emphasized` ).
+    lo_popover->ele( `Popover`
+        )->a( n = `title`        v = |abap2UI5 - Popover - { mv_product }|
+        )->a( n = `placement`    v = `Right`
+        )->a( n = `contentWidth` v = `20rem` )->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `layout`   v = `ColumnLayout`
+          )->a( n = `editable` b = abap_false )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `Product` )->tag( `Text`
+              )->a( n = `text` v = mv_product )->tag( `Label`
+              )->a( n = `text` v = `info2` )->tag( `Text`
+              )->a( n = `text` v = `this is a text` )->tag( `Label`
+              )->a( n = `text` v = `info3` )->tag( `Text`
+              )->a( n = `text` v = `this is a text` )->tag( `Text`
+              )->a( n = `text` v = `this is a text` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar` 
+              )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_DETAILS` )
+                )->a( n = `text`  v = `details`
+                )->a( n = `type`  v = `Emphasized` ).
     client->popover_display( xml   = lo_popover->stringify( )
                              by_id = id ).
 
@@ -66,41 +66,61 @@ CLASS z2ui5_cl_smp_app_052 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell( )->page( id = `page_main`
-            title               = `abap2UI5 - Popover - Open from a Table Row`
-            navbuttonpress      = client->_event_nav_app_leave( )
-            shownavbutton       = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Popover - Open from a Table Row`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    page->message_strip(
-        text     = `List report layout: a dynamic page with a table whose product links open a popover ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `List report layout: a dynamic page with a table whose product links open a popover ` &&
                    `showing details for the selected row.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page = page->dynamic_page( headerexpanded = abap_true ).
+    page = page->ele( n = `DynamicPage` ns = `f`
+        )->a( n = `headerExpanded` b = abap_true ).
 
-    DATA(cont) = page->content( `f` ).
-    DATA(tab) = cont->table( id    = `tab`
-                             items = client->_bind( val = mt_table ) ).
+    DATA(cont) = page->ele( n = `content` ns = `f` ).
+    DATA(tab) = cont->ele( `Table`
+        )->a( n = `items` v = client->_bind( val = mt_table )
+        )->a( n = `id`    v = `tab` ).
 
-    DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( `Product` ).
-    lo_columns->column( )->text( `Date` ).
-    lo_columns->column( )->text( `Name` ).
-    lo_columns->column( )->text( `Location` ).
-    lo_columns->column( )->text( `Quantity` ).
+    DATA(lo_columns) = tab->ele( `columns` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Product` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Date` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Name` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Location` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Quantity` ).
 
-    DATA(lo_cells) = tab->items( )->column_list_item( ).
-    lo_cells->link( id    = `link`
-                    text  = `{PRODUCT}`
-                    press = client->_event( val = `POPOVER_DETAIL` t_arg = VALUE #( ( `${$source>/id}` ) ( `${PRODUCT}` ) ) ) ).
-    lo_cells->text( `{CREATE_DATE}` ).
-    lo_cells->text( `{CREATE_BY}` ).
-    lo_cells->text( `{STORAGE_LOCATION}` ).
-    lo_cells->text( `{QUANTITY}` ).
+    DATA(lo_cells) = tab->ele( `items` )->ele( `ColumnListItem` ).
+    lo_cells->tag( `Link`
+        )->a( n = `text`  v = `{PRODUCT}`
+        )->a( n = `press` v = client->_event( val = `POPOVER_DETAIL` t_arg = VALUE #( ( `${$source>/id}` ) ( `${PRODUCT}` ) ) )
+        )->a( n = `id`    v = `link` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_DATE}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_BY}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{STORAGE_LOCATION}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{QUANTITY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_053.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_053.clas.abap
@@ -60,47 +60,64 @@ CLASS z2ui5_cl_smp_app_053 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell( )->page( id = `page_main`
-            title                         = `abap2UI5 - Table - Search in the Backend (SearchField)`
-            navbuttonpress                = client->_event_nav_app_leave( )
-            shownavbutton                 = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Table - Search in the Backend (SearchField)`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    page->message_strip(
-        text     = `A search field triggers a backend filter on Enter or via the Go button; the matching ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A search field triggers a backend filter on Enter or via the Go button; the matching ` &&
                    `rows are computed server-side and the table is refreshed.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(vbox) = page->vbox( ).
+    DATA(vbox) = page->ele( `VBox` ).
 
-    vbox->hbox( )->search_field(
-         value  = client->_bind( mv_search_value )
-         search = client->_event( `BUTTON_SEARCH` )
-         width = `17.5rem`
-         placeholder = `Search products`
-         id    = `SEARCH` )->button(
-         text  = `Go`
-         press = client->_event( `BUTTON_START` )
-         type  = `Emphasized` ).
+    vbox->ele( `HBox` )->tag( `SearchField`
+        )->a( n = `width`       v = `17.5rem`
+        )->a( n = `search`      v = client->_event( `BUTTON_SEARCH` )
+        )->a( n = `value`       v = client->_bind( mv_search_value )
+        )->a( n = `id`          v = `SEARCH`
+        )->a( n = `placeholder` v = `Search products` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `BUTTON_START` )
+             )->a( n = `text`  v = `Go`
+             )->a( n = `type`  v = `Emphasized` ).
 
-    DATA(tab) = vbox->table( client->_bind( val = mt_table ) ).
+    DATA(tab) = vbox->ele( `Table`
+        )->a( n = `items` v = client->_bind( val = mt_table ) ).
 
-    DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( `Product` ).
-    lo_columns->column( )->text( `Date` ).
-    lo_columns->column( )->text( `Name` ).
-    lo_columns->column( )->text( `Location` ).
-    lo_columns->column( )->text( `Quantity` ).
+    DATA(lo_columns) = tab->ele( `columns` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Product` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Date` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Name` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Location` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Quantity` ).
 
-    DATA(lo_cells) = tab->items( )->column_list_item( ).
-    lo_cells->text( `{PRODUCT}` ).
-    lo_cells->text( `{CREATE_DATE}` ).
-    lo_cells->text( `{CREATE_BY}` ).
-    lo_cells->text( `{STORAGE_LOCATION}` ).
-    lo_cells->text( `{QUANTITY}` ).
+    DATA(lo_cells) = tab->ele( `items` )->ele( `ColumnListItem` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{PRODUCT}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_DATE}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_BY}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{STORAGE_LOCATION}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{QUANTITY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_059.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_059.clas.abap
@@ -83,55 +83,72 @@ CLASS z2ui5_cl_smp_app_059 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page1) = view->shell( )->page(
-        id             = `page_main`
-        title          = `abap2UI5 - Table - Live Search with Parallel Requests`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page1) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Table - Live Search with Parallel Requests`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    page1->message_strip(
-        text     = `By default abap2UI5 handles only one backend request at a time - the app is set busy and further ` &&
+    page1->tag( `MessageStrip`
+        )->a( n = `text`     v = `By default abap2UI5 handles only one backend request at a time - the app is set busy and further ` &&
                    `requests are ignored until the running one is finished. A live search needs the opposite: only the ` &&
                    `newest request matters and older ones can be dropped. Set check_allow_multi_req on the event to ` &&
                    `allow that - type in both fields and compare.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(lo_box) = page1->hbox( class = `sapUiSmallMarginBegin` ).
+    DATA(lo_box) = page1->ele( `HBox`
+        )->a( n = `class` v = `sapUiSmallMarginBegin` ).
 
-    lo_box->vbox( )->text( `Search disabled parallel (default)`
-        )->search_field(
-            width       = `17.5rem`
-            placeholder = `Search products`
-            value       = client->_bind( mv_field )
-            livechange  = client->_event( `BUTTON_SEARCH` ) ).
+    lo_box->ele( `VBox` )->tag( `Text`
+        )->a( n = `text` v = `Search disabled parallel (default)` )->tag( `SearchField`
+            )->a( n = `width`       v = `17.5rem`
+            )->a( n = `value`       v = client->_bind( mv_field )
+            )->a( n = `placeholder` v = `Search products`
+            )->a( n = `liveChange`  v = client->_event( `BUTTON_SEARCH` ) ).
 
-    lo_box->vbox( )->text( `Search parallel`
-        )->search_field(
-            width       = `17.5rem`
-            placeholder = `Search products`
-            value       = client->_bind( mv_field )
-            livechange  = client->_event(
+    lo_box->ele( `VBox` )->tag( `Text`
+        )->a( n = `text` v = `Search parallel` )->tag( `SearchField`
+            )->a( n = `width`       v = `17.5rem`
+            )->a( n = `value`       v = client->_bind( mv_field )
+            )->a( n = `placeholder` v = `Search products`
+            )->a( n = `liveChange`  v = client->_event(
                 val    = `BUTTON_SEARCH`
                 s_ctrl = VALUE #( check_allow_multi_req = abap_true ) ) ).
 
-    DATA(tab) = page1->table( client->_bind( mt_table ) ).
-    DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( `Product` ).
-    lo_columns->column( )->text( `Date` ).
-    lo_columns->column( )->text( `Name` ).
-    lo_columns->column( )->text( `Location` ).
-    lo_columns->column( )->text( `Quantity` ).
+    DATA(tab) = page1->ele( `Table`
+        )->a( n = `items` v = client->_bind( mt_table ) ).
+    DATA(lo_columns) = tab->ele( `columns` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Product` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Date` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Name` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Location` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Quantity` ).
 
-    DATA(lo_cells) = tab->items( )->column_list_item( ).
-    lo_cells->text( `{PRODUCT}` ).
-    lo_cells->text( `{CREATE_DATE}` ).
-    lo_cells->text( `{CREATE_BY}` ).
-    lo_cells->text( `{STORAGE_LOCATION}` ).
-    lo_cells->text( `{QUANTITY}` ).
+    DATA(lo_cells) = tab->ele( `items` )->ele( `ColumnListItem` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{PRODUCT}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_DATE}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_BY}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{STORAGE_LOCATION}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{QUANTITY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_061.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_061.clas.abap
@@ -21,48 +21,44 @@ CLASS z2ui5_cl_smp_app_061 IMPLEMENTATION.
 
   METHOD set_view.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Binding - Dynamic Table Typed at Runtime (RTTI)`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Dynamic Table Typed at Runtime (RTTI)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     FIELD-SYMBOLS <tab> TYPE table.
     ASSIGN t_tab->* TO <tab>.
 
-    page->message_strip(
-        text     = `A table typed dynamically at runtime via RTTI from a DDIC table type, with editable ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A table typed dynamically at runtime via RTTI from a DDIC table type, with editable ` &&
                    `multi-select rows bound directly to the dynamically created data.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table(
-            items = client->_bind( <tab> )
-            mode  = `MultiSelect`
-        )->header_toolbar(
-            )->overflow_toolbar(
-                )->title( `Dynamic typed table`
-                )->toolbar_spacer(
-                )->button(
-                    text  = `server <-> client`
-                    press = client->_event( `SEND` )
-        )->get_parent( )->get_parent( ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( <tab> )
+        )->a( n = `mode`  v = `MultiSelect` )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                    )->a( n = `text` v = `Dynamic typed table` )->tag( `ToolbarSpacer` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `SEND` )
+                    )->a( n = `text`  v = `server <-> client` )->end( )->end( ).
 
-    tab->columns(
-        )->column(
-            )->text( `uuid` )->get_parent(
-        )->column(
-            )->text( `time` )->get_parent(
-        )->column(
-            )->text( `previous` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `uuid` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `time` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `previous` )->end( ).
 
-    tab->items( )->column_list_item( selected = `{SELKZ}`
-      )->cells(
-          )->input( `{ID}`
-          )->input( `{TIMESTAMPL}`
-          )->input( `{ID_PREV}` ).
+    tab->ele( `items` )->ele( `ColumnListItem`
+        )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Input`
+              )->a( n = `value` v = `{ID}` )->tag( `Input`
+              )->a( n = `value` v = `{TIMESTAMPL}` )->tag( `Input`
+              )->a( n = `value` v = `{ID_PREV}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_064.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_064.clas.abap
@@ -112,41 +112,49 @@ CLASS z2ui5_cl_smp_app_064 IMPLEMENTATION.
   METHOD on_init.
 
     DATA temp1 TYPE z2ui5_if_types=>ty_t_name_value.
-    DATA view TYPE REF TO z2ui5_cl_xml_view.
-    DATA page1 TYPE REF TO z2ui5_cl_xml_view.
+    DATA view TYPE REF TO z2ui5_cl_ui5_view_builder.
+    DATA page1 TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA temp5 TYPE abap_bool.
-    DATA layout TYPE REF TO z2ui5_cl_xml_view.
+    DATA layout TYPE REF TO z2ui5_cl_ui5_view_builder.
     temp1 = VALUE #( ).
 
     mv_check_enabled = abap_true.
-    view             = z2ui5_cl_xml_view=>factory( ).
+    view             = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
 
     temp5          = client->check_app_prev_stack( ).
-    page1          = view->shell( )->page( id = `page_main`
-    title          = `abap2UI5 - Timer - Progress Indicator during a Backend Call`
-    navbuttonpress = client->_event_nav_app_leave( )
-    shownavbutton  = temp5
-    class          = `sapUiContentPadding` ).
+    page1          = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Timer - Progress Indicator during a Backend Call`
+        )->a( n = `showNavButton`  b = temp5
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    page1->message_strip(
-        text     = `A ProgressIndicator driven from the backend: pressing Load runs a WAIT-delayed server ` &&
+    page1->tag( `MessageStrip`
+        )->a( n = `text`     v = `A ProgressIndicator driven from the backend: pressing Load runs a WAIT-delayed server ` &&
                    `step and re-arms a client timer (follow_up_action), advancing the bar in 25% steps until it completes.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    layout = page1->vertical_layout( class = `sapuicontentpadding`
-    width  = `100%` ).
-    layout->vbox( )->progress_indicator(
-      percentvalue = client->_bind( mv_percent )
-      displayvalue = client->_bind( screen-display_value )
-      showvalue    = abap_true
-      state        = `Success` ).
+    layout = page1->ele( n = `VerticalLayout` ns = `layout`
+        )->a( n = `class` v = `sapuicontentpadding`
+        )->a( n = `width` v = `100%` ).
+    layout->ele( `VBox` )->tag( `ProgressIndicator`
+        )->a( n = `percentValue` v = client->_bind( mv_percent )
+        )->a( n = `displayValue` v = client->_bind( screen-display_value )
+        )->a( n = `showValue`    b = abap_true
+        )->a( n = `state`        v = `Success` ).
 
-    layout->button(
-        text    = `Load`
-        press   = client->_event( `LOAD` )
-        enabled = client->_bind( mv_check_enabled ) ).
+    layout->tag( `Button`
+        )->a( n = `press`   v = client->_event( `LOAD` )
+        )->a( n = `text`    v = `Load`
+        )->a( n = `enabled` v = client->_bind( mv_check_enabled ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_065.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_065.clas.abap
@@ -17,41 +17,47 @@ CLASS z2ui5_cl_smp_app_065 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = lo_view->shell(
-        )->page(
-                title          = `abap2UI5 - Nested View - Basic Example (nest_view_display)`
-                id             = `test`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( )
-            )->header_content(
-                )->link(
-      )->get_parent( ).
+    DATA(page) = lo_view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Nested View - Basic Example (nest_view_display)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `id`             v = `test` )->ele( `headerContent` )->tag( `Link` )->end( ).
 
-    page->message_strip(
-        text     = `A main view with a nested view inside: the buttons re-render everything, only the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A main view with a nested view inside: the buttons re-render everything, only the ` &&
                    `main view, only the nested view, or refresh just the nested view's model.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->content(
-      )->button( text  = `Rerender all`
-                 press = client->_event( `ALL` )
-      )->button( text  = `Rerender Main without nest`
-                 press = client->_event( `MAIN` )
-      )->button( text  = `Rerender only nested view`
-                 press = client->_event( `NEST` )
-      )->button( text  = `Update only nested MODEL (no re-render)`
-                 press = client->_event( `NEST_MODEL` )
-      )->input( client->_bind( mv_input_main ) ).
+    page->ele( `content` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `ALL` )
+          )->a( n = `text`  v = `Rerender all` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `MAIN` )
+          )->a( n = `text`  v = `Rerender Main without nest` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `NEST` )
+          )->a( n = `text`  v = `Rerender only nested view` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `NEST_MODEL` )
+          )->a( n = `text`  v = `Update only nested MODEL (no re-render)` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( mv_input_main ) ).
 
-    DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory(
-          )->page( `Nested View`
-              )->button( text  = `event`
-                         press = client->_event( `TEST` )
-              )->input( client->_bind( mv_input_nest ) ).
+    DATA(lo_view_nested) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Page`
+              )->a( n = `title` v = `Nested View` )->tag( `Button`
+                  )->a( n = `press` v = client->_event( `TEST` )
+                  )->a( n = `text`  v = `event` )->tag( `Input`
+                  )->a( n = `value` v = client->_bind( mv_input_nest ) ).
 
     IF client->check_on_init( ).
       client->view_display( lo_view->stringify( ) ).

--- a/src/01/z2ui5_cl_smp_app_067.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_067.clas.abap
@@ -26,90 +26,91 @@ CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
       currency = `USD`.
 
     ENDIF.
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-         )->page( title          = `abap2UI5 - Binding - Currency Amounts (sap.ui.model.type.Currency)`
-                  navbuttonpress = client->_event_nav_app_leave( )
-                  shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+             )->a( n = `title`          v = `abap2UI5 - Binding - Currency Amounts (sap.ui.model.type.Currency)`
+             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Formats amounts with the sap.ui.model.type.Currency type and its format options, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Formats amounts with the sap.ui.model.type.Currency type and its format options, ` &&
                    `and shows how to strip the leading zeros from a numeric field.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( title    = `Currency`
-                       editable = abap_true
-      )->content( `form`
-         )->title( `Input`
-         )->label( `Documentation`
-         )->link( text = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency`
-                  href = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency`
-         )->label( `One field`
-         )->input(
-             |\{ parts: [ '{ client->_bind( val  = amount
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Currency`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+             )->a( n = `text` v = `Input` )->tag( `Label`
+             )->a( n = `text` v = `Documentation` )->tag( `Link`
+             )->a( n = `text` v = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency`
+             )->a( n = `href` v = `https://sapui5.hana.ondemand.com/#/entity/sap.ui.model.type.Currency` )->tag( `Label`
+             )->a( n = `text` v = `One field` )->tag( `Input`
+             )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' \}|
-         )->label( `Two field`
-         )->input(
-             |\{ parts: [ '{ client->_bind( val  = amount
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' \}| )->tag( `Label`
+             )->a( n = `text` v = `Two field` )->tag( `Input`
+             )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showMeasure: false\}  \}|
-         )->input(
-             |\{ parts: [ '{ client->_bind( val  = amount
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showMeasure: false\}  \}| 
+                                                     )->tag( `Input`
+             )->a( n = `value` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showNumber: false\} \}|
-         )->label( `Default`
-         )->text(
-             |\{ parts: [ '{ client->_bind( val  = amount
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{showNumber: false\} \}| 
+                                                     )->tag( `Label`
+             )->a( n = `text` v = `Default` )->tag( `Text`
+             )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' \}|
-         )->label( `preserveDecimals:false`
-         )->text( |\{ parts: [ '{ client->_bind( val  = amount
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' \}| )->tag( `Label`
+             )->a( n = `text` v = `preserveDecimals:false` )->tag( `Text`
+             )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                       path = abap_true ) }', '| && client->_bind(
                                                       val  = currency
                                                       path = abap_true ) &&
-                     |'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ preserveDecimals : false \} \}|
-         )->label( `currencyCode:false`
-         )->text( |\{ parts: [ '{ client->_bind( val  = amount
+                     |'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ preserveDecimals : false \} \}| )->tag( `Label`
+             )->a( n = `text` v = `currencyCode:false` )->tag( `Text`
+             )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                       path = abap_true ) }', '| && client->_bind(
                                                       val  = currency
                                                       path = abap_true ) &&
-                         |'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ currencyCode : false \} \}|
-         )->label( `style:'short'`
-         )->text(
-             |\{ parts: [ '{ client->_bind( val  = amount
+                         |'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ currencyCode : false \} \}| )->tag( `Label`
+             )->a( n = `text` v = `style:'short'` )->tag( `Text`
+             )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ style : 'short' \} \}|
-         )->label( `style:'long'`
-         )->text(
-             |\{ parts: [ '{ client->_bind( val  = amount
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{ style : 'short' \} \}| 
+                                                     )->tag( `Label`
+             )->a( n = `text` v = `style:'long'` )->tag( `Text`
+             )->a( n = `text` v = |\{ parts: [ '{ client->_bind( val  = amount
                                                  path = abap_true ) }', '{ client->_bind(
                                                  val  = currency
-                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{   style : 'long' \} \}|
-         )->label( `event`
-         )->button( text  = `send`
-                    press = client->_event( `BUTTON` ) ).
+                                                 path = abap_true ) }'],  type: 'sap.ui.model.type.Currency' , formatOptions: \{   style : 'long' \} \}| 
+                                                     )->tag( `Label`
+             )->a( n = `text` v = `event` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `BUTTON` )
+             )->a( n = `text`  v = `send` ).
 
-    page->simple_form( title    = `No Zeros`
-                       editable = abap_true
-      )->content( `form`
-      )->title( `Input`
-      )->label( `Documentation`
-      )->link( text = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue`
-         href       = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue`
-      )->label( `Numeric`
-      )->input( client->_bind( val = numeric )
-
-      )->label( `Without leading Zeros`
-
-      )->text(
-      |\{path : '{ client->_bind(
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `No Zeros`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+          )->a( n = `text` v = `Input` )->tag( `Label`
+          )->a( n = `text` v = `Documentation` )->tag( `Link`
+          )->a( n = `text` v = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue`
+          )->a( n = `href` v = `https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue` )->tag( `Label`
+          )->a( n = `text` v = `Numeric` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( val = numeric ) )->tag( `Label`
+          )->a( n = `text` v = `Without leading Zeros` )->tag( `Text`
+          )->a( n = `text` v = |\{path : '{ client->_bind(
                             val  = numeric
                             path = abap_true ) }', type : 'sap.ui.model.odata.type.String', constraints : \{  isDigitSequence : true \} \}| ).
 

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -137,99 +137,146 @@ CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
       (   n = `!<leer>` v = `!(<leer>)` )
       (   n = `<leer>`  v = `<leer>` ) ).
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table`
+        )->a( n = `xmlns:u`      v = `sap.ui.unified` ).
 
-    DATA(page1) = view->shell( )->page( id = `page_main`
-            title                = `abap2UI5 - Grid Table - Full Example with sap.ui.table`
-            navbuttonpress       = client->_event_nav_app_leave( )
-            shownavbutton        = client->check_app_prev_stack( )
-            class                = `sapUiContentPadding` ).
+    DATA(page1) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Grid Table - Full Example with sap.ui.table`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    page1->message_strip(
-        text     = `A full sap.ui.table.Table inside a DynamicPage: fixed column, row-action buttons, ` &&
+    page1->tag( `MessageStrip`
+        )->a( n = `text`     v = `A full sap.ui.table.Table inside a DynamicPage: fixed column, row-action buttons, ` &&
                    `progress-indicator and currency cells, plus backend-driven search, sort and filter events.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(page) = page1->dynamic_page( headerexpanded = abap_true ).
+    DATA(page) = page1->ele( n = `DynamicPage` ns = `f`
+        )->a( n = `headerExpanded` b = abap_true ).
 
-    DATA(header_title) = page->title( ns = `f` )->get( )->dynamic_page_title( ).
-    header_title->heading( `f` )->hbox( )->title( `Search Field` ).
-    header_title->expanded_content( `f` ).
-    header_title->snapped_content( `f` ).
+    DATA(header_title) = page->ele( n = `title` ns = `f` )->ele( n = `DynamicPageTitle` ns = `f` ).
+    header_title->ele( n = `heading` ns = `f` )->ele( `HBox` )->tag( `Title`
+        )->a( n = `text` v = `Search Field` ).
+    header_title->ele( n = `expandedContent` ns = `f` ).
+    header_title->ele( n = `snappedContent` ns = `f` ).
 
-    DATA(lo_box) = page->header( )->dynamic_page_header( abap_true
-         )->flex_box( alignitems     = `Start`
-                      justifycontent = `SpaceBetween` )->flex_box( alignitems = `Start` ).
+    DATA(lo_box) = page->ele( `header` )->ele( n = `DynamicPageHeader` ns = `f`
+        )->a( n = `pinnable` b = abap_true )->ele( `FlexBox`
+             )->a( n = `alignItems`     v = `Start`
+             )->a( n = `justifyContent` v = `SpaceBetween` )->ele( `FlexBox`
+                          )->a( n = `alignItems` v = `Start` ).
 
-    lo_box->vbox( )->text( `Search` )->search_field(
-         value  = client->_bind( mv_search_value )
-         search = client->_event( `BUTTON_SEARCH` )
-         width  = `17.5rem`
-         placeholder = `Search products`
-         id     = `SEARCH` ).
+    lo_box->ele( `VBox` )->tag( `Text`
+        )->a( n = `text` v = `Search` )->tag( `SearchField`
+        )->a( n = `width`       v = `17.5rem`
+        )->a( n = `search`      v = client->_event( `BUTTON_SEARCH` )
+        )->a( n = `value`       v = client->_bind( mv_search_value )
+        )->a( n = `id`          v = `SEARCH`
+        )->a( n = `placeholder` v = `Search products` ).
 
-    lo_box->get_parent( )->hbox( justifycontent = `End` )->button(
-        text  = `Go`
-        press = client->_event( `BUTTON_START` )
-        type  = `Emphasized` ).
+    lo_box->end( )->ele( `HBox`
+        )->a( n = `justifyContent` v = `End` )->tag( `Button`
+        )->a( n = `press` v = client->_event( `BUTTON_START` )
+        )->a( n = `text`  v = `Go`
+        )->a( n = `type`  v = `Emphasized` ).
 
-    DATA(cont) = page->content( `f` ).
+    DATA(cont) = page->ele( n = `content` ns = `f` ).
 
-    DATA(tab) = cont->ui_table( rows               = client->_bind( val = mt_table )
-                                alternaterowcolors = abap_true
-                                rowactioncount     = `2`
-                                fixedcolumncount   = `1`
-                                selectionmode      = `None`
-                                sort               = client->_event( `SORT` )
-                                filter             = client->_event( `FILTER` )
-                                customfilter       = client->_event( `CUSTOMFILTER` ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( `Products` ).
-    DATA(lo_columns) = tab->ui_columns( ).
-    lo_columns->ui_column( `4rem` )->checkbox( selected = client->_bind( lv_selkz )
-                                                       enabled  = abap_true
-                                                       select   = client->_event( `SELKZ` ) )->ui_template( )->checkbox( `{SELKZ}` ).
-    lo_columns->ui_column( width          = `5rem`
-                           sortproperty   = `ROW_ID`
-                           filterproperty = `ROW_ID` )->text( `Index` )->ui_template( )->text( `{ROW_ID}` ).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `PROCESS`
-                           filterproperty = `PROCESS` )->text( `Process Indicator`
-      )->ui_template( )->progress_indicator( class        = `sapUiSmallMarginBottom`
-                                             percentvalue = `{PROCESS}`
-                                             displayvalue = `{PROCESS} %`
-                                             showvalue    = `true`
-                                             state        = `{PROCESS_STATE}` ).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `PRODUCT`
-                           filterproperty = `PRODUCT` )->text( `Product` )->ui_template( )->input( value    = `{PRODUCT}`
-                           editable       = abap_false ).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `CREATE_DATE`
-                           filterproperty = `CREATE_DATE` )->text( `Date` )->ui_template( )->text( `{CREATE_DATE}` ).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `CREATE_BY`
-                           filterproperty = `CREATE_BY`)->text( `Name` )->ui_template( )->text( `{CREATE_BY}` ).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `STORAGE_LOCATION`
-                           filterproperty = `STORAGE_LOCATION` )->text( `Location` )->ui_template( )->text( `{STORAGE_LOCATION}`).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `QUANTITY`
-                           filterproperty = `QUANTITY` )->text( `Quantity` )->ui_template( )->text( `{QUANTITY}`).
-    lo_columns->ui_column( width          = `6rem`
-                           sortproperty   = `MEINS`
-                           filterproperty = `MEINS` )->text( `Unit` )->ui_template( )->text( `{MEINS}`).
-    lo_columns->ui_column( width          = `11rem`
-                           sortproperty   = `PRICE`
-                           filterproperty = `PRICE` )->text( `Price` )->ui_template( )->currency( value    = `{PRICE}`
-                           currency       = `{WAERS}` ).
-    lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
-      )->ui_row_action_item( type = `Navigation`
-                           press  = client->_event( val = `ROW_ACTION_ITEM_NAVIGATION` t_arg = VALUE #( ( `${ROW_ID}` ) ) )
-                          )->get_parent( )->ui_row_action_item( icon  = `sap-icon://edit`
-                                                                text  = `Edit`
-                                                                press = client->_event( val = `ROW_ACTION_ITEM_EDIT` t_arg = VALUE #( ( `${ROW_ID}` ) ) ) ).
+    DATA(tab) = cont->ele( n = `Table` ns = `table`
+        )->a( n = `rows`               v = client->_bind( val = mt_table )
+        )->a( n = `alternateRowColors` b = abap_true
+        )->a( n = `fixedColumnCount`   v = `1`
+        )->a( n = `rowActionCount`     v = `2`
+        )->a( n = `selectionMode`      v = `None`
+        )->a( n = `filter`             v = client->_event( `FILTER` )
+        )->a( n = `sort`               v = client->_event( `SORT` )
+        )->a( n = `customFilter`       v = client->_event( `CUSTOMFILTER` ) ).
+    tab->ele( n = `extension` ns = `table` )->ele( `OverflowToolbar` )->tag( `Title`
+        )->a( n = `text` v = `Products` ).
+    DATA(lo_columns) = tab->ele( n = `columns` ns = `table` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width` v = `4rem` )->tag( `CheckBox`
+        )->a( n = `selected` v = client->_bind( lv_selkz )
+        )->a( n = `enabled`  b = abap_true
+        )->a( n = `select`   v = client->_event( `SELKZ` ) )->ele( n = `template` ns = `table` )->tag( `CheckBox`
+                                                           )->a( n = `selected` v = `{SELKZ}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `5rem`
+        )->a( n = `sortProperty`   v = `ROW_ID`
+        )->a( n = `filterProperty` v = `ROW_ID` )->tag( `Text`
+                               )->a( n = `text` v = `Index` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{ROW_ID}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `PROCESS`
+        )->a( n = `filterProperty` v = `PROCESS` )->tag( `Text`
+                               )->a( n = `text` v = `Process Indicator` )->ele( n = `template` ns = `table` )->tag( `ProgressIndicator`
+          )->a( n = `class`        v = `sapUiSmallMarginBottom`
+          )->a( n = `percentValue` v = `{PROCESS}`
+          )->a( n = `displayValue` v = `{PROCESS} %`
+          )->a( n = `showValue`    v = `true`
+          )->a( n = `state`        v = `{PROCESS_STATE}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `PRODUCT`
+        )->a( n = `filterProperty` v = `PRODUCT` )->tag( `Text`
+                               )->a( n = `text` v = `Product` )->ele( n = `template` ns = `table` )->tag( `Input`
+                               )->a( n = `editable` b = abap_false
+                               )->a( n = `value`    v = `{PRODUCT}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `CREATE_DATE`
+        )->a( n = `filterProperty` v = `CREATE_DATE` )->tag( `Text`
+                               )->a( n = `text` v = `Date` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{CREATE_DATE}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `CREATE_BY`
+        )->a( n = `filterProperty` v = `CREATE_BY` )->tag( `Text`
+                               )->a( n = `text` v = `Name` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{CREATE_BY}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `STORAGE_LOCATION`
+        )->a( n = `filterProperty` v = `STORAGE_LOCATION` )->tag( `Text`
+                               )->a( n = `text` v = `Location` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{STORAGE_LOCATION}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `QUANTITY`
+        )->a( n = `filterProperty` v = `QUANTITY` )->tag( `Text`
+                               )->a( n = `text` v = `Quantity` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{QUANTITY}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `6rem`
+        )->a( n = `sortProperty`   v = `MEINS`
+        )->a( n = `filterProperty` v = `MEINS` )->tag( `Text`
+                               )->a( n = `text` v = `Unit` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{MEINS}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `11rem`
+        )->a( n = `sortProperty`   v = `PRICE`
+        )->a( n = `filterProperty` v = `PRICE` )->tag( `Text`
+                               )->a( n = `text` v = `Price` )->ele( n = `template` ns = `table` )->ele( n = `Currency` ns = `u`
+                               )->a( n = `value`    v = `{PRICE}`
+                               )->a( n = `currency` v = `{WAERS}` ).
+    lo_columns->end( )->ele( n = `rowActionTemplate` ns = `table` )->ele( n = `RowAction` ns = `table` )->ele( n = `RowActionItem` ns = `table`
+          )->a( n = `type`  v = `Navigation`
+          )->a( n = `press` v = client->_event( val = `ROW_ACTION_ITEM_NAVIGATION` t_arg = VALUE #( ( `${ROW_ID}` ) ) ) 
+          )->end( )->ele( n = `RowActionItem` ns = `table`
+                              )->a( n = `icon`  v = `sap-icon://edit`
+                              )->a( n = `text`  v = `Edit`
+                              )->a( n = `press` v = client->_event( val = `ROW_ACTION_ITEM_EDIT` t_arg = VALUE #( ( `${ROW_ID}` ) ) ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_071.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_071.clas.abap
@@ -64,38 +64,41 @@ CLASS z2ui5_cl_smp_app_071 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Binding - Model setSizeLimit for Large Tables`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Model setSizeLimit for Large Tables`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A ComboBox bound to a large internal table: adjust the model's setSizeLimit to ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A ComboBox bound to a large internal table: adjust the model's setSizeLimit to ` &&
                    `control how many of the entries the control actually renders.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( title = `Set Size Limit` editable = abap_true
-        )->content( `form`
-            )->label( `setSizeLimit`
-            )->input( client->_bind( set_size_limit )
-            )->button(
-                text  = `update size limit`
-                press = client->_event( val = `UPDATE` )
-            )->label( `Number of Entries`
-            )->input( client->_bind( combo_number )
-            )->button(
-                text  = `update number entries`
-                press = client->_event( val = `UPDATE_MODEL` )
-            )->label( `demo`
-            )->combobox( items = client->_bind( t_combo )
-               )->item(
-                   key  = `{KEY}`
-                   text = `{TEXT}` ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Set Size Limit`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `setSizeLimit` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( set_size_limit ) )->tag( `Button`
+                )->a( n = `press` v = client->_event( val = `UPDATE` )
+                )->a( n = `text`  v = `update size limit` )->tag( `Label`
+                )->a( n = `text` v = `Number of Entries` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( combo_number ) )->tag( `Button`
+                )->a( n = `press` v = client->_event( val = `UPDATE_MODEL` )
+                )->a( n = `text`  v = `update number entries` )->tag( `Label`
+                )->a( n = `text` v = `demo` )->ele( `ComboBox`
+                )->a( n = `items` v = client->_bind( t_combo ) )->tag( n = `Item` ns = `core`
+                   )->a( n = `key`  v = `{KEY}`
+                   )->a( n = `text` v = `{TEXT}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_073.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_073.clas.abap
@@ -17,27 +17,31 @@ CLASS z2ui5_cl_smp_app_073 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Browser - Open a URL in a New Tab`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Browser - Open a URL in a New Tab`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Press the button to open the app's own URL in a new browser tab: the backend builds the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Press the button to open the app's own URL in a new browser tab: the backend builds the ` &&
                    `URL and the open_new_tab front-end action launches it.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Form Title`
-        editable = abap_true
-        )->content( `form`
-            )->button(
-                text  = `open new tab`
-                press = client->_event( val = `BUTTON_OPEN_NEW_TAB` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Form Title`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Button`
+                )->a( n = `press` v = client->_event( val = `BUTTON_OPEN_NEW_TAB` )
+                )->a( n = `text`  v = `open new tab` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -72,50 +72,52 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - File - Upload to the Backend`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - File - Upload to the Backend`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The file_uploader custom control returns the picked file as a base64 data URL; the backend ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The file_uploader custom control returns the picked file as a base64 data URL; the backend ` &&
                    `strips the prefix, decodes the payload and shows the file content in a message box.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     IF table IS NOT INITIAL.
 
       FIELD-SYMBOLS <table> TYPE table.
       ASSIGN table->* TO <table>.
 
-      DATA(tab) = page->table( client->_bind( <table> )
-          )->header_toolbar(
-              )->overflow_toolbar(
-                  )->title( `CSV Content`
-                  )->toolbar_spacer(
-          )->get_parent( )->get_parent( ).
+      DATA(tab) = page->ele( `Table`
+          )->a( n = `items` v = client->_bind( <table> ) )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                      )->a( n = `text` v = `CSV Content` )->tag( `ToolbarSpacer` )->end( )->end( ).
 
       DATA(fields)  = z2ui5_cl_smp_context=>rtti_get_t_attri_by_any( <table> ).
-      DATA(columns) = tab->columns( ).
-      DATA(cells)   = tab->items( )->column_list_item( )->cells( ).
+      DATA(columns) = tab->ele( `columns` ).
+      DATA(cells)   = tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` ).
 
       LOOP AT fields REFERENCE INTO DATA(field).
-        columns->column( )->text( field->name ).
-        cells->text( |\{{ field->name }\}| ).
+        columns->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = field->name ).
+        cells->tag( `Text`
+            )->a( n = `text` v = |\{{ field->name }\}| ).
       ENDLOOP.
 
     ENDIF.
 
-    page->footer(
-        )->overflow_toolbar(
-            )->_z2ui5( )->file_uploader(
-                value       = client->_bind( file )
-                path        = client->_bind( filepath )
-                placeholder = `filepath here...`
-                upload      = client->_event( `UPLOAD` ) ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( n = `FileUploader` ns = `z2ui5`
+                )->a( n = `placeholder` v = `filepath here...`
+                )->a( n = `upload`      v = client->_event( `UPLOAD` )
+                )->a( n = `path`        v = client->_bind( filepath )
+                )->a( n = `value`       v = client->_bind( file ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -77,7 +77,8 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
         )->a( n = `title`          v = `abap2UI5 - File - Upload to the Backend`
@@ -85,7 +86,7 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
         )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `The file_uploader custom control returns the picked file as a base64 data URL; the backend ` &&
+        )->a( n = `text` v = `The file_uploader custom control returns the picked file as a base64 data URL; the backend ` &&
                    `strips the prefix, decodes the payload and shows the file content in a message box.`
         )->a( n = `type`     v = `Information`
         )->a( n = `showIcon` b = abap_true

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -31,52 +31,55 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-      view           = view->shell( )->page( id = `page_main`
-      title          = `abap2UI5 - Control - MultiInput with Tokens`
-      navbuttonpress = client->_event_nav_app_leave( )
-      shownavbutton  = client->check_app_prev_stack( ) ).
+      view           = view->ele( `Shell` )->ele( `Page`
+          )->a( n = `title`          v = `abap2UI5 - Control - MultiInput with Tokens`
+          )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+          )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+          )->a( n = `id`             v = `page_main` ).
 
-      view->message_strip(
-          text     = `The multiinput_ext custom control extends a sap.m.MultiInput so that added and removed ` &&
+      view->tag( `MessageStrip`
+          )->a( n = `text`     v = `The multiinput_ext custom control extends a sap.m.MultiInput so that added and removed ` &&
                      `tokens are reported back to ABAP, where the token table and the linked list are updated.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      view->_z2ui5( )->multiinput_ext(
-                            addedtokens   = client->_bind( mt_tokens_added )
-                            removedtokens = client->_bind( mt_tokens_removed )
-                            change        = client->_event( `UPDATE_BACKEND` )
-                            multiinputid  = `test` ).
+      view->tag( n = `MultiInputExt` ns = `z2ui5`
+          )->a( n = `MultiInputId`  v = `test`
+          )->a( n = `change`        v = client->_event( `UPDATE_BACKEND` )
+          )->a( n = `addedTokens`   v = client->_bind( mt_tokens_added )
+          )->a( n = `removedTokens` v = client->_bind( mt_tokens_removed ) ).
 
-      view->multi_input(
-                            id     = `test`
-                            tokens = client->_bind( mt_token )
-                       )->tokens(
-                           )->token( key      = `{KEY}`
-                                     text     = `{TEXT}`
-                                     visible  = `{VISIBLE}`
-                                     selected = `{SELKZ}`
-                                     editable = `{EDITABLE}` ).
+      view->ele( `MultiInput`
+          )->a( n = `tokens` v = client->_bind( mt_token )
+          )->a( n = `id`     v = `test` )->ele( `tokens` )->tag( `Token`
+                               )->a( n = `key`      v = `{KEY}`
+                               )->a( n = `text`     v = `{TEXT}`
+                               )->a( n = `selected` v = `{SELKZ}`
+                               )->a( n = `visible`  v = `{VISIBLE}`
+                               )->a( n = `editable` v = `{EDITABLE}` ).
 
-      DATA(tab) = view->table(
-        items = client->_bind( mt_token )
-        mode  = `MultiSelect` ).
+      DATA(tab) = view->ele( `Table`
+          )->a( n = `items` v = client->_bind( mt_token )
+          )->a( n = `mode`  v = `MultiSelect` ).
 
-      tab->columns(
-        )->column(
-           )->text( `KEY` )->get_parent(
-        )->column(
-           )->text( `TEXT` ).
+      tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+               )->a( n = `text` v = `KEY` )->end( )->ele( `Column` )->tag( `Text`
+               )->a( n = `text` v = `TEXT` ).
 
-      tab->items( )->column_list_item( selected = `{SELKZ}`
-        )->cells(
-            )->input( value   = `{KEY}`
-                      enabled = `{EDITABLE}`
-            )->input( value   = `{TEXT}`
-                      enabled = `{EDITABLE}`).
+      tab->ele( `items` )->ele( `ColumnListItem`
+          )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Input`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{KEY}` )->tag( `Input`
+                )->a( n = `enabled` v = `{EDITABLE}`
+                )->a( n = `value`   v = `{TEXT}` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -36,7 +36,8 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
           )->a( n = `height`       v = `100%`
           )->a( n = `xmlns`        v = `sap.m`
           )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
       view           = view->ele( `Shell` )->ele( `Page`
           )->a( n = `title`          v = `abap2UI5 - Control - MultiInput with Tokens`
@@ -45,7 +46,7 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
           )->a( n = `id`             v = `page_main` ).
 
       view->tag( `MessageStrip`
-          )->a( n = `text`     v = `The multiinput_ext custom control extends a sap.m.MultiInput so that added and removed ` &&
+          )->a( n = `text` v = `The multiinput_ext custom control extends a sap.m.MultiInput so that added and removed ` &&
                      `tokens are reported back to ABAP, where the token table and the linked list are updated.`
           )->a( n = `type`     v = `Information`
           )->a( n = `showIcon` b = abap_true

--- a/src/01/z2ui5_cl_smp_app_081.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_081.clas.abap
@@ -38,22 +38,20 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
-    view->popover(
-                  title     = `Popover Title`
-                  placement = mv_placement
-              )->footer( )->overflow_toolbar(
-                  )->toolbar_spacer(
-                  )->button(
-                      text  = `Cancel`
-                      press = client->_event( `BUTTON_CANCEL` )
-                  )->button(
-                      text  = `Confirm`
-                      press = client->_event( `BUTTON_CONFIRM` )
-                      type  = `Emphasized`
-                )->get_parent( )->get_parent(
-            )->text( `make an input here:`
-            )->input( `abcd` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
+    view->ele( `Popover`
+        )->a( n = `title`     v = `Popover Title`
+        )->a( n = `placement` v = mv_placement )->ele( `footer` )->ele( `OverflowToolbar` )->tag( `ToolbarSpacer` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BUTTON_CANCEL` )
+                      )->a( n = `text`  v = `Cancel` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BUTTON_CONFIRM` )
+                      )->a( n = `text`  v = `Confirm`
+                      )->a( n = `type`  v = `Emphasized` )->end( )->end( )->tag( `Text`
+                )->a( n = `text` v = `make an input here:` )->tag( `Input`
+                )->a( n = `value` v = `abcd` ).
 
     client->popover_display(
       xml   = view->stringify( )
@@ -64,18 +62,19 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
 
   METHOD popover_list_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
-    view->popover(
-                  title     = `Popover Title`
-                  placement = mv_placement
-              )->list(
-                items           = client->_bind( mt_tab )
-                selectionchange = client->_event( val = `SEL_CHANGE` )
-                mode            = `SingleSelectMaster`
-                 )->standard_list_item(
-                  title       = `{ID}`
-                  description = `{NAME}`
-                  selected    = `{SELECTED}` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
+    view->ele( `Popover`
+        )->a( n = `title`     v = `Popover Title`
+        )->a( n = `placement` v = mv_placement )->ele( `List`
+                  )->a( n = `items`           v = client->_bind( mt_tab )
+                  )->a( n = `mode`            v = `SingleSelectMaster`
+                  )->a( n = `selectionChange` v = client->_event( val = `SEL_CHANGE` ) )->tag( `StandardListItem`
+                     )->a( n = `title`       v = `{ID}`
+                     )->a( n = `description` v = `{NAME}`
+                     )->a( n = `selected`    v = `{SELECTED}` ).
 
     client->popover_display(
       xml   = view->stringify( )
@@ -86,54 +85,51 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popover - Select from a List`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popover - Select from a List`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Opens a Popover anchored to a button, showing a selectable list inside it; the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Opens a Popover anchored to a button, showing a selectable list inside it; the ` &&
                    `segmented button chooses on which side the popover appears.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Popover`
-        editable = abap_true
-              )->content( `form`
-                  )->title( `Input`
-                  )->label( `Link`
-                  )->link( text = `Documentation UI5 Popover Control`
-                           href = `https://openui5.hana.ondemand.com/entity/sap.m.Popover`
-                  )->label( `placement`
-                  )->segmented_button( client->_bind( mv_placement )
-                        )->items(
-                        )->segmented_button_item(
-                                key  = `Left`
-                                icon = `sap-icon://add-favorite`
-                                text = `Left`
-                        )->segmented_button_item(
-                                key  = `Top`
-                                icon = `sap-icon://accept`
-                                text = `Top`
-                        )->segmented_button_item(
-                                key  = `Bottom`
-                                icon = `sap-icon://accept`
-                                text = `Bottom`
-                        )->segmented_button_item(
-                                key  = `Right`
-                                icon = `sap-icon://attachment`
-                                text = `Right`
-                  )->get_parent( )->get_parent(
-                  )->label( `popover`
-                  )->button(
-                      text  = `show popover with list`
-                      press = client->_event( `POPOVER_LIST` )
-                      id    = `TEST` ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Popover`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                      )->a( n = `text` v = `Input` )->tag( `Label`
+                      )->a( n = `text` v = `Link` )->tag( `Link`
+                      )->a( n = `text` v = `Documentation UI5 Popover Control`
+                      )->a( n = `href` v = `https://openui5.hana.ondemand.com/entity/sap.m.Popover` )->tag( `Label`
+                      )->a( n = `text` v = `placement` )->ele( `SegmentedButton`
+                      )->a( n = `selectedKey` v = client->_bind( mv_placement ) )->ele( `items` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://add-favorite`
+                            )->a( n = `key`  v = `Left`
+                            )->a( n = `text` v = `Left` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://accept`
+                            )->a( n = `key`  v = `Top`
+                            )->a( n = `text` v = `Top` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://accept`
+                            )->a( n = `key`  v = `Bottom`
+                            )->a( n = `text` v = `Bottom` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://attachment`
+                            )->a( n = `key`  v = `Right`
+                            )->a( n = `text` v = `Right` )->end( )->end( )->tag( `Label`
+                      )->a( n = `text` v = `popover` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `POPOVER_LIST` )
+                      )->a( n = `text`  v = `show popover with list`
+                      )->a( n = `id`    v = `TEST` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -49,47 +49,51 @@ CLASS z2ui5_cl_smp_app_088 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell( )->page(
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( )
-        title          = `abap2UI5 - Control - Switch NavContainer Page by ID`
-       )->content( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Control - Switch NavContainer Page by ID`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( `content` ).
 
-    page->message_strip(
-        text     = `Selecting a tab in the IconTabHeader switches the NavContainer page on the client via the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Selecting a tab in the IconTabHeader switches the NavContainer page on the client via the ` &&
                    `generic CONTROL_BY_ID front-end action (whitelisted method 'to'), without a backend roundtrip.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->icon_tab_header( selectedkey                   = client->_bind( mv_selected_key )
-                                                  select = client->follow_up_action( val   = client->cs_event-control_by_id
+    page->ele( `IconTabHeader`
+        )->a( n = `selectedKey` v = client->_bind( mv_selected_key )
+        )->a( n = `select`      v = client->follow_up_action( val   = client->cs_event-control_by_id
                                                                                      t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
-                                                  mode   = `Inline`
-                                  )->items(
-                                    )->icon_tab_filter( key  = `page1`
-                                                        text = `Home` )->get_parent(
-                                    )->icon_tab_filter( key  = `page2`
-                                                        text = `Applications` )->get_parent(
-                                    )->icon_tab_filter( key  = `page3`
-                                                        text = `Users and Groups` ).
+        )->a( n = `mode`        v = `Inline` )->ele( `items` )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Home`
+                                        )->a( n = `key`  v = `page1` )->end( )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Applications`
+                                        )->a( n = `key`  v = `page2` )->end( )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Users and Groups`
+                                        )->a( n = `key`  v = `page3` ).
 
-    page->nav_container( id                    = `NavCon`
-                         initialpage           = `page1`
-                         defaulttransitionname = `flip`
-                                     )->pages(
-                                     )->page(
-                                       title = `first page`
-                                       id    = `page1`
-                                    )->get_parent(
-                                     )->page(
-                                       title = `second page`
-                                       id    = `page2`
-                                    )->get_parent(
-                                     )->page(
-                                       title = `third page`
-                                       id    = `page3` ).
+    page->ele( `NavContainer`
+        )->a( n = `initialPage`           v = `page1`
+        )->a( n = `id`                    v = `NavCon`
+        )->a( n = `defaultTransitionName` v = `flip` )->ele( `pages` )->ele( `Page`
+                                         )->a( n = `title` v = `first page`
+                                         )->a( n = `id`    v = `page1` )->end( )->ele( `Page`
+                                         )->a( n = `title` v = `second page`
+                                         )->a( n = `id`    v = `page2` )->end( )->ele( `Page`
+                                         )->a( n = `title` v = `third page`
+                                         )->a( n = `id`    v = `page3` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_097.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_097.clas.abap
@@ -35,30 +35,49 @@ CLASS z2ui5_cl_smp_app_097 IMPLEMENTATION.
 
   METHOD view_display_detail.
 
-    DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view_nested) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
 
-    DATA(page) = lo_view_nested->page( `Nested View` ).
+    DATA(page) = lo_view_nested->ele( `Page`
+        )->a( n = `title` v = `Nested View` ).
 
-    DATA(tab) = page->ui_table( rows               = client->_bind( val = t_tab2 )
-                                alternaterowcolors = abap_true
-                                rowactioncount     = `1`
-                                fixedcolumncount   = `1`
-                                selectionmode      = `None`
-                                sort               = client->_event( `SORT` )
-                                filter             = client->_event( `FILTER` )
-                                customfilter       = client->_event( `CUSTOMFILTER` ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( `Products` ).
-    DATA(lo_columns) = tab->ui_columns( ).
+    DATA(tab) = page->ele( n = `Table` ns = `table`
+        )->a( n = `rows`               v = client->_bind( val = t_tab2 )
+        )->a( n = `alternateRowColors` b = abap_true
+        )->a( n = `fixedColumnCount`   v = `1`
+        )->a( n = `rowActionCount`     v = `1`
+        )->a( n = `selectionMode`      v = `None`
+        )->a( n = `filter`             v = client->_event( `FILTER` )
+        )->a( n = `sort`               v = client->_event( `SORT` )
+        )->a( n = `customFilter`       v = client->_event( `CUSTOMFILTER` ) ).
+    tab->ele( n = `extension` ns = `table` )->ele( `OverflowToolbar` )->tag( `Title`
+        )->a( n = `text` v = `Products` ).
+    DATA(lo_columns) = tab->ele( n = `columns` ns = `table` ).
 
-    lo_columns->ui_column( sortproperty                  = `TITLE`
-                                          filterproperty = `TITLE` )->text( `Index` )->ui_template( )->text( `{TITLE}` ).
-    lo_columns->ui_column( sortproperty   = `DESCR`
-                           filterproperty = `DESCR` )->text( `DESCR` )->ui_template( )->text( `{DESCR}` ).
-    lo_columns->ui_column( sortproperty   = `INFO`
-                           filterproperty = `INFO` )->text( `INFO` )->ui_template( )->text( `{INFO}` ).
-    lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
-       )->ui_row_action_item( icon = `sap-icon://delete`
-                           press   = client->_event( val = `ROW_DELETE` t_arg = VALUE #( ( `${UUID}` ) ) ) ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `TITLE`
+        )->a( n = `filterProperty` v = `TITLE` )->tag( `Text`
+                                              )->a( n = `text` v = `Index` )->ele( n = `template` ns = `table` )->tag( `Text`
+                                              )->a( n = `text` v = `{TITLE}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `DESCR`
+        )->a( n = `filterProperty` v = `DESCR` )->tag( `Text`
+                               )->a( n = `text` v = `DESCR` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{DESCR}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `INFO`
+        )->a( n = `filterProperty` v = `INFO` )->tag( `Text`
+                               )->a( n = `text` v = `INFO` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{INFO}` ).
+    lo_columns->end( )->ele( n = `rowActionTemplate` ns = `table` )->ele( n = `RowAction` ns = `table` )->ele( n = `RowActionItem` ns = `table`
+           )->a( n = `icon`  v = `sap-icon://delete`
+           )->a( n = `press` v = client->_event( val = `ROW_DELETE` t_arg = VALUE #( ( `${UUID}` ) ) ) ).
 
     client->nest_view_display(
       val            = lo_view_nested->stringify( )
@@ -71,36 +90,42 @@ CLASS z2ui5_cl_smp_app_097 IMPLEMENTATION.
 
   METHOD view_display_master.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-       )->page(
-          title          = `abap2UI5 - Nested View - Master-Detail with FlexibleColumnLayout`
-          navbuttonpress = client->_event_nav_app_leave( )
-          shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` )->ele( `Shell` )->ele( `Page`
+           )->a( n = `title`          v = `abap2UI5 - Nested View - Master-Detail with FlexibleColumnLayout`
+           )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+           )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A master-detail screen built with FlexibleColumnLayout: select a list row and its ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A master-detail screen built with FlexibleColumnLayout: select a list row and its ` &&
                    `detail opens in a second column as a nested view with a table.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(col_layout) = page->flexible_column_layout( layout = client->_bind( mv_layout )
-                                                     id     = `test` ).
+    DATA(col_layout) = page->ele( n = `FlexibleColumnLayout` ns = `f`
+        )->a( n = `layout` v = client->_bind( mv_layout )
+        )->a( n = `id`     v = `test` ).
 
-    DATA(lr_master) = col_layout->begin_column_pages( ).
+    DATA(lr_master) = col_layout->ele( n = `beginColumnPages` ns = `f` ).
 
-    DATA(lr_list) = lr_master->list(
-          headertext      = `List Output`
-          items           = client->_bind( val = t_tab )
-          mode            = `SingleSelectMaster`
-          selectionchange = client->_event( `SELCHANGE` )
-          )->standard_list_item(
-              title       = `{TITLE}`
-              description = `{DESCR}`
-              icon        = `{ICON}`
-              info        = `{INFO}`
-              press       = client->_event( `TEST` )
-              selected    = `{SELECTED}` ).
+    DATA(lr_list) = lr_master->ele( `List`
+        )->a( n = `headerText`      v = `List Output`
+        )->a( n = `items`           v = client->_bind( val = t_tab )
+        )->a( n = `mode`            v = `SingleSelectMaster`
+        )->a( n = `selectionChange` v = client->_event( `SELCHANGE` ) )->tag( `StandardListItem`
+              )->a( n = `title`       v = `{TITLE}`
+              )->a( n = `description` v = `{DESCR}`
+              )->a( n = `icon`        v = `{ICON}`
+              )->a( n = `info`        v = `{INFO}`
+              )->a( n = `press`       v = client->_event( `TEST` )
+              )->a( n = `selected`    v = `{SELECTED}` ).
 
     client->view_display( lr_list->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_098.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_098.clas.abap
@@ -40,30 +40,49 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
 
   METHOD view_display_detail.
 
-    DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view_nested) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
 
-    DATA(page) = lo_view_nested->page( `Nested View` ).
+    DATA(page) = lo_view_nested->ele( `Page`
+        )->a( n = `title` v = `Nested View` ).
 
-    DATA(tab) = page->ui_table( rows               = client->_bind( val = t_tab2 )
-                                alternaterowcolors = abap_true
-                                rowactioncount     = `1`
-                                fixedcolumncount   = `1`
-                                selectionmode      = `None`
-                                sort               = client->_event( `SORT` )
-                                filter             = client->_event( `FILTER` )
-                                customfilter       = client->_event( `CUSTOMFILTER` ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( `Products` ).
-    DATA(lo_columns) = tab->ui_columns( ).
+    DATA(tab) = page->ele( n = `Table` ns = `table`
+        )->a( n = `rows`               v = client->_bind( val = t_tab2 )
+        )->a( n = `alternateRowColors` b = abap_true
+        )->a( n = `fixedColumnCount`   v = `1`
+        )->a( n = `rowActionCount`     v = `1`
+        )->a( n = `selectionMode`      v = `None`
+        )->a( n = `filter`             v = client->_event( `FILTER` )
+        )->a( n = `sort`               v = client->_event( `SORT` )
+        )->a( n = `customFilter`       v = client->_event( `CUSTOMFILTER` ) ).
+    tab->ele( n = `extension` ns = `table` )->ele( `OverflowToolbar` )->tag( `Title`
+        )->a( n = `text` v = `Products` ).
+    DATA(lo_columns) = tab->ele( n = `columns` ns = `table` ).
 
-    lo_columns->ui_column( sortproperty                  = `TITLE`
-                                          filterproperty = `TITLE` )->text( `Index` )->ui_template( )->text( `{TITLE}` ).
-    lo_columns->ui_column( sortproperty   = `DESCR`
-                           filterproperty = `DESCR` )->text( `DESCR` )->ui_template( )->text( `{DESCR}` ).
-    lo_columns->ui_column( sortproperty   = `INFO`
-                           filterproperty = `INFO`)->text( `INFO` )->ui_template( )->text( `{INFO}` ).
-    lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
-       )->ui_row_action_item( type = `Navigation` "icon = `sap-icon://navigation-right-arrow`
-                           press   = client->_event( val = `ROW_NAVIGATE` t_arg = VALUE #( ( `${TITLE}` ) ) ) ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `TITLE`
+        )->a( n = `filterProperty` v = `TITLE` )->tag( `Text`
+                                              )->a( n = `text` v = `Index` )->ele( n = `template` ns = `table` )->tag( `Text`
+                                              )->a( n = `text` v = `{TITLE}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `DESCR`
+        )->a( n = `filterProperty` v = `DESCR` )->tag( `Text`
+                               )->a( n = `text` v = `DESCR` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{DESCR}` ).
+    lo_columns->ele( n = `Column` ns = `table`
+        )->a( n = `sortProperty`   v = `INFO`
+        )->a( n = `filterProperty` v = `INFO` )->tag( `Text`
+                               )->a( n = `text` v = `INFO` )->ele( n = `template` ns = `table` )->tag( `Text`
+                               )->a( n = `text` v = `{INFO}` ).
+    lo_columns->end( )->ele( n = `rowActionTemplate` ns = `table` )->ele( n = `RowAction` ns = `table` )->ele( n = `RowActionItem` ns = `table`
+           )->a( n = `type`  v = `Navigation` "icon = `sap-icon://navigation-right-arrow`
+           )->a( n = `press` v = client->_event( val = `ROW_NAVIGATE` t_arg = VALUE #( ( `${TITLE}` ) ) ) ).
 
     client->nest_view_display(
       val            = lo_view_nested->stringify( )
@@ -76,14 +95,22 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
 
   METHOD view_display_detail_detail.
 
-    DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view_nested) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
 
-    DATA(page) = lo_view_nested->page( `Nested View` ).
+    DATA(page) = lo_view_nested->ele( `Page`
+        )->a( n = `title` v = `Nested View` ).
 
-    page = page->text( client->_bind( mv_title )
-       )->button(
-           text  = `frontend event`
-           press = client->_event( `NN_VIEW` ) ).
+    page = page->tag( `Text`
+        )->a( n = `text` v = client->_bind( mv_title ) )->tag( `Button`
+           )->a( n = `press` v = client->_event( `NN_VIEW` )
+           )->a( n = `text`  v = `frontend event` ).
 
     client->nest2_view_display(
       val            = lo_view_nested->stringify( )
@@ -96,37 +123,43 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
 
   METHOD view_display_master.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-       )->page(
-          showheader     = xsdbool( abap_false = client->get( )-check_launchpad_active )
-          title          = `abap2UI5 - Nested View - Three Columns with FlexibleColumnLayout`
-          navbuttonpress = client->_event_nav_app_leave( )
-          shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` )->ele( `Shell` )->ele( `Page`
+           )->a( n = `title`          v = `abap2UI5 - Nested View - Three Columns with FlexibleColumnLayout`
+           )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+           )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+           )->a( n = `showHeader`     b = xsdbool( abap_false = client->get( )-check_launchpad_active ) ).
 
-    page->message_strip(
-        text     = `A three-column FlexibleColumnLayout: select a row to open the detail column, then ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A three-column FlexibleColumnLayout: select a row to open the detail column, then ` &&
                    `navigate on to open a third, deeply nested column.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(col_layout) = page->flexible_column_layout( layout = client->_bind( mv_layout )
-                                                     id     = `test` ).
+    DATA(col_layout) = page->ele( n = `FlexibleColumnLayout` ns = `f`
+        )->a( n = `layout` v = client->_bind( mv_layout )
+        )->a( n = `id`     v = `test` ).
 
-    DATA(lr_master) = col_layout->begin_column_pages( ).
+    DATA(lr_master) = col_layout->ele( n = `beginColumnPages` ns = `f` ).
 
-    DATA(lr_list) = lr_master->list(
-          headertext      = `List Output`
-          items           = client->_bind( val = t_tab )
-          mode            = `SingleSelectMaster`
-          selectionchange = client->_event( `SELCHANGE` )
-          )->standard_list_item(
-              title       = `{TITLE}`
-              description = `{DESCR}`
-              icon        = `{ICON}`
-              info        = `{INFO}`
-              press       = client->_event( `TEST` )
-              selected    = `{SELECTED}` ).
+    DATA(lr_list) = lr_master->ele( `List`
+        )->a( n = `headerText`      v = `List Output`
+        )->a( n = `items`           v = client->_bind( val = t_tab )
+        )->a( n = `mode`            v = `SingleSelectMaster`
+        )->a( n = `selectionChange` v = client->_event( `SELCHANGE` ) )->tag( `StandardListItem`
+              )->a( n = `title`       v = `{TITLE}`
+              )->a( n = `description` v = `{DESCR}`
+              )->a( n = `icon`        v = `{ICON}`
+              )->a( n = `info`        v = `{INFO}`
+              )->a( n = `press`       v = client->_event( `TEST` )
+              )->a( n = `selected`    v = `{SELECTED}` ).
 
     client->view_display( lr_list->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_104.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_104.clas.abap
@@ -77,7 +77,10 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
         )->a( n = `xmlns:f`      v = `sap.f`
-        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+        )->a( n = `xmlns:layout` v = `sap.ui.layout`
+        " the sub-apps build into this shared root, so their prefixes are
+        " declared here - z2ui5_cl_smp_app_105 injects a form:SimpleForm
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
     DATA(page) = view_nested->ele( `Page`
         )->a( n = `title` v = `Nested View` ).
     grid_sub = page->ele( n = `Grid` ns = `layout`

--- a/src/01/z2ui5_cl_smp_app_104.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_104.clas.abap
@@ -21,8 +21,8 @@ CLASS z2ui5_cl_smp_app_104 DEFINITION PUBLIC.
     DATA t_tab TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
 
     DATA layout      TYPE string.
-    DATA grid_sub    TYPE REF TO z2ui5_cl_xml_view.
-    DATA view_nested TYPE REF TO z2ui5_cl_xml_view.
+    DATA grid_sub    TYPE REF TO z2ui5_cl_ui5_view_builder.
+    DATA view_nested TYPE REF TO z2ui5_cl_ui5_view_builder.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
@@ -70,46 +70,60 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
 
   METHOD view_display_detail.
 
-    view_nested = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view_nested->page( `Nested View` ).
-    grid_sub = page->grid( `L12 M12 S12`
-        )->content( `layout` ).
+    view_nested = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view_nested->ele( `Page`
+        )->a( n = `title` v = `Nested View` ).
+    grid_sub = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L12 M12 S12` )->ele( n = `content` ns = `layout` ).
 
   ENDMETHOD.
 
 
   METHOD view_display_master.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-       )->page(
-          title          = `abap2UI5 - Nested View - Embed Another App's View`
-          navbuttonpress = client->_event_nav_app_leave( )
-          shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` )->ele( `Shell` )->ele( `Page`
+           )->a( n = `title`          v = `abap2UI5 - Nested View - Embed Another App's View`
+           )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+           )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Selecting a list row instantiates another abap2UI5 app by its class name and ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Selecting a list row instantiates another abap2UI5 app by its class name and ` &&
                    `embeds that app's own view into the detail column.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(col_layout) = page->flexible_column_layout( layout = client->_bind( layout )
-                                                     id     = `test` ).
+    DATA(col_layout) = page->ele( n = `FlexibleColumnLayout` ns = `f`
+        )->a( n = `layout` v = client->_bind( layout )
+        )->a( n = `id`     v = `test` ).
 
-    DATA(master) = col_layout->begin_column_pages( ).
+    DATA(master) = col_layout->ele( n = `beginColumnPages` ns = `f` ).
 
-    DATA(list) = master->list(
-          headertext      = `List Output`
-          items           = client->_bind( val = t_tab )
-          mode            = `SingleSelectMaster`
-          selectionchange = client->_event( val = `SELCHANGE` )
-          )->standard_list_item(
-              title       = `{TITLE}`
-              description = `{DESCR}`
-              icon        = `{ICON}`
-              info        = `{INFO}`
-              press       = client->_event( `TEST` )
-              selected    = `{SELECTED}` ).
+    DATA(list) = master->ele( `List`
+        )->a( n = `headerText`      v = `List Output`
+        )->a( n = `items`           v = client->_bind( val = t_tab )
+        )->a( n = `mode`            v = `SingleSelectMaster`
+        )->a( n = `selectionChange` v = client->_event( val = `SELCHANGE` ) )->tag( `StandardListItem`
+              )->a( n = `title`       v = `{TITLE}`
+              )->a( n = `description` v = `{DESCR}`
+              )->a( n = `icon`        v = `{ICON}`
+              )->a( n = `info`        v = `{INFO}`
+              )->a( n = `press`       v = client->_event( `TEST` )
+              )->a( n = `selected`    v = `{SELECTED}` ).
 
     client->view_display( list->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_105.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_105.clas.abap
@@ -3,14 +3,14 @@ CLASS z2ui5_cl_smp_app_105 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    DATA view_parent TYPE REF TO z2ui5_cl_xml_view.
+    DATA view_parent TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_class_1 TYPE string.
     DATA mr_data TYPE REF TO data.
 
     METHODS on_event.
     METHODS view_display
       CHANGING
-        xml TYPE REF TO z2ui5_cl_xml_view OPTIONAL.
+        xml TYPE REF TO z2ui5_cl_ui5_view_builder OPTIONAL.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
@@ -25,30 +25,33 @@ CLASS z2ui5_cl_smp_app_105 IMPLEMENTATION.
 
     " Deliberately styled DIFFERENTLY from sub-app class 2 (a table), so the
     " parent demo 104 shows at a glance WHICH class is embedded right now.
-    view_parent->message_strip(
-        text     = `SUB-APP CLASS 1 (z2ui5_cl_smp_app_105): a green FORM - it has no page of ` &&
+    view_parent->tag( `MessageStrip`
+        )->a( n = `text`     v = `SUB-APP CLASS 1 (z2ui5_cl_smp_app_105): a green FORM - it has no page of ` &&
                    `its own, its controls are injected into the detail column of the calling ` &&
                    `parent app through a shared view reference.`
-        type     = `Success`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Success`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = view_parent->panel( headertext = `Class 1 - Form`
-        )->simple_form( editable = abap_true
-        )->content( `form` ).
+    DATA(form) = view_parent->ele( `Panel`
+        )->a( n = `headerText` v = `Class 1 - Form` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Embedded class`
-        )->object_status( text  = `z2ui5_cl_smp_app_105`
-                          state = `Success` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Embedded class` )->ele( `ObjectStatus`
+            )->a( n = `state` v = `Success`
+            )->a( n = `text`  v = `z2ui5_cl_smp_app_105` ).
 
-    form->label( `Input from class 1`
-        )->input( value       = client->_bind( mv_class_1 )
-                  placeholder = `type here - the value lives in sub-app 1` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Input from class 1` )->tag( `Input`
+            )->a( n = `placeholder` v = `type here - the value lives in sub-app 1`
+            )->a( n = `value`       v = client->_bind( mv_class_1 ) ).
 
-    form->label( `Event`
-        )->button( text  = `raise event in sub-app 1`
-                   press = client->_event( `MESSAGE_SUB` )
-                   icon  = `sap-icon://form` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Event` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `MESSAGE_SUB` )
+            )->a( n = `text`  v = `raise event in sub-app 1`
+            )->a( n = `icon`  v = `sap-icon://form` ).
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_109.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_109.clas.abap
@@ -26,37 +26,35 @@ CLASS z2ui5_cl_smp_app_109 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
-    view->quick_view( placement = mv_placement
-              )->quick_view_page( pageid      = `employeePageId`
-                                  header      = `Employee Info`
-                                  title       = `choper725`
-                                  titleurl    = `https://github.com/abap2UI5/abap2UI5`
-                                  description = `Enjoy`
-                            )->quick_view_group( heading = `Contact Details`
-                              )->quick_view_group_element( label = `Mobile`
-                                                           value = `123-456-789`
-                                                           type  = `mobile`
-                                                         )->get_parent(
-                              )->quick_view_group_element( label = `Phone`
-                                                           value = `789-456-123`
-                                                           type  = `phone`
-                                                         )->get_parent(
-                              )->quick_view_group_element( label        = `Email`
-                                                           value        = `thisisemail@email.com`
-                                                           emailsubject = `Subject`
-                                                           type         = `email`
-                                                         )->get_parent(
-                              )->get_parent(
-                           )->quick_view_group( heading = `Company`
-                            )->quick_view_group_element( label   = `Name`
-                                                           value = `Adventure Company`
-                                                           url   = `https://github.com/abap2UI5/abap2UI5`
-                                                           type  = `link`
-                                                         )->get_parent(
-                            )->quick_view_group_element( label   = `Address`
-                                                           value = `Here"`
-                                                         )->get_parent( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
+    view->ele( `QuickView`
+        )->a( n = `placement` v = mv_placement )->ele( `QuickViewPage`
+                  )->a( n = `description` v = `Enjoy`
+                  )->a( n = `header`      v = `Employee Info`
+                  )->a( n = `pageId`      v = `employeePageId`
+                  )->a( n = `title`       v = `choper725`
+                  )->a( n = `titleUrl`    v = `https://github.com/abap2UI5/abap2UI5` )->ele( `QuickViewGroup`
+                                )->a( n = `heading` v = `Contact Details` )->ele( `QuickViewGroupElement`
+                                  )->a( n = `label` v = `Mobile`
+                                  )->a( n = `type`  v = `mobile`
+                                  )->a( n = `value` v = `123-456-789` )->end( )->ele( `QuickViewGroupElement`
+                                  )->a( n = `label` v = `Phone`
+                                  )->a( n = `type`  v = `phone`
+                                  )->a( n = `value` v = `789-456-123` )->end( )->ele( `QuickViewGroupElement`
+                                  )->a( n = `emailSubject` v = `Subject`
+                                  )->a( n = `label`        v = `Email`
+                                  )->a( n = `type`         v = `email`
+                                  )->a( n = `value`        v = `thisisemail@email.com` )->end( )->end( )->ele( `QuickViewGroup`
+                               )->a( n = `heading` v = `Company` )->ele( `QuickViewGroupElement`
+                                )->a( n = `label` v = `Name`
+                                )->a( n = `type`  v = `link`
+                                )->a( n = `url`   v = `https://github.com/abap2UI5/abap2UI5`
+                                )->a( n = `value` v = `Adventure Company` )->end( )->ele( `QuickViewGroupElement`
+                                )->a( n = `label` v = `Address`
+                                )->a( n = `value` v = `Here"` )->end( ).
 
     client->popover_display(
       xml   = view->stringify( )
@@ -67,52 +65,49 @@ CLASS z2ui5_cl_smp_app_109 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popover - QuickView Contact Card`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popover - QuickView Contact Card`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Opens a QuickView popover, a compact contact card with grouped fields and links, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Opens a QuickView popover, a compact contact card with grouped fields and links, ` &&
                    `anchored to a button; the segmented button sets its placement.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `QuickView Popover`
-        editable = abap_true
-              )->content( `form`
-                  )->title( `QuickView Popover`
-                  )->label( `placement`
-                  )->segmented_button( client->_bind( mv_placement )
-                        )->items(
-                        )->segmented_button_item(
-                                key  = `Left`
-                                icon = `sap-icon://add-favorite`
-                                text = `Left`
-                        )->segmented_button_item(
-                                key  = `Top`
-                                icon = `sap-icon://accept`
-                                text = `Top`
-                        )->segmented_button_item(
-                                key  = `Bottom`
-                                icon = `sap-icon://accept`
-                                text = `Bottom`
-                        )->segmented_button_item(
-                                key  = `Right`
-                                icon = `sap-icon://attachment`
-                                text = `Right`
-                  )->get_parent( )->get_parent(
-                    )->label( `popover`
-                    )->button(
-                        text  = `show`
-                        press = client->_event( `POPOVER` )
-                        id    = `TEST`
-                        width = `10rem` ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `QuickView Popover`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                      )->a( n = `text` v = `QuickView Popover` )->tag( `Label`
+                      )->a( n = `text` v = `placement` )->ele( `SegmentedButton`
+                      )->a( n = `selectedKey` v = client->_bind( mv_placement ) )->ele( `items` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://add-favorite`
+                            )->a( n = `key`  v = `Left`
+                            )->a( n = `text` v = `Left` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://accept`
+                            )->a( n = `key`  v = `Top`
+                            )->a( n = `text` v = `Top` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://accept`
+                            )->a( n = `key`  v = `Bottom`
+                            )->a( n = `text` v = `Bottom` )->tag( `SegmentedButtonItem`
+                            )->a( n = `icon` v = `sap-icon://attachment`
+                            )->a( n = `key`  v = `Right`
+                            )->a( n = `text` v = `Right` )->end( )->end( )->tag( `Label`
+                        )->a( n = `text` v = `popover` )->tag( `Button`
+                        )->a( n = `press` v = client->_event( `POPOVER` )
+                        )->a( n = `text`  v = `show`
+                        )->a( n = `id`    v = `TEST`
+                        )->a( n = `width` v = `10rem` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_112.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_112.clas.abap
@@ -9,7 +9,7 @@ CLASS z2ui5_cl_smp_app_112 DEFINITION PUBLIC.
         info    TYPE string,
       END OF ty_s_item.
 
-    DATA view_parent TYPE REF TO z2ui5_cl_xml_view.
+    DATA view_parent TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_class_2 TYPE string.
     DATA mr_data TYPE REF TO data.
     DATA t_items TYPE STANDARD TABLE OF ty_s_item WITH EMPTY KEY.
@@ -17,7 +17,7 @@ CLASS z2ui5_cl_smp_app_112 DEFINITION PUBLIC.
     METHODS on_event.
     METHODS view_display
       CHANGING
-        xml TYPE REF TO z2ui5_cl_xml_view OPTIONAL.
+        xml TYPE REF TO z2ui5_cl_ui5_view_builder OPTIONAL.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
@@ -36,25 +36,27 @@ CLASS z2ui5_cl_smp_app_112 IMPLEMENTATION.
                        ( product = `Monitor 27"`  info = `2 weeks` )
                        ( product = `Dock Pro`     info = `sold out` ) ).
 
-    view_parent->message_strip(
-        text     = `SUB-APP CLASS 2 (z2ui5_cl_smp_app_112): an orange LIST - a different class ` &&
+    view_parent->tag( `MessageStrip`
+        )->a( n = `text`     v = `SUB-APP CLASS 2 (z2ui5_cl_smp_app_112): an orange LIST - a different class ` &&
                    `with different controls and its own data, embedded into the same detail ` &&
                    `column of the parent app.`
-        type     = `Warning`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Warning`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    view_parent->list( headertext = `Class 2 - Products`
-                          items      = client->_bind( t_items )
-        )->standard_list_item( title = `{PRODUCT}`
-                               info  = `{INFO}` ).
+    view_parent->ele( `List`
+        )->a( n = `headerText` v = `Class 2 - Products`
+        )->a( n = `items`      v = client->_bind( t_items ) )->tag( `StandardListItem`
+            )->a( n = `title` v = `{PRODUCT}`
+            )->a( n = `info`  v = `{INFO}` ).
 
-    view_parent->vbox( `sapUiSmallMargin`
-        )->input( value       = client->_bind( mv_class_2 )
-                  placeholder = `type here - the value lives in sub-app 2`
-        )->button( text  = `raise event in sub-app 2`
-                   press = client->_event( `MESSAGE_SUB` )
-                   icon  = `sap-icon://table-view` ).
+    view_parent->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Input`
+            )->a( n = `placeholder` v = `type here - the value lives in sub-app 2`
+            )->a( n = `value`       v = client->_bind( mv_class_2 ) )->tag( `Button`
+            )->a( n = `press` v = client->_event( `MESSAGE_SUB` )
+            )->a( n = `text`  v = `raise event in sub-app 2`
+            )->a( n = `icon`  v = `sap-icon://table-view` ).
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -62,59 +62,57 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-          )->page(
-                  title          = `abap2UI5 - Device - Geolocation from the Browser`
-                  navbuttonpress = client->_event_nav_app_leave( )
-                  shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Device - Geolocation from the Browser`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The geolocation custom control reads the device position from the browser and binds ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The geolocation custom control reads the device position from the browser and binds ` &&
                    `longitude, latitude, altitude, accuracy and speed into the read-only form below.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->_z2ui5( )->geolocation(
-                                        finished         = client->_event( `GEOLOCATION_LOADED` )
-                                        error            = client->_event( val   = `GEOLOCATION_ERROR`
+    page->tag( n = `Geolocation` ns = `z2ui5`
+        )->a( n = `finished`         v = client->_event( `GEOLOCATION_LOADED` )
+        )->a( n = `error`            v = client->_event( val   = `GEOLOCATION_ERROR`
                                                                            t_arg = VALUE #( ( `${$parameters>/code}` )
                                                                                             ( `${$parameters>/message}` ) ) )
-                                        longitude        = client->_bind( longitude )
-                                        latitude         = client->_bind( latitude )
-                                        altitude         = client->_bind( altitude )
-                                        altitudeaccuracy = client->_bind( altitudeaccuracy )
-                                        accuracy         = client->_bind( accuracy )
-                                        speed            = client->_bind( speed )
-              )->simple_form( title    = `Geolocation`
-                              editable = abap_false
-                  )->content( `form`
-                      )->label( `Longitude`
-                      )->input(
-                          value    = client->_bind( longitude )
-                          editable = abap_false
-                      )->label( `Latitude`
-                      )->input(
-                          value    = client->_bind( latitude )
-                          editable = abap_false
-                      )->label( `Altitude`
-                      )->input(
-                          value    = client->_bind( altitude )
-                          editable = abap_false
-                      )->label( `Accuracy`
-                      )->input(
-                          value    = client->_bind( accuracy )
-                          editable = abap_false
-                      )->label( `AltitudeAccuracy`
-                      )->input(
-                          value    = client->_bind( altitudeaccuracy )
-                          editable = abap_false
-                      )->label( `Speed`
-                      )->input(
-                          value    = client->_bind( speed )
-                          editable = abap_false ).
+        )->a( n = `longitude`        v = client->_bind( longitude )
+        )->a( n = `latitude`         v = client->_bind( latitude )
+        )->a( n = `altitude`         v = client->_bind( altitude )
+        )->a( n = `accuracy`         v = client->_bind( accuracy )
+        )->a( n = `altitudeAccuracy` v = client->_bind( altitudeaccuracy )
+        )->a( n = `speed`            v = client->_bind( speed ) )->ele( n = `SimpleForm` ns = `form`
+                  )->a( n = `title`    v = `Geolocation`
+                  )->a( n = `editable` b = abap_false )->ele( n = `content` ns = `form` )->tag( `Label`
+                          )->a( n = `text` v = `Longitude` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( longitude ) )->tag( `Label`
+                          )->a( n = `text` v = `Latitude` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( latitude ) )->tag( `Label`
+                          )->a( n = `text` v = `Altitude` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( altitude ) )->tag( `Label`
+                          )->a( n = `text` v = `Accuracy` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( accuracy ) )->tag( `Label`
+                          )->a( n = `text` v = `AltitudeAccuracy` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( altitudeaccuracy ) )->tag( `Label`
+                          )->a( n = `text` v = `Speed` )->tag( `Input`
+                          )->a( n = `editable` b = abap_false
+                          )->a( n = `value`    v = client->_bind( speed ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -68,7 +68,8 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
               )->a( n = `title`          v = `abap2UI5 - Device - Geolocation from the Browser`
@@ -76,15 +77,15 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
               )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `The geolocation custom control reads the device position from the browser and binds ` &&
+        )->a( n = `text` v = `The geolocation custom control reads the device position from the browser and binds ` &&
                    `longitude, latitude, altitude, accuracy and speed into the read-only form below.`
         )->a( n = `type`     v = `Information`
         )->a( n = `showIcon` b = abap_true
         )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     page->tag( n = `Geolocation` ns = `z2ui5`
-        )->a( n = `finished`         v = client->_event( `GEOLOCATION_LOADED` )
-        )->a( n = `error`            v = client->_event( val   = `GEOLOCATION_ERROR`
+        )->a( n = `finished` v = client->_event( `GEOLOCATION_LOADED` )
+        )->a( n = `error`    v = client->_event( val   = `GEOLOCATION_ERROR`
                                                                            t_arg = VALUE #( ( `${$parameters>/code}` )
                                                                                             ( `${$parameters>/message}` ) ) )
         )->a( n = `longitude`        v = client->_bind( longitude )
@@ -95,22 +96,22 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
         )->a( n = `speed`            v = client->_bind( speed ) )->ele( n = `SimpleForm` ns = `form`
                   )->a( n = `title`    v = `Geolocation`
                   )->a( n = `editable` b = abap_false )->ele( n = `content` ns = `form` )->tag( `Label`
-                          )->a( n = `text` v = `Longitude` )->tag( `Input`
+                          )->a( n = `text`     v = `Longitude` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( longitude ) )->tag( `Label`
-                          )->a( n = `text` v = `Latitude` )->tag( `Input`
+                          )->a( n = `text`     v = `Latitude` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( latitude ) )->tag( `Label`
-                          )->a( n = `text` v = `Altitude` )->tag( `Input`
+                          )->a( n = `text`     v = `Altitude` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( altitude ) )->tag( `Label`
-                          )->a( n = `text` v = `Accuracy` )->tag( `Input`
+                          )->a( n = `text`     v = `Accuracy` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( accuracy ) )->tag( `Label`
-                          )->a( n = `text` v = `AltitudeAccuracy` )->tag( `Input`
+                          )->a( n = `text`     v = `AltitudeAccuracy` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( altitudeaccuracy ) )->tag( `Label`
-                          )->a( n = `text` v = `Speed` )->tag( `Input`
+                          )->a( n = `text`     v = `Speed` )->tag( `Input`
                           )->a( n = `editable` b = abap_false
                           )->a( n = `value`    v = client->_bind( speed ) ).
 

--- a/src/01/z2ui5_cl_smp_app_122.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_122.clas.abap
@@ -67,101 +67,86 @@ CLASS z2ui5_cl_smp_app_122 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Device - Frontend Info: UI5 Version, Theme, OS, Browser`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Device - Frontend Info: UI5 Version, Theme, OS, Browser`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Reads frontend information from the client - UI5 version and theme plus device, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Reads frontend information from the client - UI5 version and theme plus device, ` &&
                    `OS and browser details - and shows each value in a read-only form.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Information`
-        editable = abap_true
-        )->content( `form`
-        )->label( `device_browser`
-        )->input(
-            value   = client->_bind( device_browser )
-            enabled = abap_false
-        )->label( `device_browser_version`
-        )->input(
-            value   = client->_bind( device_browser_version )
-            enabled = abap_false
-        )->label( `device_os`
-        )->input(
-            value   = client->_bind( device_os )
-            enabled = abap_false
-        )->label( `device_os_version`
-        )->input(
-            value   = client->_bind( device_os_version )
-            enabled = abap_false
-        )->label( `device_systemtype`
-        )->input(
-            value   = client->_bind( device_systemtype )
-            enabled = abap_false
-        )->label( `device_orientation`
-        )->input(
-            value   = client->_bind( device_orientation )
-            enabled = abap_false
-        )->label( `device_height`
-        )->input(
-            value   = client->_bind( device_height )
-            enabled = abap_false
-        )->label( `device_width`
-        )->input(
-            value   = client->_bind( device_width )
-            enabled = abap_false
-        )->label( `device_phone`
-        )->input(
-            value   = client->_bind( device_phone )
-            enabled = abap_false
-        )->label( `device_desktop`
-        )->input(
-            value   = client->_bind( device_desktop )
-            enabled = abap_false
-        )->label( `device_tablet`
-        )->input(
-            value   = client->_bind( device_tablet )
-            enabled = abap_false
-        )->label( `device_combi`
-        )->input(
-            value   = client->_bind( device_combi )
-            enabled = abap_false
-        )->label( `device_touch`
-        )->input(
-            value   = client->_bind( device_touch )
-            enabled = abap_false
-        )->label( `device_pointer`
-        )->input(
-            value   = client->_bind( device_pointer )
-            enabled = abap_false
-        )->label( `device_retina`
-        )->input(
-            value   = client->_bind( device_retina )
-            enabled = abap_false
-        )->label( `ui5_version`
-        )->input(
-            value   = client->_bind( ui5_version )
-            enabled = abap_false
-        )->label( `ui5_theme`
-        )->input(
-            value   = client->_bind( ui5_theme )
-            enabled = abap_false
-        )->label( `ui5_gav`
-        )->input(
-            value   = client->_bind( ui5_gav )
-            enabled = abap_false
-        )->label( `ui5_build_timestamp`
-        )->input(
-            value   = client->_bind( ui5_build_timestamp )
-            enabled = abap_false ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Information`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+            )->a( n = `text` v = `device_browser` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_browser ) )->tag( `Label`
+            )->a( n = `text` v = `device_browser_version` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_browser_version ) )->tag( `Label`
+            )->a( n = `text` v = `device_os` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_os ) )->tag( `Label`
+            )->a( n = `text` v = `device_os_version` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_os_version ) )->tag( `Label`
+            )->a( n = `text` v = `device_systemtype` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_systemtype ) )->tag( `Label`
+            )->a( n = `text` v = `device_orientation` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_orientation ) )->tag( `Label`
+            )->a( n = `text` v = `device_height` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_height ) )->tag( `Label`
+            )->a( n = `text` v = `device_width` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_width ) )->tag( `Label`
+            )->a( n = `text` v = `device_phone` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_phone ) )->tag( `Label`
+            )->a( n = `text` v = `device_desktop` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_desktop ) )->tag( `Label`
+            )->a( n = `text` v = `device_tablet` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_tablet ) )->tag( `Label`
+            )->a( n = `text` v = `device_combi` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_combi ) )->tag( `Label`
+            )->a( n = `text` v = `device_touch` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_touch ) )->tag( `Label`
+            )->a( n = `text` v = `device_pointer` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_pointer ) )->tag( `Label`
+            )->a( n = `text` v = `device_retina` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( device_retina ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_version` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( ui5_version ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_theme` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( ui5_theme ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_gav` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( ui5_gav ) )->tag( `Label`
+            )->a( n = `text` v = `ui5_build_timestamp` )->tag( `Input`
+            )->a( n = `enabled` b = abap_false
+            )->a( n = `value`   v = client->_bind( ui5_build_timestamp ) ).
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_125.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_125.clas.abap
@@ -19,29 +19,32 @@ CLASS z2ui5_cl_smp_app_125 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Browser - Set the Tab Title`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Browser - Set the Tab Title`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `Enter a title and press the button to run the set_title front-end action, which updates ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `Enter a title and press the button to run the set_title front-end action, which updates ` &&
                      `the browser tab title (document.title) without reloading the page.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      page->simple_form(
-          title    = `Form Title`
-          editable = abap_true
-          )->content( `form`
-          )->label( `title`
-          )->input( client->_bind( title )
-          )->button(
-              text  = `Set Title`
-              press = client->_event( `SET_TITLE` ) ).
+      page->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `title`    v = `Form Title`
+          )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `title` )->tag( `Input`
+              )->a( n = `value` v = client->_bind( title ) )->tag( `Button`
+              )->a( n = `press` v = client->_event( `SET_TITLE` )
+              )->a( n = `text`  v = `Set Title` ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `SET_TITLE` ).

--- a/src/01/z2ui5_cl_smp_app_133.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_133.clas.abap
@@ -24,44 +24,44 @@ CLASS z2ui5_cl_smp_app_133 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Focus - Set Focus and Select Text in an Input`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Focus - Set Focus and Select Text in an Input`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Pressing a button runs the set_focus front-end action, which moves keyboard focus to the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Pressing a button runs the set_focus front-end action, which moves keyboard focus to the ` &&
                    `target input and selects the text between the given start and end positions.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Focus & Cursor`
-        editable = abap_true
-        )->content( `form`
-                )->title( `Input`
-                )->label( `Sel_Start`
-                )->input( client->_bind( selstart )
-                )->label( `Sel_End`
-                )->input( client->_bind( selend )
-                )->label( `field_01`
-                )->input(
-                    value = client->_bind( field_01 )
-                    id    = `BUTTON01`
-                )->button(
-                    text  = `focus here`
-                    press = client->_event( `BUTTON01` )
-                )->label( `field_02`
-                )->input(
-                    value = client->_bind( field_02 )
-                    id    = `BUTTON02`
-                )->button(
-                    text  = `focus here`
-                    press = client->_event( `BUTTON02` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Focus & Cursor`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                    )->a( n = `text` v = `Input` )->tag( `Label`
+                    )->a( n = `text` v = `Sel_Start` )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( selstart ) )->tag( `Label`
+                    )->a( n = `text` v = `Sel_End` )->tag( `Input`
+                    )->a( n = `value` v = client->_bind( selend ) )->tag( `Label`
+                    )->a( n = `text` v = `field_01` )->tag( `Input`
+                    )->a( n = `id`    v = `BUTTON01`
+                    )->a( n = `value` v = client->_bind( field_01 ) )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON01` )
+                    )->a( n = `text`  v = `focus here` )->tag( `Label`
+                    )->a( n = `text` v = `field_02` )->tag( `Input`
+                    )->a( n = `id`    v = `BUTTON02`
+                    )->a( n = `value` v = client->_bind( field_02 ) )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `BUTTON02` )
+                    )->a( n = `text`  v = `focus here` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_143.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_143.clas.abap
@@ -55,64 +55,71 @@ CLASS z2ui5_cl_smp_app_143 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:f`      v = `sap.f`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
 
-    DATA(page1) = view->shell( )->page( id = `page_main`
-            title                = `abap2UI5 - Grid Table - Keep Column Filters on Refresh`
-            class                = `sapUiContentPadding`
-            navbuttonpress       = client->_event_nav_app_leave( )
-            shownavbutton        = client->check_app_prev_stack( ) ).
+    DATA(page1) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Grid Table - Keep Column Filters on Refresh`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    page1->message_strip(
-        text     = `This sample uses the abap2UI5 uitableext custom control so the active sap.ui.table column ` &&
+    page1->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample uses the abap2UI5 uitableext custom control so the active sap.ui.table column ` &&
                    `filters are preserved across a view model update instead of being reset.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(page) = page1->dynamic_page( headerexpanded = abap_true ).
-    page1->_z2ui5( )->uitableext( `Table1` ).
+    DATA(page) = page1->ele( n = `DynamicPage` ns = `f`
+        )->a( n = `headerExpanded` b = abap_true ).
+    page1->tag( n = `UITableExt` ns = `z2ui5`
+        )->a( n = `tableId` v = `Table1` ).
 
-    DATA(header_title) = page->title( ns = `f` )->get( )->dynamic_page_title( ).
-    header_title->heading( `f` )->hbox( )->title( `Table` ).
-    header_title->expanded_content( `f` ).
-    header_title->snapped_content( `f` ).
+    DATA(header_title) = page->ele( n = `title` ns = `f` )->ele( n = `DynamicPageTitle` ns = `f` ).
+    header_title->ele( n = `heading` ns = `f` )->ele( `HBox` )->tag( `Title`
+        )->a( n = `text` v = `Table` ).
+    header_title->ele( n = `expandedContent` ns = `f` ).
+    header_title->ele( n = `snappedContent` ns = `f` ).
 
-    DATA(cont) = page->content( `f` ).
+    DATA(cont) = page->ele( n = `content` ns = `f` ).
 
-    DATA(table) = cont->vbox(
-                  )->ui_table(
-                               rows               = client->_bind( gt_data )
-                               id                 = `Table1`
-                               alternaterowcolors = abap_true
-                               enablecellfilter   = abap_true
-                               rowactioncount     = `1`
-                               fixedcolumncount   = `1`
-                               selectionmode      = `None` ).
+    DATA(table) = cont->ele( `VBox` )->ele( n = `Table` ns = `table`
+                      )->a( n = `rows`               v = client->_bind( gt_data )
+                      )->a( n = `alternateRowColors` b = abap_true
+                      )->a( n = `enableCellFilter`   b = abap_true
+                      )->a( n = `fixedColumnCount`   v = `1`
+                      )->a( n = `rowActionCount`     v = `1`
+                      )->a( n = `selectionMode`      v = `None`
+                      )->a( n = `id`                 v = `Table1` ).
 
-    table->ui_columns(
-                              )->ui_column( sortproperty   = `FIELD1`
-                                            filterproperty = `FIELD1`
-                                            autoresizable  = `true`
-                                             )->text( `Field1`
-                                              )->ui_template( )->text( `{FIELD1}`
-                               )->get_parent( )->get_parent(
-                               )->ui_column( sortproperty   = `FIELD2`
-                                             filterproperty = `FIELD2`
-                                             autoresizable  = `true`
-                                              )->text( `Field2`
-                                               )->ui_template( )->text( `{FIELD2}`
-                               )->get_parent( )->get_parent(
-                               )->ui_column( sortproperty   = `FIELD3`
-                                             filterproperty = `FIELD3`
-                                             autoresizable  = `true`
-                                              )->text( `Field3`
-                                               )->ui_template( )->text( `{FIELD3}`
-                         )->get_parent( )->get_parent( )->get_parent(
-                              )->ui_row_action_template( )->ui_row_action(
-                              )->ui_row_action_item( icon = `sap-icon://add`
-                                                     text = `Add`
-                                    press                 = client->_event( val = `ROW_ACTION_ITEM_ADD` t_arg = VALUE #( ( `${MATNR}` ) ) ) ).
+    table->ele( n = `columns` ns = `table` )->ele( n = `Column` ns = `table`
+                                  )->a( n = `sortProperty`   v = `FIELD1`
+                                  )->a( n = `autoResizable`  v = `true`
+                                  )->a( n = `filterProperty` v = `FIELD1` )->tag( `Text`
+                                                 )->a( n = `text` v = `Field1` )->ele( n = `template` ns = `table` )->tag( `Text`
+                                                  )->a( n = `text` v = `{FIELD1}` )->end( )->end( )->ele( n = `Column` ns = `table`
+                                   )->a( n = `sortProperty`   v = `FIELD2`
+                                   )->a( n = `autoResizable`  v = `true`
+                                   )->a( n = `filterProperty` v = `FIELD2` )->tag( `Text`
+                                                  )->a( n = `text` v = `Field2` )->ele( n = `template` ns = `table` )->tag( `Text`
+                                                   )->a( n = `text` v = `{FIELD2}` )->end( )->end( )->ele( n = `Column` ns = `table`
+                                   )->a( n = `sortProperty`   v = `FIELD3`
+                                   )->a( n = `autoResizable`  v = `true`
+                                   )->a( n = `filterProperty` v = `FIELD3` )->tag( `Text`
+                                                  )->a( n = `text` v = `Field3` )->ele( n = `template` ns = `table` )->tag( `Text`
+                                                   )->a( n = `text` v = `{FIELD3}` )->end( )->end( )->end( )->ele( n = `rowActionTemplate` ns = `table` 
+                                                   )->ele( n = `RowAction` ns = `table` )->ele( n = `RowActionItem` ns = `table`
+                                  )->a( n = `icon`  v = `sap-icon://add`
+                                  )->a( n = `text`  v = `Add`
+                                  )->a( n = `press` v = client->_event( val = `ROW_ACTION_ITEM_ADD` t_arg = VALUE #( ( `${MATNR}` ) ) ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_143.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_143.clas.abap
@@ -62,7 +62,8 @@ CLASS z2ui5_cl_smp_app_143 IMPLEMENTATION.
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
         )->a( n = `xmlns:f`      v = `sap.f`
-        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
+        )->a( n = `xmlns:table`  v = `sap.ui.table`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page1) = view->ele( `Shell` )->ele( `Page`
         )->a( n = `title`          v = `abap2UI5 - Grid Table - Keep Column Filters on Refresh`
@@ -72,7 +73,7 @@ CLASS z2ui5_cl_smp_app_143 IMPLEMENTATION.
         )->a( n = `id`             v = `page_main` ).
 
     page1->tag( `MessageStrip`
-        )->a( n = `text`     v = `This sample uses the abap2UI5 uitableext custom control so the active sap.ui.table column ` &&
+        )->a( n = `text` v = `This sample uses the abap2UI5 uitableext custom control so the active sap.ui.table column ` &&
                    `filters are preserved across a view model update instead of being reset.`
         )->a( n = `type`     v = `Information`
         )->a( n = `showIcon` b = abap_true

--- a/src/01/z2ui5_cl_smp_app_144.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_144.clas.abap
@@ -24,45 +24,50 @@ CLASS z2ui5_cl_smp_app_144 IMPLEMENTATION.
 
   METHOD set_view.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Binding - Single Table Cell (tab_index)`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Single Table Cell (tab_index)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample demonstrates cell-level binding: each input is bound to one ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample demonstrates cell-level binding: each input is bound to one ` &&
                    `cell of an internal table via tab_index, so edits target exactly that row and field.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     LOOP AT t_tab REFERENCE INTO DATA(lr_row).
       DATA(lv_tabix) = sy-tabix.
-      page->input( client->_bind( val = lr_row->title tab = t_tab tab_index = lv_tabix ) ).
-      page->input( client->_bind( val = lr_row->value tab = t_tab tab_index = lv_tabix ) ).
+      page->tag( `Input`
+          )->a( n = `value` v = client->_bind( val = lr_row->title tab = t_tab tab_index = lv_tabix ) ).
+      page->tag( `Input`
+          )->a( n = `value` v = client->_bind( val = lr_row->value tab = t_tab tab_index = lv_tabix ) ).
     ENDLOOP.
 
-    DATA(tab) = page->table(
-            items = client->_bind( t_tab )
-            mode  = `MultiSelect`
-        )->header_toolbar(
-            )->overflow_toolbar(
-                )->title( `title of the table`
-        )->get_parent( )->get_parent(
-      )->columns(
-        )->column( )->text( `Title` )->get_parent(
-        )->column( )->text( `Value` )->get_parent( )->get_parent(
-      )->items( )->column_list_item( selected = `{SELKZ}`
-      )->cells(
-          )->input( `{TITLE}`
-          )->input( `{VALUE}` ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_tab )
+        )->a( n = `mode`  v = `MultiSelect` )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                    )->a( n = `text` v = `title of the table` )->end( )->end( )->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Value` )->end( )->end( )->ele( `items` )->ele( `ColumnListItem`
+          )->a( n = `selected` v = `{SELKZ}` )->ele( `cells` )->tag( `Input`
+              )->a( n = `value` v = `{TITLE}` )->tag( `Input`
+              )->a( n = `value` v = `{VALUE}` ).
 
-    page->input( client->_bind( val = t_tab[ 1 ]-title tab = t_tab tab_index = 1 ) ).
-    page->input( client->_bind( val = t_tab[ 1 ]-value tab = t_tab tab_index = 1 ) ).
-    page->input( client->_bind( val = t_tab[ 2 ]-title tab = t_tab tab_index = 2 ) ).
-    page->input( client->_bind( val = t_tab[ 2 ]-value tab = t_tab tab_index = 2 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = t_tab[ 1 ]-title tab = t_tab tab_index = 1 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = t_tab[ 1 ]-value tab = t_tab tab_index = 1 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = t_tab[ 2 ]-title tab = t_tab tab_index = 2 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = t_tab[ 2 ]-value tab = t_tab tab_index = 2 ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_160.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_160.clas.abap
@@ -101,55 +101,71 @@ CLASS z2ui5_cl_smp_app_160 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:table`  v = `sap.ui.table` ).
 
-    DATA(page) = view->shell(
-      )->page(
-        title          = `abap2UI5 - Grid Table - Events on Cell Level`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( )
-        )->header_content(
-            )->link(
-      )->get_parent( ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+          )->a( n = `title`          v = `abap2UI5 - Grid Table - Events on Cell Level`
+          )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+          )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) )->ele( `headerContent` )->tag( `Link` )->end( ).
 
-    page->message_strip(
-        text     = `Pressing ENTER in a sap.ui.table cell input fires a backend event that carries the cell id, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Pressing ENTER in a sap.ui.table cell input fires a backend event that carries the cell id, ` &&
                    `its row index and the parent row id as event arguments, shown here in a message box.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->text( `Make an input and press ENTER` ).
+    page->tag( `Text`
+        )->a( n = `text` v = `Make an input and press ENTER` ).
 
-    DATA(table) = page->flex_box( height = `85vh`
-        )->ui_table( alternaterowcolors = `true`
-                     selectionmode      = `None`
-                     rows               = client->_bind( mt_output )
-    ).
+    DATA(table) = page->ele( `FlexBox`
+        )->a( n = `height` v = `85vh` )->ele( n = `Table` ns = `table`
+            )->a( n = `rows`               v = client->_bind( mt_output )
+            )->a( n = `alternateRowColors` v = `true`
+            )->a( n = `selectionMode`      v = `None` ).
 
-    DATA(columns) = table->ui_columns( ).
+    DATA(columns) = table->ele( n = `columns` ns = `table` ).
 
-    columns->ui_column( width          = `5.2rem`
-                        sortproperty   = `SET_SK`
-                        filterproperty = `SET_SK` )->text( `Column 1` )->ui_template( )->text( `{SET_SK}` ).
-    columns->ui_column( width          = `5rem`
-                        sortproperty   = `MATNR`
-                        filterproperty = `MATNR` )->text( `Column 2` )->ui_template( )->text( `{MATNR}` ).
-    columns->ui_column( width          = `5rem`
-                        sortproperty   = `PL_TOTAL`
-                        filterproperty = `PL_TOTAL` )->text( `Column 5` )->ui_template( )->input(
-                        value          = `{PL_TOTAL}`
-                        submit         = client->_event( val = `PL_TOTAL_CHANGE` t_arg = VALUE #(
+    columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `5.2rem`
+        )->a( n = `sortProperty`   v = `SET_SK`
+        )->a( n = `filterProperty` v = `SET_SK` )->tag( `Text`
+                            )->a( n = `text` v = `Column 1` )->ele( n = `template` ns = `table` )->tag( `Text`
+                            )->a( n = `text` v = `{SET_SK}` ).
+    columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `5rem`
+        )->a( n = `sortProperty`   v = `MATNR`
+        )->a( n = `filterProperty` v = `MATNR` )->tag( `Text`
+                            )->a( n = `text` v = `Column 2` )->ele( n = `template` ns = `table` )->tag( `Text`
+                            )->a( n = `text` v = `{MATNR}` ).
+    columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `5rem`
+        )->a( n = `sortProperty`   v = `PL_TOTAL`
+        )->a( n = `filterProperty` v = `PL_TOTAL` )->tag( `Text`
+                            )->a( n = `text` v = `Column 5` )->ele( n = `template` ns = `table` )->tag( `Input`
+                            )->a( n = `type`     v = `Number`
+                            )->a( n = `editable` b = abap_true
+                            )->a( n = `value`    v = `{PL_TOTAL}`
+                            )->a( n = `submit`   v = client->_event( val = `PL_TOTAL_CHANGE` t_arg = VALUE #(
         ( `${$source>/id}` )
         ( `$event.oSource.sId` )
         ( `${INDEX}` )
         ( `$event.oSource.oParent.sId` )
         ( `${$parameters>/value}` )
-         ) ) editable = abap_true type = `Number` ).
+         ) ) ).
 
-    columns->ui_column( width          = `4rem`
-                        sortproperty   = `per_cent_total`
-                        filterproperty = `per_cent_total` )->text( `Column 6` )->ui_template( )->text( `{PL_TOTAL} %` ).
+    columns->ele( n = `Column` ns = `table`
+        )->a( n = `width`          v = `4rem`
+        )->a( n = `sortProperty`   v = `per_cent_total`
+        )->a( n = `filterProperty` v = `per_cent_total` )->tag( `Text`
+                            )->a( n = `text` v = `Column 6` )->ele( n = `template` ns = `table` )->tag( `Text`
+                            )->a( n = `text` v = `{PL_TOTAL} %` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_161.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_161.clas.abap
@@ -20,20 +20,21 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
 
   METHOD simple_popup1.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    DATA(dialog) = popup->dialog(
-            afterclose = client->_event( `BTN_OK_1ND` )
-         )->content( ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `afterClose` v = client->_event( `BTN_OK_1ND` ) )->ele( `content` ).
 
-    DATA(content) = dialog->button( text  = `Open 2nd popup`
-                                    press = client->_event( `GOTO_2ND` ) ).
+    DATA(content) = dialog->tag( `Button`
+        )->a( n = `press` v = client->_event( `GOTO_2ND` )
+        )->a( n = `text`  v = `Open 2nd popup` ).
 
-    dialog->get_parent( )->buttons(
-                  )->button(
-                      text  = `OK`
-                      press = client->_event( `BTN_OK_1ND` )
-                      type  = `Emphasized` ).
+    dialog->end( )->ele( `buttons` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BTN_OK_1ND` )
+                      )->a( n = `text`  v = `OK`
+                      )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -42,19 +43,20 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
 
   METHOD simple_popup2.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    DATA(dialog) = popup->dialog(
-        afterclose = client->_event( `BTN_OK_2ND` )
-         )->content( ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `afterClose` v = client->_event( `BTN_OK_2ND` ) )->ele( `content` ).
 
-    DATA(content) = dialog->label( `this is a second popup` ).
+    DATA(content) = dialog->tag( `Label`
+        )->a( n = `text` v = `this is a second popup` ).
 
-    dialog->get_parent( )->buttons(
-                  )->button(
-                      text  = `GOTO 1ST POPUP`
-                      press = client->_event( `BTN_OK_2ND` )
-                      type  = `Emphasized` ).
+    dialog->end( )->ele( `buttons` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BTN_OK_2ND` )
+                      )->a( n = `text`  v = `GOTO 1ST POPUP`
+                      )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -63,23 +65,27 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Popup - Dialog inside a Dialog`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popup - Dialog inside a Dialog`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample opens a popup from a button and then chains to a second popup ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample opens a popup from a button and then chains to a second popup ` &&
                    `from within the first one.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->button(
-        text  = `Open Popup...`
-        press = client->_event( `POPUP` ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `POPUP` )
+        )->a( n = `text`  v = `Open Popup...` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_163.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_163.clas.abap
@@ -28,28 +28,31 @@ CLASS z2ui5_cl_smp_app_163 IMPLEMENTATION.
 
   METHOD view_menu.
 
-    DATA(menu_view) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(menu_view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    menu_view->_generic_property( VALUE #( n = `core:require` v = `{ MessageToast: 'sap/m/MessageToast' }` ) ).
+    menu_view->a( n = `core:require` v = `{ MessageToast: 'sap/m/MessageToast' }` ).
 
-    menu_view->menu( title = `Choose Your Action`
-      )->menu_item( text  = `Accept`
-                    icon  = `sap-icon://accept`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})`
-      )->menu_item( text  = `Reject`
-                    icon  = `sap-icon://decline`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})`
-      )->menu_item( text  = `Email`
-                    icon  = `sap-icon://email`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})`
-      )->menu_item( text  = `Forward`
-                    icon  = `sap-icon://forward`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})`
-      )->menu_item( text  = `Delete`
-                    icon  = `sap-icon://delete`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})`
-      )->menu_item( text  = `Other`
-                    press = `MessageToast.show('selected action is ' + ${$source>/text})` ).
+    menu_view->ele( `Menu`
+        )->a( n = `title` v = `Choose Your Action` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Accept`
+          )->a( n = `icon`  v = `sap-icon://accept` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Reject`
+          )->a( n = `icon`  v = `sap-icon://decline` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Email`
+          )->a( n = `icon`  v = `sap-icon://email` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Forward`
+          )->a( n = `icon`  v = `sap-icon://forward` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Delete`
+          )->a( n = `icon`  v = `sap-icon://delete` )->tag( `MenuItem`
+          )->a( n = `press` v = `MessageToast.show('selected action is ' + ${$source>/text})`
+          )->a( n = `text`  v = `Other` ).
 
     client->popover_display( xml   = menu_view->stringify( )
                              by_id = `menuButton` ).
@@ -59,26 +62,33 @@ CLASS z2ui5_cl_smp_app_163 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    view           = view->shell( )->page( id = `page_main`
-    title          = `abap2UI5 - Menu - Menu Button with core:require`
-    navbuttonpress = client->_event_nav_app_leave( )
-    shownavbutton  = client->check_app_prev_stack( ) ).
+    view           = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Menu - Menu Button with core:require`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    view->message_strip(
-        text     = `This sample opens a Menu as a popover anchored to a button; choosing an ` &&
+    view->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample opens a Menu as a popover anchored to a button; choosing an ` &&
                    `item shows the selected action in a MessageToast.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(vbox) = view->vbox( ).
+    DATA(vbox) = view->ele( `VBox` ).
 
-    vbox->button( text  = `Open Menu`
-                  press = client->_event( `OPEN_MENU` )
-                  id    = `menuButton`
-                  class = `sapUiSmallMargin` ).
+    vbox->tag( `Button`
+        )->a( n = `press` v = client->_event( `OPEN_MENU` )
+        )->a( n = `text`  v = `Open Menu`
+        )->a( n = `id`    v = `menuButton`
+        )->a( n = `class` v = `sapUiSmallMargin` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_166.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_166.clas.abap
@@ -38,31 +38,44 @@ CLASS z2ui5_cl_smp_app_166 IMPLEMENTATION.
 
   METHOD set_view.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Binding - Structure Fields and INCLUDEs`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - Structure Fields and INCLUDEs`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample demonstrates structure-level binding: each input is bound to a ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample demonstrates structure-level binding: each input is bound to a ` &&
                    `field of a flat structure, including fields pulled in via INCLUDE.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->input( client->_bind( val = ms_struc-title ) ).
-    page->input( client->_bind( val = ms_struc-value ) ).
-    page->input( client->_bind( val = ms_struc-value2 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc-title ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc-value ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc-value2 ) ).
 
-    page->input( client->_bind( val = ms_struc2-title ) ).
-    page->input( client->_bind( val = ms_struc2-value ) ).
-    page->input( client->_bind( val = ms_struc2-value2 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-title ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-value ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-value2 ) ).
 
-    page->input( client->_bind( val = ms_struc2-incl_title ) ).
-    page->input( client->_bind( val = ms_struc2-incl_value ) ).
-    page->input( client->_bind( val = ms_struc2-incl_value2 ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-incl_title ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-incl_value ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( val = ms_struc2-incl_value2 ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_167.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_167.clas.abap
@@ -21,45 +21,55 @@ CLASS z2ui5_cl_smp_app_167 IMPLEMENTATION.
 
   METHOD set_view.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Event - Extra Arguments with t_arg`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Event - Extra Arguments with t_arg`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample shows how to pass extra arguments to an event via t_arg - fixed ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample shows how to pass extra arguments to an event via t_arg - fixed ` &&
                    `values, model values, or client-side expressions - and read them in the backend.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->link( text   = `More information...`
-                target = `_blank`
-                href   = `https://sapui5.hana.ondemand.com/sdk/#/topic/b0fb4de7364f4bcbb053a99aa645affe` ).
+    page->tag( `Link`
+        )->a( n = `text`   v = `More information...`
+        )->a( n = `target` v = `_blank`
+        )->a( n = `href`   v = `https://sapui5.hana.ondemand.com/sdk/#/topic/b0fb4de7364f4bcbb053a99aa645affe` ).
 
-    page->button( text  = `EVENT_FIX_VAL`
-                  press = client->_event( val = `EVENT_FIX_VAL` t_arg = VALUE #(
-        ( `FIX_VAL` ) ) ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( val = `EVENT_FIX_VAL` t_arg = VALUE #(
+        ( `FIX_VAL` ) ) )
+        )->a( n = `text`  v = `EVENT_FIX_VAL` ).
 
-    page->input( client->_bind( mv_value ) ).
-    page->button( text  = `EVENT_MODEL_VALUE`
-                  press = client->_event( val = `EVENT_MODEL_VALUE` t_arg = VALUE #(
-        ( `$` && client->_bind( mv_value ) ) ) ) ).
+    page->tag( `Input`
+        )->a( n = `value` v = client->_bind( mv_value ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( val = `EVENT_MODEL_VALUE` t_arg = VALUE #(
+        ( `$` && client->_bind( mv_value ) ) ) )
+        )->a( n = `text`  v = `EVENT_MODEL_VALUE` ).
 
-    page->button( text  = `SOURCE_PROPERTY_TEXT`
-                  press = client->_event( val = `SOURCE_PROPERTY_TEXT` t_arg = VALUE #(
-        ( `${$source>/text}` ) ) ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( val = `SOURCE_PROPERTY_TEXT` t_arg = VALUE #(
+        ( `${$source>/text}` ) ) )
+        )->a( n = `text`  v = `SOURCE_PROPERTY_TEXT` ).
 
-    page->input(
-        description = `make an input and press enter - `
-        submit      = client->_event( val = `EVENT_PROPERTY_VALUE` t_arg = VALUE #(
+    page->tag( `Input`
+        )->a( n = `description` v = `make an input and press enter - `
+        )->a( n = `submit`      v = client->_event( val = `EVENT_PROPERTY_VALUE` t_arg = VALUE #(
         ( `${$parameters>/value}` ) ) ) ).
 
-    page->button( text  = `PARENT_PROPERTY_ID`
-                  press = client->_event( val = `PARENT_PROPERTY_ID` t_arg = VALUE #(
-        ( `$event.oSource.oParent.sId` ) ) ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( val = `PARENT_PROPERTY_ID` t_arg = VALUE #(
+        ( `$event.oSource.oParent.sId` ) ) )
+        )->a( n = `text`  v = `PARENT_PROPERTY_ID` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_170.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_170.clas.abap
@@ -22,50 +22,44 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
 
   METHOD simple_popup1.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    DATA(dialog) = popup->dialog( stretch = abap_true
-            afterclose                    = client->_event( `BTN_OK_1ND` )
-         )->content( ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `stretch`    b = abap_true
+        )->a( n = `afterClose` v = client->_event( `BTN_OK_1ND` ) )->ele( `content` ).
 
-    DATA(content) = dialog->icon_tab_bar( selectedkey        = client->_bind( mv_selected_key )
-                                                  select     = client->follow_up_action( val   = client->cs_event-control_by_id
+    DATA(content) = dialog->ele( `IconTabBar`
+        )->a( n = `select`      v = client->follow_up_action( val   = client->cs_event-control_by_id
                                                                                          view  = client->cs_view-popup
                                                                                          t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
-                                                  headermode = `Inline`
-                                                  expanded   = abap_true
-                                                  expandable = abap_false
-                                  )->items(
-                                    )->icon_tab_filter( key  = `page1`
-                                                        text = `Home` )->get_parent(
-                                    )->icon_tab_filter( key  = `page2`
-                                                        text = `Applications` )->get_parent(
-                                    )->icon_tab_filter( key  = `page3`
-                                                        text = `Users and Groups`
-      )->get_parent( )->get_parent(
-                                        )->content( )->vbox( height = `100%`
-                                         )->nav_container( id                    = `NavCon`
-                                                           initialpage           = `page1`
-                                                           defaulttransitionname = `flip`
-                                                           height                = `400px`
-                                           )->pages(
-                                            )->page(
-                                              title = `first page`
-                                              id    = `page1`
-                                           )->get_parent(
-                                            )->page(
-                                              title = `second page`
-                                              id    = `page2`
-                                           )->get_parent(
-                                            )->page(
-                                              title = `third page`
-                                              id    = `page3` ).
+        )->a( n = `expandable`  b = abap_false
+        )->a( n = `expanded`    b = abap_true
+        )->a( n = `headerMode`  v = `Inline`
+        )->a( n = `selectedKey` v = client->_bind( mv_selected_key ) )->ele( `items` )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Home`
+                                        )->a( n = `key`  v = `page1` )->end( )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Applications`
+                                        )->a( n = `key`  v = `page2` )->end( )->ele( `IconTabFilter`
+                                        )->a( n = `text` v = `Users and Groups`
+                                        )->a( n = `key`  v = `page3` )->end( )->end( )->ele( `content` )->ele( `VBox`
+                                            )->a( n = `height` v = `100%` )->ele( `NavContainer`
+                                             )->a( n = `initialPage`           v = `page1`
+                                             )->a( n = `id`                    v = `NavCon`
+                                             )->a( n = `height`                v = `400px`
+                                             )->a( n = `defaultTransitionName` v = `flip` )->ele( `pages` )->ele( `Page`
+                                                )->a( n = `title` v = `first page`
+                                                )->a( n = `id`    v = `page1` )->end( )->ele( `Page`
+                                                )->a( n = `title` v = `second page`
+                                                )->a( n = `id`    v = `page2` )->end( )->ele( `Page`
+                                                )->a( n = `title` v = `third page`
+                                                )->a( n = `id`    v = `page3` ).
 
-    dialog->get_parent( )->buttons(
-                  )->button(
-                      text  = `OK`
-                      press = client->_event( `BTN_OK_1ND` )
-                      type  = `Emphasized` ).
+    dialog->end( )->ele( `buttons` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BTN_OK_1ND` )
+                      )->a( n = `text`  v = `OK`
+                      )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -74,19 +68,20 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
 
   METHOD simple_popup2.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    DATA(dialog) = popup->dialog(
-        afterclose = client->_event( `BTN_OK_2ND` )
-         )->content( ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `afterClose` v = client->_event( `BTN_OK_2ND` ) )->ele( `content` ).
 
-    DATA(content) = dialog->label( `this is a second popup` ).
+    DATA(content) = dialog->tag( `Label`
+        )->a( n = `text` v = `this is a second popup` ).
 
-    dialog->get_parent( )->buttons(
-                  )->button(
-                      text  = `GOTO 1ST POPUP`
-                      press = client->_event( `BTN_OK_2ND` )
-                      type  = `Emphasized` ).
+    dialog->end( )->ele( `buttons` )->tag( `Button`
+                      )->a( n = `press` v = client->_event( `BTN_OK_2ND` )
+                      )->a( n = `text`  v = `GOTO 1ST POPUP`
+                      )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -95,23 +90,27 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-                title          = `abap2UI5 - Popup - Navigate between Dialogs (NavContainer)`
-                navbuttonpress = client->_event_nav_app_leave( )
-                shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popup - Navigate between Dialogs (NavContainer)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Press the button to open a dialog; from there a second popup can be opened and navigated ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Press the button to open a dialog; from there a second popup can be opened and navigated ` &&
                    `back to the first, demonstrating popup-to-popup navigation.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->button(
-        text  = `Open Popup...`
-        press = client->_event( `POPUP` ) ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `POPUP` )
+        )->a( n = `text`  v = `Open Popup...` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_173.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_173.clas.abap
@@ -39,47 +39,53 @@ CLASS z2ui5_cl_smp_app_173 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock`   v = `true`
+        )->a( n = `height`         v = `100%`
+        )->a( n = `xmlns`          v = `sap.m`
+        )->a( n = `xmlns:mvc`      v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`     v = `sap.ui.core`
+        )->a( n = `xmlns:template` v = `http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1` ).
 
-    view           = view->shell( )->page( id    = `page_main`
-    class          = `sapUiContentPadding`
-    title          = `abap2UI5 - Templating - Build Columns Dynamically (template:repeat)`
-    navbuttonpress = client->_event_nav_app_leave( )
-    shownavbutton  = client->check_app_prev_stack( ) ).
+    view           = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Templating - Build Columns Dynamically (template:repeat)`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `class`          v = `sapUiContentPadding`
+        )->a( n = `id`             v = `page_main` ).
 
-    view->message_strip(
-        text     = `This sample builds table columns and cells dynamically from a layout table ` &&
+    view->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample builds table columns and cells dynamically from a layout table ` &&
                    `using template repeat, plus a template if/then/else that re-renders on a switch.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    view->table( client->_bind( mt_data )
-      )->columns(
-        )->template_repeat( list = `{template>/MT_LAYOUT}`
-                            var  = `L0`
-          )->column( mergeduplicates = `{L0>MERGE}`
-                     visible         = `{L0>VISIBLE}` )->text( `{L0>FNAME}` )->get_parent(
-        )->get_parent( )->get_parent(
-        )->items(
-          )->column_list_item(
-            )->cells(
-              )->template_repeat( list = `{template>/MT_LAYOUT}`
-                                  var  = `L1`
-                )->object_identifier( text = `{= '{' + ${L1>FNAME} + '}' }` ).
+    view->ele( `Table`
+        )->a( n = `items` v = client->_bind( mt_data ) )->ele( `columns` )->ele( n = `repeat` ns = `template`
+            )->a( n = `list` v = `{template>/MT_LAYOUT}`
+            )->a( n = `var`  v = `L0` )->ele( `Column`
+              )->a( n = `mergeDuplicates` v = `{L0>MERGE}`
+              )->a( n = `visible`         v = `{L0>VISIBLE}` )->tag( `Text`
+                         )->a( n = `text` v = `{L0>FNAME}` )->end( )->end( )->end( )->ele( `items` )->ele( `ColumnListItem` 
+                         )->ele( `cells` )->ele( n = `repeat` ns = `template`
+                  )->a( n = `list` v = `{template>/MT_LAYOUT}`
+                  )->a( n = `var`  v = `L1` )->ele( `ObjectIdentifier`
+                    )->a( n = `text` v = `{= '{' + ${L1>FNAME} + '}' }` ).
 
-    view->label( `IF Template (with re-rendering)` ).
-    view->switch( state  = client->_bind( mv_flag )
-                  change = client->_event( `CHANGE_FLAG` ) ).
-                  view   = view->vbox( ).
+    view->tag( `Label`
+        )->a( n = `text` v = `IF Template (with re-rendering)` ).
+    view->tag( `Switch`
+        )->a( n = `state`  v = client->_bind( mv_flag )
+        )->a( n = `change` v = client->_event( `CHANGE_FLAG` ) ).
+                  view   = view->ele( `VBox` ).
 
-    view->template_if( `{template>/MV_FLAG}`
-      )->template_then(
-        )->icon( src   = `sap-icon://accept`
-                 color = `green` )->get_parent(
-      )->template_else(
-        )->icon( src   = `sap-icon://decline`
-                 color = `red` ).
+    view->ele( n = `if` ns = `template`
+        )->a( n = `test` v = `{template>/MV_FLAG}` )->ele( n = `then` ns = `template` )->tag( n = `Icon` ns = `core`
+            )->a( n = `color` v = `green`
+            )->a( n = `src`   v = `sap-icon://accept` )->end( )->ele( n = `else` ns = `template` )->tag( n = `Icon` ns = `core`
+            )->a( n = `color` v = `red`
+            )->a( n = `src`   v = `sap-icon://decline` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_176.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_176.clas.abap
@@ -40,21 +40,26 @@ CLASS z2ui5_cl_smp_app_176 IMPLEMENTATION.
 
   METHOD main_view.
 
-    DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock`   v = `true`
+        )->a( n = `height`         v = `100%`
+        )->a( n = `xmlns`          v = `sap.m`
+        )->a( n = `xmlns:mvc`      v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`     v = `sap.ui.core`
+        )->a( n = `xmlns:template` v = `http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1` ).
 
-    DATA(page) = lo_view->shell(
-        )->page(
-                title          = `abap2UI5 - Templating - Dynamic Content in a Nested View`
-                id             = `test`
-                navbuttonpress = i_client->_event_nav_app_leave( )
-                shownavbutton  = i_client->check_app_prev_stack( ) ).
+    DATA(page) = lo_view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Templating - Dynamic Content in a Nested View`
+            )->a( n = `showNavButton`  b = i_client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = i_client->_event_nav_app_leave( )
+            )->a( n = `id`             v = `test` ).
 
-    page->message_strip(
-        text     = `This sample renders a main view and then embeds a second view into it as ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample renders a main view and then embeds a second view into it as ` &&
                    `nested content via nest_view_display.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     i_client->view_display( lo_view->stringify( ) ).
 
@@ -72,22 +77,25 @@ CLASS z2ui5_cl_smp_app_176 IMPLEMENTATION.
                          ( fname = `DATE` merge = `false` visible = `true`  binding = `{DATE}` )
                          ( fname = `AGE`  merge = `false` visible = `false` binding = `{AGE}` ) ).
 
-    DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lo_view_nested) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock`   v = `true`
+        )->a( n = `height`         v = `100%`
+        )->a( n = `xmlns`          v = `sap.m`
+        )->a( n = `xmlns:mvc`      v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`     v = `sap.ui.core`
+        )->a( n = `xmlns:template` v = `http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1` ).
 
-    lo_view_nested->shell( )->page( `Nested View`
-      )->table( i_client->_bind( mt_data )
-      )->columns(
-        )->template_repeat( list = `{template>/MT_LAYOUT}`
-                            var  = `LO`
-          )->column( mergeduplicates = `{LO>MERGE}`
-                     visible         = `{LO>VISIBLE}` )->get_parent(
-        )->get_parent( )->get_parent(
-        )->items(
-          )->column_list_item(
-            )->cells(
-              )->template_repeat( list = `{template>/MT_LAYOUT}`
-                                  var  = `LO2`
-                )->object_identifier( text = `{= '{' + ${LO2>FNAME} + '}' }` ).
+    lo_view_nested->ele( `Shell` )->ele( `Page`
+        )->a( n = `title` v = `Nested View` )->ele( `Table`
+          )->a( n = `items` v = i_client->_bind( mt_data ) )->ele( `columns` )->ele( n = `repeat` ns = `template`
+            )->a( n = `list` v = `{template>/MT_LAYOUT}`
+            )->a( n = `var`  v = `LO` )->ele( `Column`
+              )->a( n = `mergeDuplicates` v = `{LO>MERGE}`
+              )->a( n = `visible`         v = `{LO>VISIBLE}` )->end( )->end( )->end( )->ele( `items` )->ele( `ColumnListItem` 
+              )->ele( `cells` )->ele( n = `repeat` ns = `template`
+                  )->a( n = `list` v = `{template>/MT_LAYOUT}`
+                  )->a( n = `var`  v = `LO2` )->ele( `ObjectIdentifier`
+                    )->a( n = `text` v = `{= '{' + ${LO2>FNAME} + '}' }` ).
 
     i_client->nest_view_display( val           = lo_view_nested->stringify( )
                                  id            = `test`

--- a/src/01/z2ui5_cl_smp_app_186.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_186.clas.abap
@@ -53,40 +53,44 @@ CLASS z2ui5_cl_smp_app_186 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-         )->page(
-            title          = `abap2UI5 - File - Download to the Browser`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+             )->a( n = `title`          v = `abap2UI5 - File - Download to the Browser`
+             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The download_b64_file front-end action hands a base64 encoded file to the browser, which saves it ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The download_b64_file front-end action hands a base64 encoded file to the browser, which saves it ` &&
                    `under the given name - no ICF download service and no extra request needed.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->flex_box( width          = `100%`
-                    height         = `600px`
-                    alignitems     = `Center`
-                    justifycontent = `SpaceAround`
-      )->vbox( )->text( `Base64 String:`
-      )->text_area( value    = client->_bind( file_content_64 )
-                    rows     = `20`
-                    width    = `800px`
-                    wrapping = abap_true
-      )->get_parent(
-      )->vbox( justifycontent = `Center`
-               alignitems     = `Center`
-      )->text( `fill filename:`
-      )->input( value = client->_bind( file_name )
-                class = `sapUiLargeMarginBottom`
-                width = `15rem`
-      )->button( type  = `Emphasized`
-                 text  = `Open Download Popup`
-                 press = client->_event( `BUTTON_DOWNLOAD` ) ).
+    page->ele( `FlexBox`
+        )->a( n = `width`          v = `100%`
+        )->a( n = `height`         v = `600px`
+        )->a( n = `alignItems`     v = `Center`
+        )->a( n = `justifyContent` v = `SpaceAround` )->ele( `VBox` )->tag( `Text`
+          )->a( n = `text` v = `Base64 String:` )->tag( `TextArea`
+          )->a( n = `value`    v = client->_bind( file_content_64 )
+          )->a( n = `rows`     v = `20`
+          )->a( n = `width`    v = `800px`
+          )->a( n = `wrapping` b = abap_true )->end( )->ele( `VBox`
+          )->a( n = `justifyContent` v = `Center`
+          )->a( n = `alignItems`     v = `Center` )->tag( `Text`
+          )->a( n = `text` v = `fill filename:` )->tag( `Input`
+          )->a( n = `value` v = client->_bind( file_name )
+          )->a( n = `class` v = `sapUiLargeMarginBottom`
+          )->a( n = `width` v = `15rem` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `BUTTON_DOWNLOAD` )
+          )->a( n = `text`  v = `Open Download Popup`
+          )->a( n = `type`  v = `Emphasized` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_189.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_189.clas.abap
@@ -40,29 +40,36 @@ CLASS z2ui5_cl_smp_app_189 IMPLEMENTATION.
 
   METHOD render.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-          )->page(
-              title          = `abap2UI5 - Focus - Jump to the Next Input on Enter`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Focus - Jump to the Next Input on Enter`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Pressing Enter in an input field jumps the cursor to the next one via the set_focus follow-up action.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Pressing Enter in an input field jumps the cursor to the next one via the set_focus follow-up action.`
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        editable = abap_true
-       )->content( `form`
-       )->label( `One (Press Enter)` )->input( id     = `IdOne`
-                                               value  = client->_bind( one )
-                                               submit = client->_event( `one_enter` )
-       )->label( `Two` )->input( id     = `IdTwo`
-                                 value  = client->_bind( two )
-                                 submit = client->_event( `two_enter` )
-       )->label( `Three` )->input( id    = `IdThree`
-                                   value = client->_bind( three ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+           )->a( n = `text` v = `One (Press Enter)` )->tag( `Input`
+           )->a( n = `id`     v = `IdOne`
+           )->a( n = `value`  v = client->_bind( one )
+           )->a( n = `submit` v = client->_event( `one_enter` ) )->tag( `Label`
+           )->a( n = `text` v = `Two` )->tag( `Input`
+           )->a( n = `id`     v = `IdTwo`
+           )->a( n = `value`  v = client->_bind( two )
+           )->a( n = `submit` v = client->_event( `two_enter` ) )->tag( `Label`
+           )->a( n = `text` v = `Three` )->tag( `Input`
+           )->a( n = `id`    v = `IdThree`
+           )->a( n = `value` v = client->_bind( three ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_197.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_197.clas.abap
@@ -91,52 +91,69 @@ CLASS z2ui5_cl_smp_app_197 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` )->ele( `Shell` ).
 
-    DATA(page) = view->page( id = `page_main`
-            title               = `abap2UI5 - Event - Control Objects in t_arg (FacetFilter)`
-            navbuttonpress      = client->_event_nav_app_leave( )
-            shownavbutton       = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Event - Control Objects in t_arg (FacetFilter)`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    page->message_strip(
-        text     = `This sample shows a list-report table with a FacetFilter: selecting products ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample shows a list-report table with a FacetFilter: selecting products ` &&
                    `filters the rows, and Reset restores the full list. The listClose event sends ` &&
                    `the selected FacetFilterItem controls as event arguments - the framework ` &&
                    `marshals each one into a JSON object of its properties.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->facet_filter( id                  = `idFacetFilter`
-                        type                = `Light`
-                        showpersonalization = abap_true
-                        showreset           = abap_true
-                        reset               = client->_event( `RESET` )
-      )->facet_filter_list( title     = `Products`
-                            mode      = `MultiSelect`
-                            items     = client->_bind( mt_table_products )
-                            listclose = client->_event( val   = `FILTER`
+    page->ele( `FacetFilter`
+        )->a( n = `id`                  v = `idFacetFilter`
+        )->a( n = `showPersonalization` b = abap_true
+        )->a( n = `showReset`           b = abap_true
+        )->a( n = `type`                v = `Light`
+        )->a( n = `reset`               v = client->_event( `RESET` ) )->ele( `FacetFilterList`
+          )->a( n = `mode`      v = `MultiSelect`
+          )->a( n = `title`     v = `Products`
+          )->a( n = `listClose` v = client->_event( val   = `FILTER`
                                                         t_arg = VALUE #( ( `$event.mParameters.selectedItems` ) ) )
-        )->facet_filter_item(
-            key  = `{PRODUCT}`
-            text = `{PRODUCT}` ).
+          )->a( n = `items`     v = client->_bind( mt_table_products ) )->ele( `FacetFilterItem`
+            )->a( n = `key`  v = `{PRODUCT}`
+            )->a( n = `text` v = `{PRODUCT}` ).
 
-    DATA(tab) = page->table( id    = `tab`
-                             items = client->_bind( val = mt_table ) ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( val = mt_table )
+        )->a( n = `id`    v = `tab` ).
 
-    DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( `Product` ).
-    lo_columns->column( )->text( `Date` ).
-    lo_columns->column( )->text( `Name` ).
-    lo_columns->column( )->text( `Location` ).
-    lo_columns->column( )->text( `Quantity` ).
+    DATA(lo_columns) = tab->ele( `columns` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Product` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Date` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Name` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Location` ).
+    lo_columns->ele( `Column` )->tag( `Text`
+        )->a( n = `text` v = `Quantity` ).
 
-    DATA(lo_cells) = tab->items( )->column_list_item( ).
-    lo_cells->text( `{PRODUCT}` ).
-    lo_cells->text( `{CREATE_DATE}` ).
-    lo_cells->text( `{CREATE_BY}` ).
-    lo_cells->text( `{STORAGE_LOCATION}` ).
-    lo_cells->text( `{QUANTITY}` ).
+    DATA(lo_cells) = tab->ele( `items` )->ele( `ColumnListItem` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{PRODUCT}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_DATE}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{CREATE_BY}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{STORAGE_LOCATION}` ).
+    lo_cells->tag( `Text`
+        )->a( n = `text` v = `{QUANTITY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_202.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_202.clas.abap
@@ -21,58 +21,75 @@ CLASS z2ui5_cl_smp_app_202 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(lr_view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(lr_view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    lr_view        = lr_view->shell( )->page( id = `page_main`
-    title          = `abap2UI5 - Control - Wizard with Steps`
-    navbuttonpress = client->_event_nav_app_leave( )
-    shownavbutton  = client->check_app_prev_stack( ) ).
+    lr_view        = lr_view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Control - Wizard with Steps`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+        )->a( n = `id`             v = `page_main` ).
 
-    lr_view->message_strip(
-        text     = `A sap.m.Wizard guides through numbered steps. Branching is enabled: ` &&
+    lr_view->tag( `MessageStrip`
+        )->a( n = `text`     v = `A sap.m.Wizard guides through numbered steps. Branching is enabled: ` &&
                    `step 2 offers two follow-up steps, and the button pressed there picks ` &&
                    `the branch - the backend calls discardProgress and setNextStep by id ` &&
                    `(follow_up_action with cs_event-control_by_id).`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(lr_wizard) = lr_view->wizard( id              = `wiz`
-                                       enablebranching = abap_true ).
-    DATA(lr_wiz_step1) = lr_wizard->wizard_step( title     = `STEP1`
-                                                 validated = abap_true
-                                                 nextstep  = `STEP2` ).
-    lr_wiz_step1->message_strip( `STEP1` ).
+    DATA(lr_wizard) = lr_view->ele( `Wizard`
+        )->a( n = `id`              v = `wiz`
+        )->a( n = `enableBranching` b = abap_true ).
+    DATA(lr_wiz_step1) = lr_wizard->ele( `WizardStep`
+        )->a( n = `title`     v = `STEP1`
+        )->a( n = `validated` b = abap_true
+        )->a( n = `nextStep`  v = `STEP2` ).
+    lr_wiz_step1->tag( `MessageStrip`
+        )->a( n = `text` v = `STEP1` ).
 
-    DATA(lr_wiz_step2) = lr_wizard->wizard_step( id              = `STEP2`
-                                                 title           = `STEP2`
-                                                 validated       = abap_true
-                                                 subsequentsteps = `STEP22, STEP23` ).
+    DATA(lr_wiz_step2) = lr_wizard->ele( `WizardStep`
+        )->a( n = `id`              v = `STEP2`
+        )->a( n = `title`           v = `STEP2`
+        )->a( n = `validated`       b = abap_true
+        )->a( n = `subsequentSteps` v = `STEP22, STEP23` ).
 
-    lr_wiz_step2->message_strip( `STEP2` ).
-    lr_wiz_step2->button(
-        text  = `Press Step 2.2`
-        press = client->_event( `STEP22` ) ).
-    lr_wiz_step2->button(
-        text  = `Press Step 2.3`
-        press = client->_event( `STEP23` ) ).
+    lr_wiz_step2->tag( `MessageStrip`
+        )->a( n = `text` v = `STEP2` ).
+    lr_wiz_step2->tag( `Button`
+        )->a( n = `press` v = client->_event( `STEP22` )
+        )->a( n = `text`  v = `Press Step 2.2` ).
+    lr_wiz_step2->tag( `Button`
+        )->a( n = `press` v = client->_event( `STEP23` )
+        )->a( n = `text`  v = `Press Step 2.3` ).
 
-    DATA(lr_wiz_step22) = lr_wizard->wizard_step( id       = `STEP22`
-                                                 title     = `STEP2.2`
-                                                 validated = abap_true ).
+    DATA(lr_wiz_step22) = lr_wizard->ele( `WizardStep`
+        )->a( n = `id`        v = `STEP22`
+        )->a( n = `title`     v = `STEP2.2`
+        )->a( n = `validated` b = abap_true ).
 
-    lr_wiz_step22->message_strip( `STEP22` ).
+    lr_wiz_step22->tag( `MessageStrip`
+        )->a( n = `text` v = `STEP22` ).
 
-    DATA(lr_wiz_step23) = lr_wizard->wizard_step( id       = `STEP23`
-                                                 title     = `STEP2.3`
-                                                 validated = abap_true ).
+    DATA(lr_wiz_step23) = lr_wizard->ele( `WizardStep`
+        )->a( n = `id`        v = `STEP23`
+        )->a( n = `title`     v = `STEP2.3`
+        )->a( n = `validated` b = abap_true ).
 
-    lr_wiz_step23->message_strip( `STEP23` ).
+    lr_wiz_step23->tag( `MessageStrip`
+        )->a( n = `text` v = `STEP23` ).
 
-    DATA(lr_wiz_step3) = lr_wizard->wizard_step( title     = `STEP3`
-                                                 validated = abap_true ).
+    DATA(lr_wiz_step3) = lr_wizard->ele( `WizardStep`
+        )->a( n = `title`     v = `STEP3`
+        )->a( n = `validated` b = abap_true ).
 
-    lr_wiz_step3->message_strip( `STEP3` ).
+    lr_wiz_step3->tag( `MessageStrip`
+        )->a( n = `text` v = `STEP3` ).
 
     client->view_display( lr_view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_255.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_255.clas.abap
@@ -66,63 +66,63 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
                 `    font-size: 0.875rem;`                       &&
                 `}`.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->_generic( name = `style`
-                    ns   = `html` )->_cc_plain_xml( css )->get_parent( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
+    view->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
+                        )->a( n = `VALUE` v = css )->end( ).
 
-    DATA(page) = view->shell(
-         )->page(
-            title          = `abap2UI5 - CSS - FlexBox Layouts with Custom Classes`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+             )->a( n = `title`          v = `abap2UI5 - CSS - FlexBox Layouts with Custom Classes`
+             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Navigation layouts built with sap.m.FlexBox and own CSS classes: variable width, equal width with ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Navigation layouts built with sap.m.FlexBox and own CSS classes: variable width, equal width with ` &&
                    `a transition effect and a wrapping row. The hint button in the header explains each panel.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->header_content(
-       )->button( id = `hint_icon`
-           icon      = `sap-icon://hint`
-           tooltip   = `Sample information`
-           press     = client->_event( `POPOVER` ) ).
+    page->ele( `headerContent` )->tag( `Button`
+           )->a( n = `press`   v = client->_event( `POPOVER` )
+           )->a( n = `icon`    v = `sap-icon://hint`
+           )->a( n = `id`      v = `hint_icon`
+           )->a( n = `tooltip` v = `Sample information` ).
 
-    page->header_content(
-       )->link(
-           text   = `UI5 Demo Kit`
-           target = `_blank`
-           href   = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.FlexBox/sample/sap.m.sample.FlexBoxNav` ).
+    page->ele( `headerContent` )->tag( `Link`
+           )->a( n = `text`   v = `UI5 Demo Kit`
+           )->a( n = `target` v = `_blank`
+           )->a( n = `href`   v = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.FlexBox/sample/sap.m.sample.FlexBoxNav` ).
 
-    DATA(layout) = page->vbox( `navigationExamples`
-                          )->panel( headertext = `Variable width`
-                              )->flex_box(
-                                  class          = `ne-flexbox1`
-                                  rendertype     = `List`
-                                  justifycontent = `Center`
-                                  alignitems     = `Center`
-                                  )->html( `<a >Item 1</a>` )->get_parent(
-                                  )->html( `<a >Long item 2</a>` )->get_parent(
-                                  )->html( `<a >Item 3</a>` )->get_parent( )->get_parent(
-      )->panel( headertext = `Same width, transition effect`
-                              )->flex_box(
-                                  class          = `ne-flexbox2`
-                                  rendertype     = `List`
-                                  justifycontent = `SpaceBetween`
-                                  alignitems     = `Center`
-                                  )->html( `<a >Item 1</a>` )->get(
-                                      )->layout_data( `core`
-                                          )->flex_item_data( growfactor = `1`
-                                                             basesize   = `25%` )->get_parent( )->get_parent(
-                                  )->html( `<a >Long item 2</a>` )->get(
-                                      )->layout_data( `core`
-                                          )->flex_item_data( growfactor = `1`
-                                                             basesize   = `25%` )->get_parent( )->get_parent(
-                                  )->html( `<a >Item 3</a>` )->get(
-                                      )->layout_data( `core`
-                                          )->flex_item_data( growfactor = `1`
-                                                             basesize   = `25%` )->get_parent( )->get_parent( ).
+    DATA(layout) = page->ele( `VBox`
+        )->a( n = `class` v = `navigationExamples` )->ele( `Panel`
+                              )->a( n = `headerText` v = `Variable width` )->ele( `FlexBox`
+                                  )->a( n = `class`          v = `ne-flexbox1`
+                                  )->a( n = `renderType`     v = `List`
+                                  )->a( n = `alignItems`     v = `Center`
+                                  )->a( n = `justifyContent` v = `Center` )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Item 1</a>` )->end( )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Long item 2</a>` )->end( )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Item 3</a>` )->end( )->end( )->ele( `Panel`
+          )->a( n = `headerText` v = `Same width, transition effect` )->ele( `FlexBox`
+                                  )->a( n = `class`          v = `ne-flexbox2`
+                                  )->a( n = `renderType`     v = `List`
+                                  )->a( n = `alignItems`     v = `Center`
+                                  )->a( n = `justifyContent` v = `SpaceBetween` )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Item 1</a>` )->ele( n = `layoutData` ns = `core` )->tag( `FlexItemData`
+                                              )->a( n = `growFactor` v = `1`
+                                              )->a( n = `baseSize`   v = `25%` )->end( )->end( )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Long item 2</a>` )->ele( n = `layoutData` ns = `core` )->tag( `FlexItemData`
+                                              )->a( n = `growFactor` v = `1`
+                                              )->a( n = `baseSize`   v = `25%` )->end( )->end( )->ele( n = `HTML` ns = `core`
+                                      )->a( n = `content` v = `<a >Item 3</a>` )->ele( n = `layoutData` ns = `core` )->tag( `FlexItemData`
+                                              )->a( n = `growFactor` v = `1`
+                                              )->a( n = `baseSize`   v = `25%` )->end( )->end( ).
 
     client->view_display( page->stringify( ) ).
 
@@ -140,12 +140,16 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
-    view->quick_view( placement = `Bottom`
-                      width     = `auto`
-              )->quick_view_page( pageid      = `sampleInformationId`
-                                  header      = `Sample information`
-                                  description = `Here is an example of how you can use navigation items as unordered list items in a Flex Box.` ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:html` v = `http://www.w3.org/1999/xhtml` ).
+    view->ele( `QuickView`
+        )->a( n = `placement` v = `Bottom`
+        )->a( n = `width`     v = `auto` )->ele( `QuickViewPage`
+                  )->a( n = `description` v = `Here is an example of how you can use navigation items as unordered list items in a Flex Box.`
+                  )->a( n = `header`      v = `Sample information`
+                  )->a( n = `pageId`      v = `sampleInformationId` ).
 
     client->popover_display(
       xml   = view->stringify( )

--- a/src/01/z2ui5_cl_smp_app_255.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_255.clas.abap
@@ -71,10 +71,10 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
-    view->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
-                        )->a( n = `VALUE` v = css )->end( ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    " raw markup travels in the content attribute of a core:HTML leaf - the
+    " builder re-escapes it on stringify, so the literal markup is written here
+    view->tag( n = `HTML` ns = `core` )->a( n = `content` v = `<style>` && css && `</style>` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
              )->a( n = `title`          v = `abap2UI5 - CSS - FlexBox Layouts with Custom Classes`
@@ -142,8 +142,7 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
         )->a( n = `xmlns`      v = `sap.m`
-        )->a( n = `xmlns:core` v = `sap.ui.core`
-        )->a( n = `xmlns:html` v = `http://www.w3.org/1999/xhtml` ).
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
     view->ele( `QuickView`
         )->a( n = `placement` v = `Bottom`
         )->a( n = `width`     v = `auto` )->ele( `QuickViewPage`

--- a/src/01/z2ui5_cl_smp_app_279.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_279.clas.abap
@@ -41,13 +41,14 @@ CLASS z2ui5_cl_smp_app_279 IMPLEMENTATION.
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:tnt`    v = `sap.tnt` )->ele( `Shell` )->ele( `Page`
+        )->a( n = `xmlns:tnt`    v = `sap.tnt`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` )->ele( `Shell` )->ele( `Page`
                        )->a( n = `title`          v = `abap2UI5 - Navigation - Data Loss Protection on Leaving`
                        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
                        )->a( n = `navButtonPress` v = client->_event( `BACK` ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Unsaved input marks the page dirty via a custom control; navigating back then opens a confirmation ` &&
+        )->a( n = `text` v = `Unsaved input marks the page dirty via a custom control; navigating back then opens a confirmation ` &&
                    `popup instead of leaving and losing the data.`
         )->a( n = `type`     v = `Information`
         )->a( n = `showIcon` b = abap_true
@@ -129,7 +130,7 @@ CLASS z2ui5_cl_smp_app_279 IMPLEMENTATION.
         )->a( n = `title` v = `Warning`
         )->a( n = `icon`  v = `sap-icon://status-critical` )->ele( `VBox`
             )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Text`
-                )->a( n = `text` v = `Your entries will be lost when you leave this page.` )->end( )->ele( `buttons` )->tag( `Button`
+                )->a( n = `text`  v = `Your entries will be lost when you leave this page.` )->end( )->ele( `buttons` )->tag( `Button`
                 )->a( n = `press` v = client->_event( `POPUP_CANCEL` )
                 )->a( n = `text`  v = `Cancel` )->tag( `Button`
                 )->a( n = `press` v = client->_event( `POPUP_LEAVE` )

--- a/src/01/z2ui5_cl_smp_app_279.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_279.clas.abap
@@ -35,44 +35,49 @@ CLASS z2ui5_cl_smp_app_279 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory(
-                   )->shell(
-                   )->page(
-                      title          = `abap2UI5 - Navigation - Data Loss Protection on Leaving`
-                      navbuttonpress = client->_event( `BACK` )
-                      shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:tnt`    v = `sap.tnt` )->ele( `Shell` )->ele( `Page`
+                       )->a( n = `title`          v = `abap2UI5 - Navigation - Data Loss Protection on Leaving`
+                       )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                       )->a( n = `navButtonPress` v = client->_event( `BACK` ) ).
 
-    page->message_strip(
-        text     = `Unsaved input marks the page dirty via a custom control; navigating back then opens a confirmation ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Unsaved input marks the page dirty via a custom control; navigating back then opens a confirmation ` &&
                    `popup instead of leaving and losing the data.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(box) = page->flex_box( direction  = `Row`
-                                alignitems = `Start`
-                                class      = `sapUiTinyMargin` ).
+    DATA(box) = page->ele( `FlexBox`
+        )->a( n = `class`      v = `sapUiTinyMargin`
+        )->a( n = `alignItems` v = `Start`
+        )->a( n = `direction`  v = `Row` ).
 
-    box->input(
-      id          = `input`
-      value       = client->_bind( text_input )
-      submit      = client->_event( `SUBMIT` )
-      width       = `40rem`
-      placeholder = `Enter data, submit and navigate back to trigger data loss protection` ).
+    box->tag( `Input`
+        )->a( n = `id`          v = `input`
+        )->a( n = `placeholder` v = `Enter data, submit and navigate back to trigger data loss protection`
+        )->a( n = `value`       v = client->_bind( text_input )
+        )->a( n = `submit`      v = client->_event( `SUBMIT` )
+        )->a( n = `width`       v = `40rem` ).
 
-    box->info_label(
-      text        = `dirty`
-      colorscheme = `8`
-      class       = `sapUiSmallMarginBegin sapUiTinyMarginTop`
-      visible     = client->_bind( dirty ) ).
+    box->ele( n = `InfoLabel` ns = `tnt`
+        )->a( n = `class`       v = `sapUiSmallMarginBegin sapUiTinyMarginTop`
+        )->a( n = `text`        v = `dirty`
+        )->a( n = `colorScheme` v = `8`
+        )->a( n = `visible`     v = client->_bind( dirty ) ).
 
-    box->button(
-      text    = `Reset`
-      press   = client->_event( `RESET` )
-      class   = `sapUiSmallMarginBegin`
-      visible = client->_bind( dirty ) ).
+    box->tag( `Button`
+        )->a( n = `press`   v = client->_event( `RESET` )
+        )->a( n = `text`    v = `Reset`
+        )->a( n = `visible` v = client->_bind( dirty )
+        )->a( n = `class`   v = `sapUiSmallMarginBegin` ).
 
-    page->_z2ui5( )->dirty( client->_bind( dirty ) ).
+    page->tag( n = `Dirty` ns = `z2ui5` ).
 
     client->view_display( page->stringify( ) ).
 
@@ -116,21 +121,20 @@ CLASS z2ui5_cl_smp_app_279 IMPLEMENTATION.
 
   METHOD popup_confirm_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    popup->dialog(
-        title = `Warning`
-        icon  = `sap-icon://status-critical`
-        )->vbox( `sapUiSmallMargin`
-            )->text( `Your entries will be lost when you leave this page.`
-        )->get_parent(
-        )->buttons(
-            )->button(
-                text  = `Cancel`
-                press = client->_event( `POPUP_CANCEL` )
-            )->button(
-                text  = `Leave Page`
-                press = client->_event( `POPUP_LEAVE` )
-                type  = `Emphasized` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:tnt`  v = `sap.tnt` ).
+    popup->ele( `Dialog`
+        )->a( n = `title` v = `Warning`
+        )->a( n = `icon`  v = `sap-icon://status-critical` )->ele( `VBox`
+            )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Text`
+                )->a( n = `text` v = `Your entries will be lost when you leave this page.` )->end( )->ele( `buttons` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `POPUP_CANCEL` )
+                )->a( n = `text`  v = `Cancel` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `POPUP_LEAVE` )
+                )->a( n = `text`  v = `Leave Page`
+                )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_305.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_305.clas.abap
@@ -29,8 +29,7 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
     DATA(page) = view->ele( `Shell` )->ele( `Page`
                         )->a( n = `title`          v = `abap2UI5 - CSS - Color Table Cells from the Backend`
                         )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
@@ -43,8 +42,10 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
         )->a( n = `showIcon` b = abap_true
         )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
-           )->a( n = `VALUE` v = `td:has([data-color="red"]){ `
+    " raw markup travels in the content attribute of a core:HTML leaf - the
+    " builder re-escapes it on stringify, so the literal markup is written here
+    page->tag( n = `HTML` ns = `core` )->a( n = `content` v = `<style>`
+        && `td:has([data-color="red"]){ `
         && `    background-color: red;`
         && `}`
         && ``
@@ -66,7 +67,8 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
         && ``
         && `td:has([data-color="yellow"]){`
         && `    background-color: yellow;`
-        && `}` ).
+        && `}`
+        && `</style>` ).
 
     DATA(tab) = page->ele( `Table`
         )->a( n = `items` v = client->_bind( t_tab )

--- a/src/01/z2ui5_cl_smp_app_305.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_305.clas.abap
@@ -24,25 +24,27 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
 
   METHOD set_view.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-                    )->page(
-                      title          = `abap2UI5 - CSS - Color Table Cells from the Backend`
-                      navbuttonpress = client->_event_nav_app_leave( )
-                      shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:html`   v = `http://www.w3.org/1999/xhtml` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+                        )->a( n = `title`          v = `abap2UI5 - CSS - Color Table Cells from the Backend`
+                        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Table cells are coloured from the backend: each cell carries a data-color attribute bound to the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Table cells are coloured from the backend: each cell carries a data-color attribute bound to the ` &&
                    `row, and an inline html style element maps those values to a background colour.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->_generic(
-            name = `style`
-            ns   = `html`
-       )->_cc_plain_xml(
-           `td:has([data-color="red"]){ `
+    page->ele( n = `style` ns = `html` )->tag( n = `ZZPLAIN` ns = `html`
+           )->a( n = `VALUE` v = `td:has([data-color="red"]){ `
         && `    background-color: red;`
         && `}`
         && ``
@@ -66,32 +68,22 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
         && `    background-color: yellow;`
         && `}` ).
 
-    DATA(tab) = page->table(
-            items = client->_bind( t_tab )
-            mode  = `MultiSelect`
-        )->header_toolbar(
-            )->overflow_toolbar(
-                )->title( `change cell color`
-        )->get_parent( )->get_parent( ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_tab )
+        )->a( n = `mode`  v = `MultiSelect` )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                    )->a( n = `text` v = `change cell color` )->end( )->end( ).
 
-    tab->columns(
-        )->column(
-            )->text( `Title` )->get_parent(
-        )->column(
-            )->text( `Color` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+                )->a( n = `text` v = `Color` )->end( ).
 
-    tab->items( )->column_list_item(
-      )->cells(
-        )->text( `{TITLE}`
-          )->get(
-            )->custom_data(
-              )->core_custom_data( key        = `color`
-                                   value      = `{VALUE}`
-                                   writetodom = abap_true
-            )->get_parent(
-          )->get_parent(
-        )->input( value   = `{VALUE}`
-                  enabled = abap_true ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->ele( `Text`
+            )->a( n = `text` v = `{TITLE}` )->ele( `customData` )->tag( n = `CustomData` ns = `core`
+                  )->a( n = `value`      v = `{VALUE}`
+                  )->a( n = `key`        v = `color`
+                  )->a( n = `writeToDom` b = abap_true )->end( )->end( )->tag( `Input`
+            )->a( n = `enabled` b = abap_true
+            )->a( n = `value`   v = `{VALUE}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -73,7 +73,8 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(cont) = view->ele( `Shell` ).
     DATA(page) = cont->ele( `Page`
@@ -82,7 +83,7 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
         )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Capture photos from the device camera custom control; pick the facing mode and camera, then select ` &&
+        )->a( n = `text` v = `Capture photos from the device camera custom control; pick the facing mode and camera, then select ` &&
                    `a captured picture from the list to display it in full resolution.`
         )->a( n = `type`     v = `Information`
         )->a( n = `showIcon` b = abap_true
@@ -90,23 +91,23 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
 
     page->ele( `VBox`
         )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
-           )->a( n = `text`     v = `facingMode: `
-           )->a( n = `labelFor` v = `ComboFacingMode` )->ele( `ComboBox`
+           )->a( n = `text`        v = `facingMode: `
+           )->a( n = `labelFor`    v = `ComboFacingMode` )->ele( `ComboBox`
            )->a( n = `selectedKey` v = client->_bind( facing_mode )
            )->a( n = `items`       v = |\{path:'{ client->_bind( val  = facing_modes
                     path        = abap_true ) }', sorter: \{ path: 'TEXT' \} \}|
-           )->a( n = `id`          v = `ComboFacingMode` )->tag( n = `Item` ns = `core`
+           )->a( n = `id`   v = `ComboFacingMode` )->tag( n = `Item` ns = `core`
            )->a( n = `key`  v = `{KEY}`
            )->a( n = `text` v = `{TEXT}` ).
 
     page->ele( `VBox`
         )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
-           )->a( n = `text`     v = `device: `
-           )->a( n = `labelFor` v = `ComboDevice` )->ele( n = `CameraSelector` ns = `z2ui5`
+           )->a( n = `text`        v = `device: `
+           )->a( n = `labelFor`    v = `ComboDevice` )->ele( n = `CameraSelector` ns = `z2ui5`
            )->a( n = `selectedKey` v = client->_bind( device )
            )->a( n = `items`       v = |\{path:'{ client->_bind( val  = devices
            path        = abap_true ) }', sorter: \{ path: 'TEXT' \} \}|
-           )->a( n = `id`          v = `ComboDevice` )->tag( n = `Item` ns = `core`
+           )->a( n = `id`   v = `ComboDevice` )->tag( n = `Item` ns = `core`
            )->a( n = `key`  v = `{KEY}`
            )->a( n = `text` v = `{TEXT}` ).
 

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -68,65 +68,77 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(cont) = view->shell( ).
-    DATA(page) = cont->page( title          = `abap2UI5 - Device - Camera, Take Photos`
-                             navbuttonpress = client->_event_nav_app_leave( )
-                             shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(cont) = view->ele( `Shell` ).
+    DATA(page) = cont->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Device - Camera, Take Photos`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Capture photos from the device camera custom control; pick the facing mode and camera, then select ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Capture photos from the device camera custom control; pick the facing mode and camera, then select ` &&
                    `a captured picture from the list to display it in full resolution.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-       )->label( text     = `facingMode: `
-                 labelfor = `ComboFacingMode`
-       )->combobox( id          = `ComboFacingMode`
-                    selectedkey = client->_bind( facing_mode )
-                    items       = |\{path:'{ client->_bind( val  = facing_modes
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
+           )->a( n = `text`     v = `facingMode: `
+           )->a( n = `labelFor` v = `ComboFacingMode` )->ele( `ComboBox`
+           )->a( n = `selectedKey` v = client->_bind( facing_mode )
+           )->a( n = `items`       v = |\{path:'{ client->_bind( val  = facing_modes
                     path        = abap_true ) }', sorter: \{ path: 'TEXT' \} \}|
-       )->get( )->item( key  = `{KEY}`
-                        text = `{TEXT}` ).
+           )->a( n = `id`          v = `ComboFacingMode` )->tag( n = `Item` ns = `core`
+           )->a( n = `key`  v = `{KEY}`
+           )->a( n = `text` v = `{TEXT}` ).
 
-    page->vbox( `sapUiSmallMargin`
-       )->label( text     = `device: `
-                 labelfor = `ComboDevice`
-       )->_z2ui5( )->camera_selector(
-           id          = `ComboDevice`
-           selectedkey = client->_bind( device )
-           items       = |\{path:'{ client->_bind( val  = devices
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
+           )->a( n = `text`     v = `device: `
+           )->a( n = `labelFor` v = `ComboDevice` )->ele( n = `CameraSelector` ns = `z2ui5`
+           )->a( n = `selectedKey` v = client->_bind( device )
+           )->a( n = `items`       v = |\{path:'{ client->_bind( val  = devices
            path        = abap_true ) }', sorter: \{ path: 'TEXT' \} \}|
-       )->get( )->item( key  = `{KEY}`
-                        text = `{TEXT}` ).
+           )->a( n = `id`          v = `ComboDevice` )->tag( n = `Item` ns = `core`
+           )->a( n = `key`  v = `{KEY}`
+           )->a( n = `text` v = `{TEXT}` ).
 
-    page->_z2ui5( )->camera_picture( value      = client->_bind( mv_picture_base )
-                                     thumbnail  = client->_bind( mv_picture_thumb )
-                                     onphoto    = client->_event( `CAPTURE` )
-                                     facingmode = client->_bind( facing_mode )
-                                     deviceid   = client->_bind( device ) ).
+    page->tag( n = `CameraPicture` ns = `z2ui5`
+        )->a( n = `value`      v = client->_bind( mv_picture_base )
+        )->a( n = `thumbnail`  v = client->_bind( mv_picture_thumb )
+        )->a( n = `OnPhoto`    v = client->_event( `CAPTURE` )
+        )->a( n = `facingMode` v = client->_bind( facing_mode )
+        )->a( n = `deviceId`   v = client->_bind( device ) ).
 
-    DATA(lo_list) = page->list(
-                                headertext      = `List Output`
-                                items           = client->_bind( mt_picture_out )
-                                mode            = `SingleSelectMaster`
-                                selectionchange = client->_event( `DISPLAY` ) ).
+    DATA(lo_list) = page->ele( `List`
+        )->a( n = `headerText`      v = `List Output`
+        )->a( n = `items`           v = client->_bind( mt_picture_out )
+        )->a( n = `mode`            v = `SingleSelectMaster`
+        )->a( n = `selectionChange` v = client->_event( `DISPLAY` ) ).
 
-    DATA(lo_item) = lo_list->_generic( name   = `CustomListItem`
-                                       t_prop = VALUE #( ( n = `selected` v = `{SELECTED}` ) ) ).
+    DATA(lo_item) = lo_list->ele( `CustomListItem`
+        )->a( n = `selected` v = `{SELECTED}` ).
 
-    DATA(lo_hbox) = lo_item->hbox( alignitems = `Center` ).
-    lo_hbox->image( src    = `{THUMBNAIL}`
-                    height = `80px` ).
-    lo_hbox->text( `{NAME}` ).
+    DATA(lo_hbox) = lo_item->ele( `HBox`
+        )->a( n = `alignItems` v = `Center` ).
+    lo_hbox->tag( `Image`
+        )->a( n = `src`    v = `{THUMBNAIL}`
+        )->a( n = `height` v = `80px` ).
+    lo_hbox->tag( `Text`
+        )->a( n = `text` v = `{NAME}` ).
 
     IF mv_pic_display IS NOT INITIAL.
-      page->image( src    = client->_bind( mv_pic_display )
-                   height = `200px`
-                   class  = `sapUiSmallMargin` ).
+      page->tag( `Image`
+          )->a( n = `src`    v = client->_bind( mv_pic_display )
+          )->a( n = `class`  v = `sapUiSmallMargin`
+          )->a( n = `height` v = `200px` ).
     ENDIF.
 
     client->view_display( view->stringify( ) ).

--- a/src/01/z2ui5_cl_smp_app_316.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_316.clas.abap
@@ -41,103 +41,129 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
     body       = `body`
     new_window = `true` ).
 
-    DATA(page) = z2ui5_cl_xml_view=>factory(
-        )->shell(
-            )->page( title          = `abap2UI5 - Browser - Open Mail, Phone and SMS Links`
-                     navbuttonpress = client->_event_nav_app_leave( )
-                     shownavbutton  = client->check_app_prev_stack( )
-                      ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` )->ele( `Shell` )->ele( `Page`
+                )->a( n = `title`          v = `abap2UI5 - Browser - Open Mail, Phone and SMS Links`
+                )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The URL helper triggers native browser actions from ABAP: open e-mail, telephone and SMS links, or ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The URL helper triggers native browser actions from ABAP: open e-mail, telephone and SMS links, or ` &&
                    `redirect the browser to a URL.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(layout) = page->vertical_layout( class = `sapUiContentPadding`
-                                          width = `100%` ).
+    DATA(layout) = page->ele( n = `VerticalLayout` ns = `layout`
+        )->a( n = `class` v = `sapUiContentPadding`
+        )->a( n = `width` v = `100%` ).
 
-    DATA(email_form) = layout->simple_form( `Trigger E-Mail` ).
+    DATA(email_form) = layout->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Trigger E-Mail` ).
 
-    email_form->label( text     = `E-Mail`
-                       labelfor = `inputEmail` ).
-    email_form->input( id          = `inputEmail`
-                       value       = client->_bind( email-email )
-                       type        = `Email`
-                       placeholder = `Enter email`
-                       class       = `sapUiSmallMarginBottom` ).
+    email_form->tag( `Label`
+        )->a( n = `text`     v = `E-Mail`
+        )->a( n = `labelFor` v = `inputEmail` ).
+    email_form->tag( `Input`
+        )->a( n = `id`          v = `inputEmail`
+        )->a( n = `placeholder` v = `Enter email`
+        )->a( n = `type`        v = `Email`
+        )->a( n = `value`       v = client->_bind( email-email )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
 
-    email_form->input( id          = `inputCcEmail`
-                       value       = client->_bind( email-cc )
-                       type        = `Email`
-                       placeholder = `Enter cc email`
-                       class       = `sapUiSmallMarginBottom` ).
+    email_form->tag( `Input`
+        )->a( n = `id`          v = `inputCcEmail`
+        )->a( n = `placeholder` v = `Enter cc email`
+        )->a( n = `type`        v = `Email`
+        )->a( n = `value`       v = client->_bind( email-cc )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
 
-    email_form->input( id          = `inputBccEmail`
-                       value       = client->_bind( email-bcc )
-                       type        = `Email`
-                       placeholder = `Enter bcc email`
-                       class       = `sapUiSmallMarginBottom` ).
+    email_form->tag( `Input`
+        )->a( n = `id`          v = `inputBccEmail`
+        )->a( n = `placeholder` v = `Enter bcc email`
+        )->a( n = `type`        v = `Email`
+        )->a( n = `value`       v = client->_bind( email-bcc )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
 
-    email_form->label( text     = `Subject`
-                       labelfor = `inputText` ).
-    email_form->input( id          = `inputText`
-                       value       = client->_bind( email-subject )
-                       placeholder = `Enter text`
-                       class       = `sapUiSmallMarginBottom` ).
+    email_form->tag( `Label`
+        )->a( n = `text`     v = `Subject`
+        )->a( n = `labelFor` v = `inputText` ).
+    email_form->tag( `Input`
+        )->a( n = `id`          v = `inputText`
+        )->a( n = `placeholder` v = `Enter text`
+        )->a( n = `value`       v = client->_bind( email-subject )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
 
-    email_form->label( `Mail Body`
-         )->text_area( valueliveupdate = abap_true
-                       value           = client->_bind( email-body )
-                       growing         = abap_true
-                       growingmaxlines = `7`
-                       width           = `100%` ).
+    email_form->tag( `Label`
+        )->a( n = `text` v = `Mail Body` )->tag( `TextArea`
+             )->a( n = `value`           v = client->_bind( email-body )
+             )->a( n = `width`           v = `100%`
+             )->a( n = `valueLiveUpdate` b = abap_true
+             )->a( n = `growing`         b = abap_true
+             )->a( n = `growingMaxLines` v = `7` ).
 
-    email_form->button( text  = `Trigger Email`
-                        press = client->follow_up_action( val   = client->cs_event-urlhelper
+    email_form->tag( `Button`
+        )->a( n = `press` v = client->follow_up_action( val   = client->cs_event-urlhelper
                         t_arg = VALUE #( ( `TRIGGER_EMAIL` )
-                                                                        ( |${ client->_bind( email ) }| ) ) ) ).
+                                                                        ( |${ client->_bind( email ) }| ) ) )
+        )->a( n = `text`  v = `Trigger Email` ).
 
-    DATA(telephone_form) = layout->simple_form( `Trigger Telephone` ).
+    DATA(telephone_form) = layout->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Trigger Telephone` ).
 
-    telephone_form->label( text     = `Telephone`
-                           labelfor = `inputTel` ).
-    telephone_form->input( id          = `inputTel`
-                           value       = client->_bind( phone )
-                           type        = `Tel`
-                           placeholder = `Enter telephone number`
-                           class       = `sapUiSmallMarginBottom` ).
-    telephone_form->button(
-        text  = `Trigger Telephone`
-        press = client->follow_up_action( val   = client->cs_event-urlhelper
+    telephone_form->tag( `Label`
+        )->a( n = `text`     v = `Telephone`
+        )->a( n = `labelFor` v = `inputTel` ).
+    telephone_form->tag( `Input`
+        )->a( n = `id`          v = `inputTel`
+        )->a( n = `placeholder` v = `Enter telephone number`
+        )->a( n = `type`        v = `Tel`
+        )->a( n = `value`       v = client->_bind( phone )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
+    telephone_form->tag( `Button`
+        )->a( n = `press` v = client->follow_up_action( val   = client->cs_event-urlhelper
         t_arg = VALUE #( ( `TRIGGER_TEL` )
-                                                        ( |${ client->_bind( phone ) }| ) ) ) ).
+                                                        ( |${ client->_bind( phone ) }| ) ) )
+        )->a( n = `text`  v = `Trigger Telephone` ).
 
-    DATA(mobile_form) = layout->simple_form( `Trigger SMS` ).
+    DATA(mobile_form) = layout->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Trigger SMS` ).
 
-    mobile_form->label( text     = `Number`
-                        labelfor = `inputNumber` ).
-    mobile_form->input( id          = `inputNumber`
-                        value       = client->_bind( mobile )
-                        type        = `Number`
-                        placeholder = `Enter a number`
-                        class       = `sapUiSmallMarginBottom` ).
-    mobile_form->button( text  = `Trigger SMS`
-                         press = client->follow_up_action( val   = client->cs_event-urlhelper
-                         t_arg = VALUE #( ( `TRIGGER_SMS` ) ( |${ client->_bind( mobile ) }| ) ) ) ).
+    mobile_form->tag( `Label`
+        )->a( n = `text`     v = `Number`
+        )->a( n = `labelFor` v = `inputNumber` ).
+    mobile_form->tag( `Input`
+        )->a( n = `id`          v = `inputNumber`
+        )->a( n = `placeholder` v = `Enter a number`
+        )->a( n = `type`        v = `Number`
+        )->a( n = `value`       v = client->_bind( mobile )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
+    mobile_form->tag( `Button`
+        )->a( n = `press` v = client->follow_up_action( val   = client->cs_event-urlhelper
+                         t_arg = VALUE #( ( `TRIGGER_SMS` ) ( |${ client->_bind( mobile ) }| ) ) )
+        )->a( n = `text`  v = `Trigger SMS` ).
 
-    DATA(url_form) = layout->simple_form( `Redirect` ).
-    url_form->label( text     = `URL`
-                     labelfor = `inputUrl` ).
-    url_form->input( id          = `inputUrl`
-                     value       = client->_bind( url-url )
-                     type        = `Url`
-                     placeholder = `Enter URL`
-                     class       = `sapUiSmallMarginBottom` ).
-    url_form->button( text  = `Redirect`
-                      press = client->follow_up_action( val   = client->cs_event-urlhelper
-                      t_arg = VALUE #( ( `REDIRECT` ) ( |${ client->_bind( url ) }| ) ) ) ).
+    DATA(url_form) = layout->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title` v = `Redirect` ).
+    url_form->tag( `Label`
+        )->a( n = `text`     v = `URL`
+        )->a( n = `labelFor` v = `inputUrl` ).
+    url_form->tag( `Input`
+        )->a( n = `id`          v = `inputUrl`
+        )->a( n = `placeholder` v = `Enter URL`
+        )->a( n = `type`        v = `Url`
+        )->a( n = `value`       v = client->_bind( url-url )
+        )->a( n = `class`       v = `sapUiSmallMarginBottom` ).
+    url_form->tag( `Button`
+        )->a( n = `press` v = client->follow_up_action( val   = client->cs_event-urlhelper
+                      t_arg = VALUE #( ( `REDIRECT` ) ( |${ client->_bind( url ) }| ) ) )
+        )->a( n = `text`  v = `Redirect` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -20,65 +20,70 @@ CLASS z2ui5_cl_smp_app_325 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page( title          = `abap2UI5 - Browser - Copy to Clipboard`
-                   navbuttonpress = client->_event_nav_app_leave( )
-                   shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:uxap`   v = `sap.uxap` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Browser - Copy to Clipboard`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `Copy the input field or text-area content to the system clipboard via the clipboard_copy follow-up action.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `Copy the input field or text-area content to the system clipboard via the clipboard_copy follow-up action.`
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      DATA(obj_page) = page->object_page_layout(
-          showtitleinheadercontent = abap_true
-          showeditheaderbutton     = abap_true
-          uppercaseanchorbar       = abap_false ).
+      DATA(obj_page) = page->ele( n = `ObjectPageLayout` ns = `uxap`
+          )->a( n = `showTitleInHeaderContent` b = abap_true
+          )->a( n = `showEditHeaderButton`     b = abap_true
+          )->a( n = `upperCaseAnchorBar`       b = abap_false ).
 
-      DATA(header_title) = obj_page->header_title(
-         )->object_page_dyn_header_title( ).
+      DATA(header_title) = obj_page->ele( n = `headerTitle` ns = `uxap` )->ele( n = `ObjectPageDynamicHeaderTitle` ns = `uxap` ).
 
-      header_title->expanded_heading( )->hbox( )->title(
-          text     = `Test`
-          wrapping = abap_true ).
-      header_title->snapped_heading( )->flex_box( alignitems = `Center` )->title(
-          text     = `Test`
-          wrapping = abap_true ).
+      header_title->ele( n = `expandedHeading` ns = `uxap` )->ele( `HBox` )->tag( `Title`
+          )->a( n = `text`     v = `Test`
+          )->a( n = `wrapping` b = abap_true ).
+      header_title->ele( n = `snappedHeading` ns = `uxap` )->ele( `FlexBox`
+          )->a( n = `alignItems` v = `Center` )->tag( `Title`
+          )->a( n = `text`     v = `Test`
+          )->a( n = `wrapping` b = abap_true ).
 
-      DATA(sections) = obj_page->sections( ).
+      DATA(sections) = obj_page->ele( n = `sections` ns = `uxap` ).
 
-      sections->object_page_section(
-                                     titleuppercase = abap_false
-                                     id             = `id_sec1`
-                                     title          = `...`
-        )->sub_sections( )->object_page_sub_section( id    = `id_input`
-                                                     title = `Input field`
-        )->blocks( )->vbox(
-        )->input( value = client->_bind( input )
-                  width = `50%`
-        )->button( text  = `Copy input`
-                   type  = `Emphasized`
-                   press = client->_event( `COPY_INPUT` ) ).
+      sections->ele( n = `ObjectPageSection` ns = `uxap`
+          )->a( n = `titleUppercase` b = abap_false
+          )->a( n = `title`          v = `...`
+          )->a( n = `id`             v = `id_sec1` )->ele( n = `subSections` ns = `uxap` )->ele( n = `ObjectPageSubSection` ns = `uxap`
+            )->a( n = `id`    v = `id_input`
+            )->a( n = `title` v = `Input field` )->ele( n = `blocks` ns = `uxap` )->ele( `VBox` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( input )
+            )->a( n = `width` v = `50%` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `COPY_INPUT` )
+            )->a( n = `text`  v = `Copy input`
+            )->a( n = `type`  v = `Emphasized` ).
 
-      sections->object_page_section( titleuppercase = abap_false
-                                     id             = `id_sec2`
-                                     title          = `...`
-        )->sub_sections( )->object_page_sub_section( id    = `id_text_area`
-                                                     title = `Text area`
-        )->blocks( )->vbox(
-        )->button( text  = `Copy text area`
-                   type  = `Emphasized`
-                   press = client->_event( `COPY_TEXT_AREA` )
-        )->text_area( valueliveupdate = abap_true
-                      editable        = abap_true
-                      value           = client->_bind( text )
-                      growing         = abap_true
-                      growingmaxlines = `50`
-                      width           = `100%`
-                      rows            = `15`
-                      id              = `text_id` ).
+      sections->ele( n = `ObjectPageSection` ns = `uxap`
+          )->a( n = `titleUppercase` b = abap_false
+          )->a( n = `title`          v = `...`
+          )->a( n = `id`             v = `id_sec2` )->ele( n = `subSections` ns = `uxap` )->ele( n = `ObjectPageSubSection` ns = `uxap`
+            )->a( n = `id`    v = `id_text_area`
+            )->a( n = `title` v = `Text area` )->ele( n = `blocks` ns = `uxap` )->ele( `VBox` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `COPY_TEXT_AREA` )
+            )->a( n = `text`  v = `Copy text area`
+            )->a( n = `type`  v = `Emphasized` )->tag( `TextArea`
+            )->a( n = `value`           v = client->_bind( text )
+            )->a( n = `rows`            v = `15`
+            )->a( n = `width`           v = `100%`
+            )->a( n = `valueLiveUpdate` b = abap_true
+            )->a( n = `editable`        b = abap_true
+            )->a( n = `id`              v = `text_id`
+            )->a( n = `growing`         b = abap_true
+            )->a( n = `growingMaxLines` v = `50` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_327.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_327.clas.abap
@@ -107,7 +107,8 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
         )->a( n = `xmlns:core`   v = `sap.ui.core`
-        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
         )->a( n = `title`          v = `abap2UI5 - Browser - Local and Session Storage`
@@ -115,7 +116,7 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
         )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Reads and writes the browser's local or session storage. The ` &&
+        )->a( n = `text` v = `Reads and writes the browser's local or session storage. The ` &&
                    `value is a whole ABAP structure, not just a string: the write ` &&
                    `side sends it with the STORE_DATA frontend action, the invisible ` &&
                    `z2ui5:Storage control reads it back and reports it as JSON.`
@@ -126,22 +127,22 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
     page->ele( n = `SimpleForm` ns = `form`
         )->a( n = `title`    v = `Local/Session Storage`
         )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
-                )->a( n = `text` v = `Type` )->ele( `Select`
+                )->a( n = `text`           v = `Type` )->ele( `Select`
                 )->a( n = `forceSelection` b = abap_true
                 )->a( n = `selectedKey`    v = client->_bind( s_storage-type )
                 )->a( n = `items`          v = client->_bind( t_types ) )->tag( n = `Item` ns = `core`
                     )->a( n = `key`  v = `{TYPE}`
                     )->a( n = `text` v = `{TYPE}` )->end( )->tag( `Label`
-                )->a( n = `text` v = `Prefix` )->tag( `Input`
+                )->a( n = `text`  v = `Prefix` )->tag( `Input`
                 )->a( n = `value` v = client->_bind( s_storage-prefix ) )->tag( `Label`
-                )->a( n = `text` v = `Key` )->tag( `Input`
+                )->a( n = `text`  v = `Key` )->tag( `Input`
                 )->a( n = `value` v = client->_bind( s_storage-key ) )->tag( `Label`
-                )->a( n = `text` v = `Value - Field 1` )->tag( `Input`
+                )->a( n = `text`  v = `Value - Field 1` )->tag( `Input`
                 )->a( n = `type`  v = `Number`
                 )->a( n = `value` v = client->_bind( s_storage-value-field1 ) )->tag( `Label`
-                )->a( n = `text` v = `Value - Field 2` )->tag( `Input`
+                )->a( n = `text`  v = `Value - Field 2` )->tag( `Input`
                 )->a( n = `value` v = client->_bind( s_storage-value-field2 ) )->tag( `Label`
-                )->a( n = `text` v = `` )->tag( `Button`
+                )->a( n = `text`  v = `` )->tag( `Button`
                 )->a( n = `press` v = client->follow_up_action(
                            val   = z2ui5_if_client=>cs_event-store_data
                            t_arg = VALUE #( ( |${ client->_bind( s_storage ) }| ) ) )
@@ -159,10 +160,10 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
                                                     ( `${$parameters>/prefix}` )
                                                     ( `${$parameters>/key}` )
                                                     ( `${$parameters>/value}` ) ) )
-        )->a( n = `type`     v = client->_bind( s_storage-type )
-        )->a( n = `prefix`   v = client->_bind( s_storage-prefix )
-        )->a( n = `key`      v = client->_bind( s_storage-key )
-        )->a( n = `value`    v = client->_bind( s_stored_value ) ).
+        )->a( n = `type`   v = client->_bind( s_storage-type )
+        )->a( n = `prefix` v = client->_bind( s_storage-prefix )
+        )->a( n = `key`    v = client->_bind( s_storage-key )
+        )->a( n = `value`  v = client->_bind( s_stored_value ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_327.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_327.clas.abap
@@ -101,61 +101,68 @@ CLASS z2ui5_cl_smp_app_327 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell( )->page( title          = `abap2UI5 - Browser - Local and Session Storage`
-                                       navbuttonpress = client->_event_nav_app_leave( )
-                                       shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Browser - Local and Session Storage`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Reads and writes the browser's local or session storage. The ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Reads and writes the browser's local or session storage. The ` &&
                    `value is a whole ABAP structure, not just a string: the write ` &&
                    `side sends it with the STORE_DATA frontend action, the invisible ` &&
                    `z2ui5:Storage control reads it back and reports it as JSON.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form( title    = `Local/Session Storage`
-                       editable = abap_true
-        )->content( `form`
-            )->label( `Type`
-            )->select( forceselection = abap_true
-                       selectedkey    = client->_bind( s_storage-type )
-                       items          = client->_bind( t_types )
-                )->item( key  = `{TYPE}`
-                         text = `{TYPE}` )->get_parent(
-            )->label( `Prefix`
-            )->input( client->_bind( s_storage-prefix )
-            )->label( `Key`
-            )->input( client->_bind( s_storage-key )
-            )->label( `Value - Field 1`
-            )->input( value = client->_bind( s_storage-value-field1 )
-                      type  = `Number`
-            )->label( `Value - Field 2`
-            )->input( client->_bind( s_storage-value-field2 )
-            )->label( ``
-            )->button( text  = `store`
-                       press = client->follow_up_action(
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Local/Session Storage`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `Type` )->ele( `Select`
+                )->a( n = `forceSelection` b = abap_true
+                )->a( n = `selectedKey`    v = client->_bind( s_storage-type )
+                )->a( n = `items`          v = client->_bind( t_types ) )->tag( n = `Item` ns = `core`
+                    )->a( n = `key`  v = `{TYPE}`
+                    )->a( n = `text` v = `{TYPE}` )->end( )->tag( `Label`
+                )->a( n = `text` v = `Prefix` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( s_storage-prefix ) )->tag( `Label`
+                )->a( n = `text` v = `Key` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( s_storage-key ) )->tag( `Label`
+                )->a( n = `text` v = `Value - Field 1` )->tag( `Input`
+                )->a( n = `type`  v = `Number`
+                )->a( n = `value` v = client->_bind( s_storage-value-field1 ) )->tag( `Label`
+                )->a( n = `text` v = `Value - Field 2` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( s_storage-value-field2 ) )->tag( `Label`
+                )->a( n = `text` v = `` )->tag( `Button`
+                )->a( n = `press` v = client->follow_up_action(
                            val   = z2ui5_if_client=>cs_event-store_data
                            t_arg = VALUE #( ( |${ client->_bind( s_storage ) }| ) ) )
-            )->button( text  = `get`
-                       press = client->_event( `GET_STORED_VALUE` ) ).
+                )->a( n = `text`  v = `store` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `GET_STORED_VALUE` )
+                )->a( n = `text`  v = `get` ).
 
     " Invisible companion control: it reads `key` out of the selected storage
     " and fires `finished` when the stored value differs from `value`. The
     " comparison is by value, so a structure does not re-trigger on every
     " render.
-    page->_z2ui5( )->storage(
-        finished = client->_event( val   = `LOCAL_STORAGE_LOADED`
+    page->tag( n = `Storage` ns = `z2ui5`
+        )->a( n = `finished` v = client->_event( val   = `LOCAL_STORAGE_LOADED`
                                    t_arg = VALUE #( ( `${$parameters>/type}` )
                                                     ( `${$parameters>/prefix}` )
                                                     ( `${$parameters>/key}` )
                                                     ( `${$parameters>/value}` ) ) )
-        type     = client->_bind( s_storage-type )
-        prefix   = client->_bind( s_storage-prefix )
-        key      = client->_bind( s_storage-key )
-        value    = client->_bind( s_stored_value ) ).
+        )->a( n = `type`     v = client->_bind( s_storage-type )
+        )->a( n = `prefix`   v = client->_bind( s_storage-prefix )
+        )->a( n = `key`      v = client->_bind( s_storage-key )
+        )->a( n = `value`    v = client->_bind( s_stored_value ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_352.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_352.clas.abap
@@ -41,31 +41,34 @@ CLASS z2ui5_cl_smp_app_352 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-             )->page(
-                 title          = `abap2UI5 - Browser - Soft Keyboard Mode on Mobile`
-                 navbuttonpress = client->_event_nav_app_leave( )
-                 shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+                 )->a( n = `title`          v = `abap2UI5 - Browser - Soft Keyboard Mode on Mobile`
+                 )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                 )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Set the on-screen soft keyboard mode (numeric or off) via the keyboard_set_mode follow-up action, and ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Set the on-screen soft keyboard mode (numeric or off) via the keyboard_set_mode follow-up action, and ` &&
                    `focus the input on load.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-              editable = abap_true
-         )->content( `form`
-             )->title( `Keyboard on/off`
-             )->label( `Input (numeric keyboard)`
-             )->input(
-                 id               = `ZINPUT`
-                 value            = client->_bind( input )
-                 showvaluehelp    = abap_true
-                 valuehelprequest = client->_event( `CALL_KEYBOARD` ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Title`
+                 )->a( n = `text` v = `Keyboard on/off` )->tag( `Label`
+                 )->a( n = `text` v = `Input (numeric keyboard)` )->tag( `Input`
+                 )->a( n = `id`               v = `ZINPUT`
+                 )->a( n = `value`            v = client->_bind( input )
+                 )->a( n = `valueHelpRequest` v = client->_event( `CALL_KEYBOARD` )
+                 )->a( n = `showValueHelp`    b = abap_true ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_361.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_361.clas.abap
@@ -15,55 +15,56 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Browser - Logout from the Client`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Browser - Logout from the Client`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `follow_up_action( ) returned straight into the press attribute: the button carries SYSTEM_LOGOUT ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `follow_up_action( ) returned straight into the press attribute: the button carries SYSTEM_LOGOUT ` &&
                      `itself, so pressing it signs out on the client without ever reaching the backend. Inside a Fiori ` &&
                      `Launchpad the shell container handles the sign-out; otherwise the app navigates to the ICF logoff endpoint.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiMediumMargin`
-      )->button(
-          text  = `Logout (client)`
-          icon  = `sap-icon://log`
-          type  = `Reject`
-          class = `sapUiSmallMargin`
-          press = client->follow_up_action( client->cs_event-system_logout ) ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiMediumMargin` )->tag( `Button`
+          )->a( n = `press` v = client->follow_up_action( client->cs_event-system_logout )
+          )->a( n = `text`  v = `Logout (client)`
+          )->a( n = `icon`  v = `sap-icon://log`
+          )->a( n = `type`  v = `Reject`
+          )->a( n = `class` v = `sapUiSmallMargin` ).
 
-      page->message_strip(
-          text     = `The same client-side call, but with an argument: t_arg passes the ICF logoff endpoint, here with a ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `The same client-side call, but with an argument: t_arg passes the ICF logoff endpoint, here with a ` &&
                      `redirect to google.com appended. Still no backend roundtrip - the argument is baked into the view.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiMediumMargin`
-      )->button(
-          text  = `Logout (client, with redirect)`
-          icon  = `sap-icon://log`
-          type  = `Reject`
-          class = `sapUiSmallMargin`
-          press = client->follow_up_action(
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiMediumMargin` )->tag( `Button`
+          )->a( n = `press` v = client->follow_up_action(
                       val   = client->cs_event-system_logout
-                      t_arg = VALUE #( ( `/sap/public/bc/icf/logoff?redirecturl=www.google.com` ) ) ) ).
+                      t_arg = VALUE #( ( `/sap/public/bc/icf/logoff?redirecturl=www.google.com` ) ) )
+          )->a( n = `text`  v = `Logout (client, with redirect)`
+          )->a( n = `icon`  v = `sap-icon://log`
+          )->a( n = `type`  v = `Reject`
+          )->a( n = `class` v = `sapUiSmallMargin` ).
 
-      page->message_strip(
-          text     = `The other way round: _event( 'LOGOUT' ) makes the button call the backend, and follow_up_action( ) ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `The other way round: _event( 'LOGOUT' ) makes the button call the backend, and follow_up_action( ) ` &&
                      `is invoked there on client - the identical SYSTEM_LOGOUT, only queued after the response renders. ` &&
                      `Take this route when the logout depends on backend logic, e.g. saving a draft first.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiMediumMargin`
-      )->button(
-          text  = `Logout (via backend)`
-          icon  = `sap-icon://log`
-          type  = `Reject`
-          class = `sapUiSmallMargin`
-          press = client->_event( `LOGOUT` ) ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiMediumMargin` )->tag( `Button`
+          )->a( n = `press` v = client->_event( `LOGOUT` )
+          )->a( n = `text`  v = `Logout (via backend)`
+          )->a( n = `icon`  v = `sap-icon://log`
+          )->a( n = `type`  v = `Reject`
+          )->a( n = `class` v = `sapUiSmallMargin` ).
 
       client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_362.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_362.clas.abap
@@ -110,46 +110,51 @@ CLASS z2ui5_cl_smp_app_362 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            id             = `id_page`
-            title          = `abap2UI5 - Scroll - Scroll to a Pixel Position`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Scroll - Scroll to a Pixel Position`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+            )->a( n = `id`             v = `id_page` ).
 
-    page->message_strip(
-        text = `Toolbar buttons scroll the page to a specific pixel position. Refresh keeps the current position by reading client->get( )-s_scroll-main and pushing it back via SCROLL_TO.`
-        type = `Information` ).
+    page->tag( `MessageStrip`
+        )->a( n = `text` v = `Toolbar buttons scroll the page to a specific pixel position. Refresh keeps the current position by reading client->get( )-s_scroll-main and pushing it back via SCROLL_TO.`
+        )->a( n = `type` v = `Information` ).
 
-    DATA(table) = page->table( sticky     = `ColumnHeaders,HeaderToolbar`
-                               headertext = `100 entries`
-                               items      = client->_bind( t_tab ) ).
+    DATA(table) = page->ele( `Table`
+        )->a( n = `items`      v = client->_bind( t_tab )
+        )->a( n = `headerText` v = `100 entries`
+        )->a( n = `sticky`     v = `ColumnHeaders,HeaderToolbar` ).
 
-    table->columns(
-        )->column( )->text( `Title` )->get_parent(
-        )->column( )->text( `Color` )->get_parent(
-        )->column( )->text( `Info` )->get_parent(
-        )->column( )->text( `Description` ).
+    table->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Info` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Description` ).
 
-    table->items( )->column_list_item( )->cells(
-       )->text( `{TITLE}`
-       )->text( `{VALUE}`
-       )->text( `{INFO}`
-       )->text( `{DESCR}` ).
+    table->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+           )->a( n = `text` v = `{TITLE}` )->tag( `Text`
+           )->a( n = `text` v = `{VALUE}` )->tag( `Text`
+           )->a( n = `text` v = `{INFO}` )->tag( `Text`
+           )->a( n = `text` v = `{DESCR}` ).
 
-    page->footer( )->overflow_toolbar(
-         )->button( text  = `Top (smooth)`
-                    press = client->_event( `SCROLL_TOP` )
-         )->button( text  = `Middle (smooth)`
-                    press = client->_event( `SCROLL_MIDDLE` )
-         )->button( text  = `Bottom (smooth)`
-                    press = client->_event( `SCROLL_BOTTOM` )
-         )->button( text  = `Middle (jump)`
-                    press = client->_event( `SCROLL_JUMP` )
-         )->button( text  = `Refresh (keep position)`
-                    press = client->_event( `REFRESH` )
-                    type  = `Emphasized` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `SCROLL_TOP` )
+             )->a( n = `text`  v = `Top (smooth)` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `SCROLL_MIDDLE` )
+             )->a( n = `text`  v = `Middle (smooth)` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `SCROLL_BOTTOM` )
+             )->a( n = `text`  v = `Bottom (smooth)` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `SCROLL_JUMP` )
+             )->a( n = `text`  v = `Middle (jump)` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `REFRESH` )
+             )->a( n = `text`  v = `Refresh (keep position)`
+             )->a( n = `type`  v = `Emphasized` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_363.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_363.clas.abap
@@ -68,58 +68,73 @@ CLASS z2ui5_cl_smp_app_363 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Scroll - Scroll a Control into View`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Scroll - Scroll a Control into View`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text = `Use the toolbar to scroll to a control by id, or press Validate - if the middle field is empty it scrolls to it automatically.`
-        type = `Information` ).
+    page->tag( `MessageStrip`
+        )->a( n = `text` v = `Use the toolbar to scroll to a control by id, or press Validate - if the middle field is empty it scrolls to it automatically.`
+        )->a( n = `type` v = `Information` ).
 
-    DATA(form) = page->simple_form( editable = abap_true
-                                    title    = `Long form`
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Long form`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
     " Top section
-    form->label( `Top field (id = top_input)` ).
-    form->input( id    = `top_input`
-                 value = client->_bind( field_01 ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Top field (id = top_input)` ).
+    form->tag( `Input`
+        )->a( n = `id`    v = `top_input`
+        )->a( n = `value` v = client->_bind( field_01 ) ).
 
     " spacer
     DO 25 TIMES.
-      form->label( `spacer` ).
-      form->text( | spacer line { sy-index }| ).
+      form->tag( `Label`
+          )->a( n = `text` v = `spacer` ).
+      form->tag( `Text`
+          )->a( n = `text` v = | spacer line { sy-index }| ).
     ENDDO.
 
     " Middle section (required)
-    form->label( `Middle field - required (id = middle_input)` ).
-    form->input( id    = `middle_input`
-                 value = client->_bind( field_02 ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Middle field - required (id = middle_input)` ).
+    form->tag( `Input`
+        )->a( n = `id`    v = `middle_input`
+        )->a( n = `value` v = client->_bind( field_02 ) ).
 
     " spacer
     DO 25 TIMES.
-      form->label( `spacer` ).
-      form->text( | spacer line { sy-index }| ).
+      form->tag( `Label`
+          )->a( n = `text` v = `spacer` ).
+      form->tag( `Text`
+          )->a( n = `text` v = | spacer line { sy-index }| ).
     ENDDO.
 
     " Bottom section
-    form->label( `Bottom field (id = bottom_input)` ).
-    form->input( id    = `bottom_input`
-                 value = client->_bind( field_03 ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Bottom field (id = bottom_input)` ).
+    form->tag( `Input`
+        )->a( n = `id`    v = `bottom_input`
+        )->a( n = `value` v = client->_bind( field_03 ) ).
 
-    page->footer( )->overflow_toolbar(
-         )->button( text  = `Jump to Top`
-                    press = client->_event( `JUMP_TOP` )
-         )->button( text  = `Jump to Middle`
-                    press = client->_event( `JUMP_MIDDLE` )
-         )->button( text  = `Jump to Bottom`
-                    press = client->_event( `JUMP_BOTTOM` )
-         )->button( text  = `Validate`
-                    press = client->_event( `VALIDATE` )
-                    type  = `Emphasized` ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `JUMP_TOP` )
+             )->a( n = `text`  v = `Jump to Top` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `JUMP_MIDDLE` )
+             )->a( n = `text`  v = `Jump to Middle` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `JUMP_BOTTOM` )
+             )->a( n = `text`  v = `Jump to Bottom` )->tag( `Button`
+             )->a( n = `press` v = client->_event( `VALIDATE` )
+             )->a( n = `text`  v = `Validate`
+             )->a( n = `type`  v = `Emphasized` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_381.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_381.clas.abap
@@ -77,86 +77,90 @@ CLASS z2ui5_cl_smp_app_381 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-         )->page(
-            title          = `abap2UI5 - Message - MessageToast, Text and Duration`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+             )->a( n = `title`          v = `abap2UI5 - Message - MessageToast, Text and Duration`
+             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample demonstrates MessageToast: configure the text, duration, position ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample demonstrates MessageToast: configure the text, duration, position ` &&
                    `and animation, then show a short, non-blocking toast notification.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->header_content(
-       )->link(
-           text   = `UI5 Demo Kit`
-           target = `_blank`
-           href   = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.MessageToast/sample/sap.m.sample.MessageToast` ).
+    page->ele( `headerContent` )->tag( `Link`
+           )->a( n = `text`   v = `UI5 Demo Kit`
+           )->a( n = `target` v = `_blank`
+           )->a( n = `href`   v = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.MessageToast/sample/sap.m.sample.MessageToast` ).
 
-    DATA(form) = page->panel( headertext = `Message Toast Configuration`
-                          )->simple_form(
-                              title    = `Settings`
-                              editable = abap_true
-                              )->content( `form` ).
+    DATA(form) = page->ele( `Panel`
+        )->a( n = `headerText` v = `Message Toast Configuration` )->ele( n = `SimpleForm` ns = `form`
+                              )->a( n = `title`    v = `Settings`
+                              )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Message`
-        )->input( client->_bind( message )
-        )->label( `Duration (ms)`
-        )->input(
-            value = client->_bind( duration )
-            type  = `Number`
-        )->label( `Width`
-        )->input( client->_bind( width ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Message` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( message ) )->tag( `Label`
+            )->a( n = `text` v = `Duration (ms)` )->tag( `Input`
+            )->a( n = `type`  v = `Number`
+            )->a( n = `value` v = client->_bind( duration ) )->tag( `Label`
+            )->a( n = `text` v = `Width` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( width ) ).
 
-    DATA(select_my) = form->label( `my`
-                          )->select( selectedkey = client->_bind( my ) ).
-    DATA(select_at) = form->label( `at`
-                          )->select( selectedkey = client->_bind( at ) ).
+    DATA(select_my) = form->tag( `Label`
+        )->a( n = `text` v = `my` )->ele( `Select`
+                              )->a( n = `selectedKey` v = client->_bind( my ) ).
+    DATA(select_at) = form->tag( `Label`
+        )->a( n = `text` v = `at` )->ele( `Select`
+                              )->a( n = `selectedKey` v = client->_bind( at ) ).
 
     LOOP AT get_positions( ) INTO DATA(position).
-      select_my->item(
-          key  = position
-          text = position ).
-      select_at->item(
-          key  = position
-          text = position ).
+      select_my->tag( n = `Item` ns = `core`
+          )->a( n = `key`  v = position
+          )->a( n = `text` v = position ).
+      select_at->tag( n = `Item` ns = `core`
+          )->a( n = `key`  v = position
+          )->a( n = `text` v = position ).
     ENDLOOP.
 
-    form->label( `offset` ).
-    form->input( client->_bind( offset ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `offset` ).
+    form->tag( `Input`
+        )->a( n = `value` v = client->_bind( offset ) ).
 
-    DATA(select_animation) = form->label( `animationTimingFunction`
-                                 )->select( selectedkey = client->_bind( animation_timing ) ).
-    select_animation->item(
-                     key  = `ease`
-                     text = `ease`
-                 )->item(
-                     key  = `linear`
-                     text = `linear`
-                 )->item(
-                     key  = `ease-in`
-                     text = `ease-in`
-                 )->item(
-                     key  = `ease-out`
-                     text = `ease-out`
-                 )->item(
-                     key  = `ease-in-out`
-                     text = `ease-in-out` ).
+    DATA(select_animation) = form->tag( `Label`
+        )->a( n = `text` v = `animationTimingFunction` )->ele( `Select`
+                                     )->a( n = `selectedKey` v = client->_bind( animation_timing ) ).
+    select_animation->tag( n = `Item` ns = `core`
+        )->a( n = `key`  v = `ease`
+        )->a( n = `text` v = `ease` )->tag( n = `Item` ns = `core`
+                     )->a( n = `key`  v = `linear`
+                     )->a( n = `text` v = `linear` )->tag( n = `Item` ns = `core`
+                     )->a( n = `key`  v = `ease-in`
+                     )->a( n = `text` v = `ease-in` )->tag( n = `Item` ns = `core`
+                     )->a( n = `key`  v = `ease-out`
+                     )->a( n = `text` v = `ease-out` )->tag( n = `Item` ns = `core`
+                     )->a( n = `key`  v = `ease-in-out`
+                     )->a( n = `text` v = `ease-in-out` ).
 
-    form->label( `animationDuration (ms)`
-        )->input(
-            value = client->_bind( animation_duration )
-            type  = `Number`
-        )->label( `autoClose`
-        )->checkbox( client->_bind( autoclose ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `animationDuration (ms)` )->tag( `Input`
+            )->a( n = `type`  v = `Number`
+            )->a( n = `value` v = client->_bind( animation_duration ) )->tag( `Label`
+            )->a( n = `text` v = `autoClose` )->tag( `CheckBox`
+            )->a( n = `selected` v = client->_bind( autoclose ) ).
 
-    form->button(
-        text  = `Show Message Toast`
-        type  = `Emphasized`
-        press = client->_event( `SHOW` ) ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `SHOW` )
+        )->a( n = `text`  v = `Show Message Toast`
+        )->a( n = `type`  v = `Emphasized` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_382.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_382.clas.abap
@@ -67,64 +67,58 @@ CLASS z2ui5_cl_smp_app_382 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-         )->page(
-            title          = `abap2UI5 - Message - MessageBox, Types and Custom Actions`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` )->ele( `Shell` )->ele( `Page`
+             )->a( n = `title`          v = `abap2UI5 - Message - MessageBox, Types and Custom Actions`
+             )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This sample demonstrates MessageBox: open confirm, information, success, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This sample demonstrates MessageBox: open confirm, information, success, ` &&
                    `warning, error, or a custom dialog with your own actions.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->header_content(
-       )->link(
-           text   = `UI5 Demo Kit`
-           target = `_blank`
-           href   = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.MessageBox/sample/sap.m.sample.MessageBox` ).
+    page->ele( `headerContent` )->tag( `Link`
+           )->a( n = `text`   v = `UI5 Demo Kit`
+           )->a( n = `target` v = `_blank`
+           )->a( n = `href`   v = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.MessageBox/sample/sap.m.sample.MessageBox` ).
 
-    page->panel( headertext = `Message Box Configuration`
-             )->simple_form(
-                 title    = `Settings`
-                 editable = abap_true
-                 )->content( `form`
-                 )->label( `Title`
-                 )->input( client->_bind( title )
-                 )->label( `Message`
-                 )->input( client->_bind( message )
-                 )->label( `Details`
-                 )->text_area(
-                     value = client->_bind( details )
-                     rows  = `3` ).
+    page->ele( `Panel`
+        )->a( n = `headerText` v = `Message Box Configuration` )->ele( n = `SimpleForm` ns = `form`
+                 )->a( n = `title`    v = `Settings`
+                 )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                     )->a( n = `text` v = `Title` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( title ) )->tag( `Label`
+                     )->a( n = `text` v = `Message` )->tag( `Input`
+                     )->a( n = `value` v = client->_bind( message ) )->tag( `Label`
+                     )->a( n = `text` v = `Details` )->tag( `TextArea`
+                     )->a( n = `value` v = client->_bind( details )
+                     )->a( n = `rows`  v = `3` ).
 
-    page->footer(
-        )->overflow_toolbar(
-            )->text( `Open Message Box:`
-            )->toolbar_spacer(
-            )->button(
-                text  = `Confirm`
-                press = client->_event( `confirm` )
-            )->button(
-                text  = `Information`
-                press = client->_event( `information` )
-            )->button(
-                text  = `Success`
-                type  = `Accept`
-                press = client->_event( `success` )
-            )->button(
-                text  = `Warning`
-                press = client->_event( `warning` )
-            )->button(
-                text  = `Error`
-                type  = `Reject`
-                press = client->_event( `error` )
-            )->button(
-                text  = `Custom`
-                type  = `Emphasized`
-                press = client->_event( `CUSTOM` ) ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `Text`
+                )->a( n = `text` v = `Open Message Box:` )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `confirm` )
+                )->a( n = `text`  v = `Confirm` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `information` )
+                )->a( n = `text`  v = `Information` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `success` )
+                )->a( n = `text`  v = `Success`
+                )->a( n = `type`  v = `Accept` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `warning` )
+                )->a( n = `text`  v = `Warning` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `error` )
+                )->a( n = `text`  v = `Error`
+                )->a( n = `type`  v = `Reject` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `CUSTOM` )
+                )->a( n = `text`  v = `Custom`
+                )->a( n = `type`  v = `Emphasized` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_421.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_421.clas.abap
@@ -96,93 +96,82 @@ CLASS z2ui5_cl_smp_app_421 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Focus - Focus a Table Cell by Column and Row`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Focus - Focus a Table Cell by Column and Row`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Set the keyboard focus to any editable table cell from the backend - type a column id ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Set the keyboard focus to any editable table cell from the backend - type a column id ` &&
                    `(Title, Color, Info, Checkbox or Description) and a row index, then press Set Focus, or ` &&
                    `use Next / Reset. No JavaScript is shipped with the view: every cell has a stable control ` &&
                    `id (<column>_<row>) that the set_focus follow-up action targets, and the framework reports ` &&
                    `the currently focused cell back to the backend in s_focus.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table(
-        )->header_toolbar(
-            )->overflow_toolbar(
-                )->title( client->_bind( focusid )
-                )->toolbar_spacer(
-                )->label( `Column Id`
-                )->input(
-                    value       = client->_bind( focuscolumn )
-                    submit      = client->_event( `FOCUS` )
-                    placeholder = `Column`
-                    width       = `8rem`
-                )->label( `Row Index`
-                )->input(
-                    value       = client->_bind( focusrow )
-                    submit      = client->_event( `FOCUS` )
-                    placeholder = `Row`
-                    type        = `Number`
-                    width       = `6rem`
-                )->button(
-                    text  = `Set Focus`
-                    press = client->_event( `FOCUS` )
-                )->button(
-                    text  = `Next Focus`
-                    press = client->_event( `NEXT` )
-                )->button(
-                    text  = `Reset Focus`
-                    press = client->_event( `RESET` )
-        )->get_parent( )->get_parent( ).
+    DATA(tab) = page->ele( `Table` )->ele( `headerToolbar` )->ele( `OverflowToolbar` )->tag( `Title`
+                    )->a( n = `text` v = client->_bind( focusid ) )->tag( `ToolbarSpacer` )->tag( `Label`
+                    )->a( n = `text` v = `Column Id` )->tag( `Input`
+                    )->a( n = `placeholder` v = `Column`
+                    )->a( n = `value`       v = client->_bind( focuscolumn )
+                    )->a( n = `submit`      v = client->_event( `FOCUS` )
+                    )->a( n = `width`       v = `8rem` )->tag( `Label`
+                    )->a( n = `text` v = `Row Index` )->tag( `Input`
+                    )->a( n = `placeholder` v = `Row`
+                    )->a( n = `type`        v = `Number`
+                    )->a( n = `value`       v = client->_bind( focusrow )
+                    )->a( n = `submit`      v = client->_event( `FOCUS` )
+                    )->a( n = `width`       v = `6rem` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `FOCUS` )
+                    )->a( n = `text`  v = `Set Focus` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `NEXT` )
+                    )->a( n = `text`  v = `Next Focus` )->tag( `Button`
+                    )->a( n = `press` v = client->_event( `RESET` )
+                    )->a( n = `text`  v = `Reset Focus` )->end( )->end( ).
 
-    tab->columns(
-        )->column( )->text( `Index` )->get_parent(
-        )->column( )->text( `Title` )->get_parent(
-        )->column( )->text( `Color` )->get_parent(
-        )->column( )->text( `Info` )->get_parent(
-        )->column( )->text( `Checkbox` )->get_parent(
-        )->column( )->text( `Description` ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Index` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Title` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Color` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Info` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Checkbox` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Description` ).
 
     " Build the rows explicitly (no aggregation binding): only then does every
     " cell keep the stable control id <column>_<row> that set_focus can target.
     " A bound template would clone the cells under randomly generated ids.
     DATA(path)  = client->_bind( val = t_tab path = abap_true ).
-    DATA(items) = tab->items( ).
+    DATA(items) = tab->ele( `items` ).
 
     LOOP AT t_tab REFERENCE INTO DATA(row).
 
       DATA(i) = sy-tabix - 1.
 
-      items->column_list_item(
-          )->cells(
-              )->text( |{ row->index }|
-              )->input(
-                  id     = |{ cs_column-title }_{ i }|
-                  value  = |\{{ path }/{ i }/TITLE\}|
-                  submit = client->_event( `NEXT` )
-              )->input(
-                  id     = |{ cs_column-color }_{ i }|
-                  value  = |\{{ path }/{ i }/VALUE\}|
-                  submit = client->_event( `NEXT` )
-              )->input(
-                  id     = |{ cs_column-info }_{ i }|
-                  value  = |\{{ path }/{ i }/INFO\}|
-                  submit = client->_event( `NEXT` )
-              )->checkbox(
-                  id       = |{ cs_column-checkbox }_{ i }|
-                  selected = |\{{ path }/{ i }/CHECKBOX\}|
-              )->input(
-                  id     = |{ cs_column-description }_{ i }|
-                  value  = |\{{ path }/{ i }/DESCRIPTION\}|
-                  submit = client->_event( `NEXT` ) ).
+      items->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                  )->a( n = `text` v = |{ row->index }| )->tag( `Input`
+                  )->a( n = `id`     v = |{ cs_column-title }_{ i }|
+                  )->a( n = `value`  v = |\{{ path }/{ i }/TITLE\}|
+                  )->a( n = `submit` v = client->_event( `NEXT` ) )->tag( `Input`
+                  )->a( n = `id`     v = |{ cs_column-color }_{ i }|
+                  )->a( n = `value`  v = |\{{ path }/{ i }/VALUE\}|
+                  )->a( n = `submit` v = client->_event( `NEXT` ) )->tag( `Input`
+                  )->a( n = `id`     v = |{ cs_column-info }_{ i }|
+                  )->a( n = `value`  v = |\{{ path }/{ i }/INFO\}|
+                  )->a( n = `submit` v = client->_event( `NEXT` ) )->tag( `CheckBox`
+                  )->a( n = `id`       v = |{ cs_column-checkbox }_{ i }|
+                  )->a( n = `selected` v = |\{{ path }/{ i }/CHECKBOX\}| )->tag( `Input`
+                  )->a( n = `id`     v = |{ cs_column-description }_{ i }|
+                  )->a( n = `value`  v = |\{{ path }/{ i }/DESCRIPTION\}|
+                  )->a( n = `submit` v = client->_event( `NEXT` ) ).
 
     ENDLOOP.
 

--- a/src/01/z2ui5_cl_smp_app_445.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_445.clas.abap
@@ -17,9 +17,9 @@ CLASS z2ui5_cl_smp_app_445 DEFINITION PUBLIC.
     "! device is rotated - no backend round-trip is involved.
     METHODS device_form
       IMPORTING
-        parent        TYPE REF TO z2ui5_cl_xml_view
+        parent        TYPE REF TO z2ui5_cl_ui5_view_builder
       RETURNING
-        VALUE(result) TYPE REF TO z2ui5_cl_xml_view.
+        VALUE(result) TYPE REF TO z2ui5_cl_ui5_view_builder.
 
   PRIVATE SECTION.
 ENDCLASS.
@@ -51,34 +51,37 @@ CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
 
   METHOD device_form.
 
-    DATA(form) = parent->simple_form( editable = abap_false
-                                      layout   = `ResponsiveGridLayout` ).
+    DATA(form) = parent->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`   v = `ResponsiveGridLayout`
+        )->a( n = `editable` b = abap_false ).
 
     " a readable label per system type instead of the raw booleans
-    form->label( `System type`
-        )->object_status(
-            text  = `{= ${device>/system/phone} ? 'Phone' : (${device>/system/tablet} ? 'Tablet' : (${device>/system/desktop} ? 'Desktop' : 'Other')) }`
-            state = `Information` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `System type` )->ele( `ObjectStatus`
+            )->a( n = `state` v = `Information`
+            )->a( n = `text`  v = `{= ${device>/system/phone} ? 'Phone' : (${device>/system/tablet} ? 'Tablet' : (${device>/system/desktop} ? 'Desktop' : 'Other')) }` ).
 
-    form->label( `Orientation`
-        )->object_status(
-            text = `{= ${device>/orientation/landscape} ? 'Landscape' : 'Portrait' }` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Orientation` )->ele( `ObjectStatus`
+            )->a( n = `text` v = `{= ${device>/orientation/landscape} ? 'Landscape' : 'Portrait' }` ).
 
     " resize/width and resize/height are updated live by UI5
-    form->label( `Window size`
-        )->object_status(
-            text = `{device>/resize/width} x {device>/resize/height} px` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Window size` )->ele( `ObjectStatus`
+            )->a( n = `text` v = `{device>/resize/width} x {device>/resize/height} px` ).
 
-    form->label( `Touch support`
-        )->object_status(
-            text  = `{= ${device>/support/touch} ? 'Yes' : 'No' }`
-            state = `{= ${device>/support/touch} ? 'Success' : 'None' }` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Touch support` )->ele( `ObjectStatus`
+            )->a( n = `state` v = `{= ${device>/support/touch} ? 'Success' : 'None' }`
+            )->a( n = `text`  v = `{= ${device>/support/touch} ? 'Yes' : 'No' }` ).
 
-    form->label( `Browser`
-        )->text( `{device>/browser/name} {device>/browser/version}` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Browser` )->tag( `Text`
+            )->a( n = `text` v = `{device>/browser/name} {device>/browser/version}` ).
 
-    form->label( `Operating system`
-        )->text( `{device>/os/name} {device>/os/version}` ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Operating system` )->tag( `Text`
+            )->a( n = `text` v = `{device>/os/name} {device>/os/version}` ).
 
     result = form.
 
@@ -87,53 +90,64 @@ CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Device - Device Model: Phone, Tablet, Desktop`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Device - Device Model: Phone, Tablet, Desktop`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The 'device>' model is a one-way JSONModel over sap.ui.Device. ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The 'device>' model is a one-way JSONModel over sap.ui.Device. ` &&
                    `Resize the window or rotate your device and the values update live - ` &&
                    `no backend round-trip. It is available in this view and in the dialog below.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " 1) the raw device state, bound field by field
-    device_form( page->panel( headertext = `Live device properties`
-                              class      = `sapUiSmallMargin` ) ).
+    device_form( page->ele( `Panel`
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `headerText` v = `Live device properties` ) ).
 
     " 2) an expression binding that reacts to the device type
-    page->message_strip(
-        text     = `{= ${device>/system/phone} ? 'Compact layout - you are on a phone.' : 'Full layout - tablet or desktop.' }`
-        type     = `{= ${device>/system/phone} ? 'Warning' : 'Success' }`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `{= ${device>/system/phone} ? 'Compact layout - you are on a phone.' : 'Full layout - tablet or desktop.' }`
+        )->a( n = `type`     v = `{= ${device>/system/phone} ? 'Warning' : 'Success' }`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " 3) a control whose content collapses on a phone: expanded = !phone
-    DATA(tabs) = page->panel( headertext = `Responsive IconTabBar (expanded only when it is not a phone)`
-                              class      = `sapUiSmallMargin`
-        )->icon_tab_bar(
-            expanded = `{= !${device>/system/phone} }`
-            class    = `sapUiResponsiveContentPadding`
-        )->items( ).
+    DATA(tabs) = page->ele( `Panel`
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `headerText` v = `Responsive IconTabBar (expanded only when it is not a phone)` )->ele( `IconTabBar`
+            )->a( n = `class`    v = `sapUiResponsiveContentPadding`
+            )->a( n = `expanded` v = `{= !${device>/system/phone} }` )->ele( `items` ).
 
-    tabs->icon_tab_filter( text = `Sales` key = `sales` icon = `sap-icon://money-bills`
-        )->text( `On a phone the tab content is collapsed to save space; on tablet/desktop it stays expanded.` ).
+    tabs->ele( `IconTabFilter`
+        )->a( n = `icon` v = `sap-icon://money-bills`
+        )->a( n = `text` v = `Sales`
+        )->a( n = `key`  v = `sales` )->tag( `Text`
+            )->a( n = `text` v = `On a phone the tab content is collapsed to save space; on tablet/desktop it stays expanded.` ).
 
-    tabs->icon_tab_filter( text = `Stock` key = `stock` icon = `sap-icon://product`
-        )->text( `Everything here is driven purely by the device> model - no event handler.` ).
+    tabs->ele( `IconTabFilter`
+        )->a( n = `icon` v = `sap-icon://product`
+        )->a( n = `text` v = `Stock`
+        )->a( n = `key`  v = `stock` )->tag( `Text`
+            )->a( n = `text` v = `Everything here is driven purely by the device> model - no event handler.` ).
 
     " 4) the same device state, but inside a popup (device> now reaches popups too)
-    page->button(
-        text  = `Open dialog (device model inside a popup)`
-        icon  = `sap-icon://sys-monitor`
-        press = client->_event( `OPEN_POPUP` )
-        class = `sapUiSmallMargin` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event( `OPEN_POPUP` )
+        )->a( n = `text`  v = `Open dialog (device model inside a popup)`
+        )->a( n = `icon`  v = `sap-icon://sys-monitor`
+        )->a( n = `class` v = `sapUiSmallMargin` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -142,20 +156,22 @@ CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
 
   METHOD popup_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core`
+        )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
     " the dialog width itself is driven by the device model
-    DATA(dialog) = popup->dialog(
-        title        = `Device model inside a popup`
-        contentwidth = `{= ${device>/system/phone} ? '95%' : '420px' }` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title`        v = `Device model inside a popup`
+        )->a( n = `contentWidth` v = `{= ${device>/system/phone} ? '95%' : '420px' }` ).
 
-    device_form( dialog->content( ) ).
+    device_form( dialog->ele( `content` ) ).
 
-    dialog->buttons(
-        )->button(
-            text  = `Close`
-            type  = `Emphasized`
-            press = client->follow_up_action( client->cs_event-popup_close ) ).
+    dialog->ele( `buttons` )->tag( `Button`
+            )->a( n = `press` v = client->follow_up_action( client->cs_event-popup_close )
+            )->a( n = `text`  v = `Close`
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_448.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_448.clas.abap
@@ -52,32 +52,38 @@ CLASS z2ui5_cl_smp_app_448 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Control - Expand a Panel by ID (setExpanded)`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Control - Expand a Panel by ID (setExpanded)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The button toggles the panel via the whitelisted setExpanded method ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The button toggles the panel via the whitelisted setExpanded method ` &&
                    `(follow_up_action with cs_event-control_by_id), client-side after render - no view rebuild.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Toggle panel`
-                   icon  = `sap-icon://expand-group`
-                   press = client->_event( `TOGGLE` ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `TOGGLE` )
+            )->a( n = `text`  v = `Toggle panel`
+            )->a( n = `icon`  v = `sap-icon://expand-group` ).
 
-    page->panel( id         = `demoPanel`
-                 headertext = `Collapsible panel`
-                 expandable = abap_true
-                 width      = `auto`
-                 class      = `sapUiSmallMargin`
-        )->text( `Content of the panel - collapsed and expanded from the backend without a roundtrip payload.` ).
+    page->ele( `Panel`
+        )->a( n = `expandable` b = abap_true
+        )->a( n = `width`      v = `auto`
+        )->a( n = `id`         v = `demoPanel`
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `headerText` v = `Collapsible panel` )->tag( `Text`
+            )->a( n = `text` v = `Content of the panel - collapsed and expanded from the backend without a roundtrip payload.` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_449.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_449.clas.abap
@@ -48,34 +48,38 @@ CLASS z2ui5_cl_smp_app_449 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Control - Open the PDF Viewer by ID`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Control - Open the PDF Viewer by ID`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     " a popup-mode PDFViewer kept as a dependent of the page; opened
     " imperatively from the backend, like a controller calling oViewer.open()
-    page->dependents(
-        )->_generic( name   = `PDFViewer`
-                     t_prop = VALUE #( ( n = `id`     v = `demoPdf` )
-                                       ( n = `title`  v = `Sample PDF` )
-                                       ( n = `source` v = `https://sapui5.hana.ondemand.com/test-resources/sap/m/demokit/sample/PDFViewerPopup/sample1.pdf` )
-                                       ( n = `height` v = `100%` ) ) ).
+    page->ele( `dependents` )->ele( `PDFViewer`
+            )->a( n = `id`     v = `demoPdf`
+            )->a( n = `title`  v = `Sample PDF`
+            )->a( n = `source` v = `https://sapui5.hana.ondemand.com/test-resources/sap/m/demokit/sample/PDFViewerPopup/sample1.pdf`
+            )->a( n = `height` v = `100%` ).
 
-    page->message_strip(
-        text     = `The button opens the popup-mode PDFViewer via the whitelisted open method ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The button opens the popup-mode PDFViewer via the whitelisted open method ` &&
                    `(follow_up_action with cs_event-control_by_id), client-side after render.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Open PDF`
-                   icon  = `sap-icon://pdf-attachment`
-                   press = client->_event( `OPEN` ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `OPEN` )
+            )->a( n = `text`  v = `Open PDF`
+            )->a( n = `icon`  v = `sap-icon://pdf-attachment` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_450.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_450.clas.abap
@@ -38,57 +38,55 @@ CLASS z2ui5_cl_smp_app_450 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
     " require the framework's curated formatter module into the view, like an
     " original UI5 app requires its model/formatter. DateAbapDateToDateObject
     " and DateAbapDateTimeToDateObject turn the ABAP date strings into the
     " real JS Date that an object-typed property (dateValue) demands - JSON
     " has no date type, so this is the one conversion the backend cannot do.
-    view->_generic_property( VALUE #( n = `core:require`
-                                      v = `{Formatter: 'z2ui5/model/formatter'}` ) ).
+    view->a( n = `core:require` v = `{Formatter: 'z2ui5/model/formatter'}` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Formatter - ABAP Date and Time Strings (DATS/TIMS)`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Formatter - ABAP Date and Time Strings (DATS/TIMS)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The model carries the plain ABAP strings 20260720 / 134501; the curated formatter ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The model carries the plain ABAP strings 20260720 / 134501; the curated formatter ` &&
                    `converts them at the binding. An initial DATS (00000000) yields null, so the field ` &&
                    `stays empty instead of rendering a wrong 1899 date.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " the paths must come from a bind call - a hardcoded path is never
     " registered in the model and the frontend receives no data for it
-    page->simple_form(
-            title    = `DATS / TIMS strings as date objects`
-            editable = abap_true
-            )->content( `form`
-            )->label( `DATS 20260720`
-            )->date_picker(
-                displayformat = `long`
-                editable      = abap_false
-                datevalue     = |\{ path: '{ client->_bind( val = dats path = abap_true ) }', | &&
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `DATS / TIMS strings as date objects`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+                )->a( n = `text` v = `DATS 20260720` )->tag( `DatePicker`
+                )->a( n = `displayFormat` v = `long`
+                )->a( n = `dateValue`     v = |\{ path: '{ client->_bind( val = dats path = abap_true ) }', | &&
                                 |formatter: 'Formatter.DateAbapDateToDateObject' \}|
-            )->label( `DATS 00000000 (initial)`
-            )->date_picker(
-                displayformat = `long`
-                editable      = abap_false
-                placeholder   = `no date`
-                datevalue     = |\{ path: '{ client->_bind( val = dats_initial path = abap_true ) }', | &&
+                )->a( n = `editable`      b = abap_false )->tag( `Label`
+                )->a( n = `text` v = `DATS 00000000 (initial)` )->tag( `DatePicker`
+                )->a( n = `displayFormat` v = `long`
+                )->a( n = `placeholder`   v = `no date`
+                )->a( n = `dateValue`     v = |\{ path: '{ client->_bind( val = dats_initial path = abap_true ) }', | &&
                                 |formatter: 'Formatter.DateAbapDateToDateObject' \}|
-            )->label( `DATS 20260720 + TIMS 134501`
-            )->_generic(
-                name   = `DateTimePicker`
-                t_prop = VALUE #(
-                    ( n = `editable`  v = `false` )
-                    ( n = `dateValue` v = |\{ parts: [\{path: '{ client->_bind( val = dats path = abap_true ) }'\}, | &&
+                )->a( n = `editable`      b = abap_false )->tag( `Label`
+                )->a( n = `text` v = `DATS 20260720 + TIMS 134501` )->ele( `DateTimePicker`
+                )->a( n = `editable`  v = `false`
+                )->a( n = `dateValue` v = |\{ parts: [\{path: '{ client->_bind( val = dats path = abap_true ) }'\}, | &&
                                           |\{path: '{ client->_bind( val = tims path = abap_true ) }'\}], | &&
-                                          |formatter: 'Formatter.DateAbapDateTimeToDateObject' \}| ) ) ).
+                                          |formatter: 'Formatter.DateAbapDateTimeToDateObject' \}| ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_452.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_452.clas.abap
@@ -127,46 +127,45 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
       error_count = error_count + 1.
     ENDLOOP.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Message - MessageView and MessagePopover`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Message - MessageView and MessagePopover`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This free-style demo combines the sap.m message controls: one bound message table is rendered three ways - as a full-page MessageView with grouped items, ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This free-style demo combines the sap.m message controls: one bound message table is rendered three ways - as a full-page MessageView with grouped items, ` &&
                    `inside a dialog and as a MessagePopover. It is not a 1:1 demo kit rebuild (those live in the samples-controls repository) ` &&
                    `and stays within the UI5 1.71 control set.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->message_view(
-        items      = client->_bind( t_msg )
-        groupitems = abap_true
-        )->message_item(
-            type        = `{TYPE}`
-            title       = `{TITLE}`
-            subtitle    = `{SUBTITLE}`
-            description = `{DESCRIPTION}`
-            groupname   = `{GROUP}`
-            )->link(
-                text   = `Show more information`
-                href   = `http://sap.com`
-                target = `_blank` ).
+    page->ele( `MessageView`
+        )->a( n = `items`      v = client->_bind( t_msg )
+        )->a( n = `groupItems` b = abap_true )->ele( `MessageItem`
+            )->a( n = `type`        v = `{TYPE}`
+            )->a( n = `title`       v = `{TITLE}`
+            )->a( n = `subtitle`    v = `{SUBTITLE}`
+            )->a( n = `description` v = `{DESCRIPTION}`
+            )->a( n = `groupName`   v = `{GROUP}` )->tag( `Link`
+                )->a( n = `text`   v = `Show more information`
+                )->a( n = `target` v = `_blank`
+                )->a( n = `href`   v = `http://sap.com` ).
 
     " ButtonType 'Negative' would match the error state, but it is only available since UI5 1.73 - src/01 must run on plain 1.71, so the default type is kept
-    page->footer( )->overflow_toolbar(
-        )->button(
-            icon  = `sap-icon://message-error`
-            text  = |{ error_count }|
-            press = client->_event( `POPUP` )
-        )->toolbar_spacer(
-        )->button(
-            id    = `messagePopoverBtn`
-            text  = `Message Popover`
-            press = client->_event( `POPOVER` ) ).
+    page->ele( `footer` )->ele( `OverflowToolbar` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPUP` )
+            )->a( n = `text`  v = |{ error_count }|
+            )->a( n = `icon`  v = `sap-icon://message-error` )->tag( `ToolbarSpacer` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `POPOVER` )
+            )->a( n = `text`  v = `Message Popover`
+            )->a( n = `id`    v = `messagePopoverBtn` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -175,33 +174,33 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
 
   METHOD popup_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
     " the dialog keeps a plain title without a back button - closing and reopening it resets the MessageView to its list page
-    DATA(dialog) = popup->dialog(
-        title             = `Publish order`
-        contentheight     = `50%`
-        contentwidth      = `50%`
-        verticalscrolling = abap_false
-        afterclose        = client->follow_up_action( client->cs_event-popup_close ) ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title`             v = `Publish order`
+        )->a( n = `contentWidth`      v = `50%`
+        )->a( n = `contentHeight`     v = `50%`
+        )->a( n = `verticalScrolling` b = abap_false
+        )->a( n = `afterClose`        v = client->follow_up_action( client->cs_event-popup_close ) ).
 
-    dialog->message_view(
-        items      = client->_bind( t_msg )
-        groupitems = abap_true
-        )->message_item(
-            type        = `{TYPE}`
-            title       = `{TITLE}`
-            subtitle    = `{SUBTITLE}`
-            description = `{DESCRIPTION}`
-            groupname   = `{GROUP}`
-            )->link(
-                text   = `Show more information`
-                href   = `http://sap.com`
-                target = `_blank` ).
+    dialog->ele( `MessageView`
+        )->a( n = `items`      v = client->_bind( t_msg )
+        )->a( n = `groupItems` b = abap_true )->ele( `MessageItem`
+            )->a( n = `type`        v = `{TYPE}`
+            )->a( n = `title`       v = `{TITLE}`
+            )->a( n = `subtitle`    v = `{SUBTITLE}`
+            )->a( n = `description` v = `{DESCRIPTION}`
+            )->a( n = `groupName`   v = `{GROUP}` )->tag( `Link`
+                )->a( n = `text`   v = `Show more information`
+                )->a( n = `target` v = `_blank`
+                )->a( n = `href`   v = `http://sap.com` ).
 
-    dialog->end_button( )->button(
-        text  = `Close`
-        press = client->follow_up_action( client->cs_event-popup_close ) ).
+    dialog->ele( `endButton` )->tag( `Button`
+        )->a( n = `press` v = client->follow_up_action( client->cs_event-popup_close )
+        )->a( n = `text`  v = `Close` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -210,22 +209,22 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    popup->message_popover(
-        items       = client->_bind( t_msg )
-        placement   = `Top`
-        beforeclose = client->_event( `POPOVER_CLOSE` )
-        )->message_item(
-            type        = `{TYPE}`
-            title       = `{TITLE}`
-            subtitle    = `{SUBTITLE}`
-            description = `{DESCRIPTION}`
-            groupname   = `{GROUP}`
-            )->link(
-                text   = `Show more information`
-                href   = `http://sap.com`
-                target = `_blank` ).
+    popup->ele( `MessagePopover`
+        )->a( n = `items`       v = client->_bind( t_msg )
+        )->a( n = `placement`   v = `Top`
+        )->a( n = `beforeClose` v = client->_event( `POPOVER_CLOSE` ) )->ele( `MessageItem`
+            )->a( n = `type`        v = `{TYPE}`
+            )->a( n = `title`       v = `{TITLE}`
+            )->a( n = `subtitle`    v = `{SUBTITLE}`
+            )->a( n = `description` v = `{DESCRIPTION}`
+            )->a( n = `groupName`   v = `{GROUP}` )->tag( `Link`
+                )->a( n = `text`   v = `Show more information`
+                )->a( n = `target` v = `_blank`
+                )->a( n = `href`   v = `http://sap.com` ).
 
     client->popover_display( xml   = popup->stringify( )
                              by_id = id ).

--- a/src/01/z2ui5_cl_smp_app_453.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_453.clas.abap
@@ -108,55 +108,54 @@ CLASS z2ui5_cl_smp_app_453 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     " no core:require, no formatter, no client-side logic: every cell binds a
     " field the backend already finished
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Formatter - When Not to Use One: Compute in ABAP`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Formatter - When Not to Use One: Compute in ABAP`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Every column is bound to a plain model field. The state, the icon, the rounded ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Every column is bound to a plain model field. The state, the icon, the rounded ` &&
                    `price and the dimension string are computed in ABAP (products_prepare) - the ` &&
                    `frontend only renders. Sample 450 shows what does belong in a formatter: the ` &&
                    `date conversion the backend physically cannot do.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table( id    = `productTable`
-                             items = client->_bind( t_products ) ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_products )
+        )->a( n = `id`    v = `productTable` ).
 
-    tab->columns(
-        )->column( )->text( `Product` )->get_parent(
-        )->column( )->text( `Weight (g)` )->get_parent(
-        )->column( )->text( `Price` )->get_parent(
-        )->column( )->text( `Dimensions` )->get_parent(
-        )->column( )->text( `Status` )->get_parent(
-        )->column( )->text( `Delivery` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Product` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Weight (g)` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Price` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Dimensions` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Status` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Delivery` )->end( ).
 
-    tab->items(
-        )->column_list_item(
-            )->cells(
-                )->text( `{NAME}`
-                )->object_number(
-                    number = `{WEIGHT}`
-                    unit   = `g`
-                    state  = `{WEIGHT_STATE}`
-                )->object_number(
-                    number = `{PRICE_DISP}`
-                    unit   = `{CURRENCY}`
-                )->text( `{DIMENSIONS}`
-                )->object_status(
-                    text  = `{STATUS}`
-                    icon  = `{STATUS_ICON}`
-                    state = `{STATUS_STATE}` )->get_parent(
-                )->object_status(
-                    text  = `{DELIVERY}`
-                    state = `{DELIVERY_STATE}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{NAME}` )->tag( `ObjectNumber`
+                    )->a( n = `number` v = `{WEIGHT}`
+                    )->a( n = `state`  v = `{WEIGHT_STATE}`
+                    )->a( n = `unit`   v = `g` )->tag( `ObjectNumber`
+                    )->a( n = `number` v = `{PRICE_DISP}`
+                    )->a( n = `unit`   v = `{CURRENCY}` )->tag( `Text`
+                    )->a( n = `text` v = `{DIMENSIONS}` )->ele( `ObjectStatus`
+                    )->a( n = `icon`  v = `{STATUS_ICON}`
+                    )->a( n = `state` v = `{STATUS_STATE}`
+                    )->a( n = `text`  v = `{STATUS}` )->end( )->ele( `ObjectStatus`
+                    )->a( n = `state` v = `{DELIVERY_STATE}`
+                    )->a( n = `text`  v = `{DELIVERY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_454.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_454.clas.abap
@@ -79,42 +79,48 @@ CLASS z2ui5_cl_smp_app_454 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - List - Filter and Sort the Binding from ABAP`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - List - Filter and Sort the Binding from ABAP`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Search and sort are applied to the list's items BINDING via follow_up_action ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Search and sort are applied to the list's items BINDING via follow_up_action ` &&
                    `with cs_event-binding_call - the UI5 controller pattern getBinding('items').filter(...). ` &&
                    `The model stays untouched.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->search_field( width       = `30%`
-                         placeholder = `Search products`
-                         search      = client->_event( val   = `SEARCH`
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `SearchField`
+            )->a( n = `width`       v = `30%`
+            )->a( n = `search`      v = client->_event( val   = `SEARCH`
                                                        t_arg = VALUE #( ( `${$parameters>/query}` ) ) )
-        )->hbox( class = `sapUiTinyMarginTop`
-            )->button( text  = `Sort ascending`
-                       icon  = `sap-icon://sort-ascending`
-                       press = client->_event( `SORT_ASC` )
-            )->button( text  = `Sort descending`
-                       icon  = `sap-icon://sort-descending`
-                       press = client->_event( `SORT_DESC` )
-                       class = `sapUiTinyMarginBegin` ).
+            )->a( n = `placeholder` v = `Search products` )->ele( `HBox`
+            )->a( n = `class` v = `sapUiTinyMarginTop` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `SORT_ASC` )
+                )->a( n = `text`  v = `Sort ascending`
+                )->a( n = `icon`  v = `sap-icon://sort-ascending` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `SORT_DESC` )
+                )->a( n = `text`  v = `Sort descending`
+                )->a( n = `icon`  v = `sap-icon://sort-descending`
+                )->a( n = `class` v = `sapUiTinyMarginBegin` ).
 
-    page->list( id         = `productList`
-                headertext = `Products`
-                items      = client->_bind( t_products )
-                class      = `sapUiSmallMargin`
-        )->standard_list_item( title       = `{NAME}`
-                               description = `{CATEGORY}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Products`
+        )->a( n = `items`      v = client->_bind( t_products )
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `id`         v = `productList` )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{NAME}`
+            )->a( n = `description` v = `{CATEGORY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_455.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_455.clas.abap
@@ -43,30 +43,35 @@ CLASS z2ui5_cl_smp_app_455 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - List - Live Filter on the Client, No Roundtrip`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - List - Live Filter on the Client, No Roundtrip`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Every keystroke filters the list's items binding purely client-side ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Every keystroke filters the list's items binding purely client-side ` &&
                    `(cs_event-binding_call via follow_up_action) - no backend roundtrip, exactly like ` &&
                    `the original UI5 controller's oBinding.filter(...). Clearing the field clears the filter.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " t_arg order: control id, aggregation, method, then the filter params
     " path / operator / value - the ${...} argument is resolved client-side
     " against the liveChange event, so the current query reaches the filter
     " without any server contact.
-    page->vbox( `sapUiSmallMargin`
-        )->search_field( width       = `30%`
-                         placeholder = `Search products`
-                         livechange  = client->follow_up_action(
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `SearchField`
+            )->a( n = `width`       v = `30%`
+            )->a( n = `placeholder` v = `Search products`
+            )->a( n = `liveChange`  v = client->follow_up_action(
                              val   = z2ui5_if_client=>cs_event-binding_call
                              t_arg = VALUE #( ( `productList` )
                                               ( `items` )
@@ -75,12 +80,13 @@ CLASS z2ui5_cl_smp_app_455 IMPLEMENTATION.
                                               ( `Contains` )
                                               ( `${$parameters>/newValue}` ) ) ) ).
 
-    page->list( id         = `productList`
-                headertext = `Products`
-                items      = client->_bind( t_products )
-                class      = `sapUiSmallMargin`
-        )->standard_list_item( title       = `{NAME}`
-                               description = `{CATEGORY}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Products`
+        )->a( n = `items`      v = client->_bind( t_products )
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `id`         v = `productList` )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{NAME}`
+            )->a( n = `description` v = `{CATEGORY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_456.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_456.clas.abap
@@ -54,7 +54,13 @@ CLASS z2ui5_cl_smp_app_456 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:u`      v = `sap.ui.unified` ).
 
     " calendar date properties (CalendarAppointment startDate/endDate,
     " PlanningCalendar startDate) are typed "object" - they demand a real JS
@@ -62,42 +68,36 @@ CLASS z2ui5_cl_smp_app_456 IMPLEMENTATION.
     " JavaScript or UI5Date date object"). Formatter.DateCreateObject from
     " the curated module converts the model's ISO strings at the point of
     " use - the model itself stays plain strings everywhere.
-    view->_generic_property( VALUE #( n = `core:require`
-                                      v = `{Formatter: 'z2ui5/model/formatter'}` ) ).
+    view->a( n = `core:require` v = `{Formatter: 'z2ui5/model/formatter'}` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Formatter - Date Objects for the PlanningCalendar`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Formatter - Date Objects for the PlanningCalendar`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The model carries plain ISO strings; Formatter.DateCreateObject turns them into ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The model carries plain ISO strings; Formatter.DateCreateObject turns them into ` &&
                    `the real JS Date objects the object-typed calendar properties require - only at ` &&
                    `the bindings that need them.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " the startDate path must come from _bind - a hardcoded binding
     " path is never registered in the model, the frontend then receives no
     " data and the formatter passes a non-Date into the object property
-    page->planning_calendar(
-        id        = `PC1`
-        class     = `sapUiSmallMargin`
-        startdate = |\{ path: '{ client->_bind( val = start_date path = abap_true ) }', | &&
+    page->ele( `PlanningCalendar`
+        )->a( n = `rows`      v = client->_bind( t_people )
+        )->a( n = `startDate` v = |\{ path: '{ client->_bind( val = start_date path = abap_true ) }', | &&
                     |formatter: 'Formatter.DateCreateObject' \}|
-        rows      = client->_bind( t_people )
-        )->rows(
-        )->planning_calendar_row(
-            title        = `{NAME}`
-            appointments = `{path: 'T_APPOINTMENTS', templateShareable: true}`
-            )->appointments(
-            )->calendar_appointment(
-                startdate = `{ path: 'START_AT', formatter: 'Formatter.DateCreateObject' }`
-                enddate   = `{ path: 'END_AT', formatter: 'Formatter.DateCreateObject' }`
-                title     = `{TITLE}`
-                type      = `{TYPE}` ).
+        )->a( n = `id`        v = `PC1`
+        )->a( n = `class`     v = `sapUiSmallMargin` )->ele( `rows` )->ele( `PlanningCalendarRow`
+            )->a( n = `appointments` v = `{path: 'T_APPOINTMENTS', templateShareable: true}`
+            )->a( n = `title`        v = `{NAME}` )->ele( `appointments` )->ele( n = `CalendarAppointment` ns = `u`
+                )->a( n = `startDate` v = `{ path: 'START_AT', formatter: 'Formatter.DateCreateObject' }`
+                )->a( n = `endDate`   v = `{ path: 'END_AT', formatter: 'Formatter.DateCreateObject' }`
+                )->a( n = `title`     v = `{TITLE}`
+                )->a( n = `type`      v = `{TYPE}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_457.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_457.clas.abap
@@ -30,38 +30,42 @@ CLASS z2ui5_cl_smp_app_457 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     " the minimal date-object case: DatePicker.dateValue is typed "object"
     " and demands a real JS Date - a plain string binding crashes view
     " creation. Formatter.DateCreateObject converts the model's ISO string
     " at this one binding; the model itself keeps the plain string (the
     " Text below proves it).
-    view->_generic_property( VALUE #( n = `core:require`
-                                      v = `{Formatter: 'z2ui5/model/formatter'}` ) ).
+    view->a( n = `core:require` v = `{Formatter: 'z2ui5/model/formatter'}` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Formatter - Date Object for the DatePicker`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Formatter - Date Object for the DatePicker`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `dateValue is an object-typed property: the ISO string from the model becomes a ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `dateValue is an object-typed property: the ISO string from the model becomes a ` &&
                    `real JS Date via Formatter.DateCreateObject - only at this binding, the model ` &&
                    `stays a plain string.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " the path must come from _bind - a hardcoded binding path is never
     " registered in the model and the frontend receives no data for it
-    page->vbox( `sapUiSmallMargin`
-        )->date_picker( displayformat = `long`
-                        datevalue     = |\{ path: '{ client->_bind( val = date_iso path = abap_true ) }', | &&
-                                        |formatter: 'Formatter.DateCreateObject' \}|
-        )->text( text  = |Model value (unchanged string): { client->_bind( date_iso ) }|
-                 class = `sapUiTinyMarginTop` ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `DatePicker`
+            )->a( n = `displayFormat` v = `long`
+            )->a( n = `dateValue`     v = |\{ path: '{ client->_bind( val = date_iso path = abap_true ) }', | &&
+                                        |formatter: 'Formatter.DateCreateObject' \}| )->tag( `Text`
+            )->a( n = `text`  v = |Model value (unchanged string): { client->_bind( date_iso ) }|
+            )->a( n = `class` v = `sapUiTinyMarginTop` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -84,7 +84,8 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:dnd`    v = `sap.ui.core.dnd` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - Table - Drag and Drop Rows`
@@ -92,7 +93,7 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Drag a row and drop it between two others: the dnd:DragDropInfo drop event ` &&
+        )->a( n = `text` v = `Drag a row and drop it between two others: the dnd:DragDropInfo drop event ` &&
                    `sends the dragged/drop indexes and the drop position to the backend, ABAP ` &&
                    `reorders the table and the refreshed model updates the list.`
         )->a( n = `type`     v = `Information`

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -79,51 +79,51 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Table - Drag and Drop Rows`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Table - Drag and Drop Rows`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Drag a row and drop it between two others: the dnd:DragDropInfo drop event ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Drag a row and drop it between two others: the dnd:DragDropInfo drop event ` &&
                    `sends the dragged/drop indexes and the drop position to the backend, ABAP ` &&
                    `reorders the table and the refreshed model updates the list.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table( id    = `reorderTable`
-                             items = client->_bind( t_products ) ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_products )
+        )->a( n = `id`    v = `reorderTable` ).
 
     " dragDropConfig is a plain sap.m aggregation here (ns = ``); the
     " DragDropInfo goes through _generic because the typed builder method
     " has no dropPosition parameter
-    tab->drag_drop_config( ``
-        )->_generic(
-            name   = `DragDropInfo`
-            ns     = `dnd`
-            t_prop = VALUE #( ( n = `sourceAggregation` v = `items` )
-                              ( n = `targetAggregation` v = `items` )
-                              ( n = `dropPosition`      v = `Between` )
-                              ( n = `drop`              v = client->_event(
+    tab->ele( `dragDropConfig` )->ele( n = `DragDropInfo` ns = `dnd`
+            )->a( n = `sourceAggregation` v = `items`
+            )->a( n = `targetAggregation` v = `items`
+            )->a( n = `dropPosition`      v = `Between`
+            )->a( n = `drop`              v = client->_event(
                                   val   = `REORDER`
                                   t_arg = VALUE #(
                                       ( `${$parameters>/draggedControl/oParent}.indexOfItem(${$parameters>/draggedControl})` )
                                       ( `${$parameters>/droppedControl/oParent}.indexOfItem(${$parameters>/droppedControl})` )
-                                      ( `${$parameters>/dropPosition}` ) ) ) ) ) ).
+                                      ( `${$parameters>/dropPosition}` ) ) ) ).
 
-    tab->columns(
-        )->column( )->text( `Product` )->get_parent(
-        )->column( )->text( `Category` )->get_parent( ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Product` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Category` )->end( ).
 
-    tab->items(
-        )->column_list_item(
-            )->cells(
-                )->text( `{NAME}`
-                )->text( `{CATEGORY}` ).
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{NAME}` )->tag( `Text`
+                    )->a( n = `text` v = `{CATEGORY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_460.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_460.clas.abap
@@ -55,25 +55,30 @@ CLASS z2ui5_cl_smp_app_460 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Tree - Nested ABAP Table in a sap.m.Tree`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Tree - Nested ABAP Table in a sap.m.Tree`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A nested ABAP table (three levels of NODES) serializes into nested JSON arrays; ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A nested ABAP table (three levels of NODES) serializes into nested JSON arrays; ` &&
                    `sap.m.Tree binds them directly - no flattening, no extra code.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->tree( id         = `tree1`
-                headertext = `Files`
-                items      = client->_bind( t_nodes )
-        )->standard_tree_item( title = `{TEXT}` ).
+    page->ele( `Tree`
+        )->a( n = `id`         v = `tree1`
+        )->a( n = `items`      v = client->_bind( t_nodes )
+        )->a( n = `headerText` v = `Files` )->tag( `StandardTreeItem`
+            )->a( n = `title` v = `{TEXT}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -103,44 +103,47 @@ CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Tree - Drag and Drop Nodes`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Tree - Drag and Drop Nodes`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Drag a file onto another folder: the drop event ships the binding context ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Drag a file onto another folder: the drop event ships the binding context ` &&
                    `paths of both tree items, ABAP moves the node inside the nested table and ` &&
                    `redraws the view - the z2ui5.cc.Tree companion keeps the expanded nodes open.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tree) = page->tree( id         = `tree1`
-                             headertext = `Folders`
-                             items      = client->_bind( t_nodes ) ).
+    DATA(tree) = page->ele( `Tree`
+        )->a( n = `id`         v = `tree1`
+        )->a( n = `items`      v = client->_bind( t_nodes )
+        )->a( n = `headerText` v = `Folders` ).
 
-    tree->drag_drop_config( ``
-        )->_generic(
-            name   = `DragDropInfo`
-            ns     = `dnd`
-            t_prop = VALUE #( ( n = `sourceAggregation` v = `items` )
-                              ( n = `targetAggregation` v = `items` )
-                              ( n = `dropPosition`      v = `On` )
-                              ( n = `drop`              v = client->_event(
+    tree->ele( `dragDropConfig` )->ele( n = `DragDropInfo` ns = `dnd`
+            )->a( n = `sourceAggregation` v = `items`
+            )->a( n = `targetAggregation` v = `items`
+            )->a( n = `dropPosition`      v = `On`
+            )->a( n = `drop`              v = client->_event(
                                   val   = `MOVE_NODE`
                                   t_arg = VALUE #(
                                       ( `${$parameters>/draggedControl}.getBindingContext().getPath()` )
-                                      ( `${$parameters>/droppedControl}.getBindingContext().getPath()` ) ) ) ) ) ).
+                                      ( `${$parameters>/droppedControl}.getBindingContext().getPath()` ) ) ) ).
 
-    tree->standard_tree_item( title = `{TEXT}` ).
+    tree->tag( `StandardTreeItem`
+        )->a( n = `title` v = `{TEXT}` ).
 
     " invisible companion: preserves the tree's expand state across the
     " move roundtrips (snapshot before the request, re-apply after render)
-    page->_z2ui5( )->tree( `tree1` ).
+    page->tag( n = `Tree` ns = `z2ui5` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -108,7 +108,9 @@ CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc`
+        )->a( n = `xmlns:dnd`    v = `sap.ui.core.dnd` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - Tree - Drag and Drop Nodes`
@@ -116,7 +118,7 @@ CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Drag a file onto another folder: the drop event ships the binding context ` &&
+        )->a( n = `text` v = `Drag a file onto another folder: the drop event ships the binding context ` &&
                    `paths of both tree items, ABAP moves the node inside the nested table and ` &&
                    `redraws the view - the z2ui5.cc.Tree companion keeps the expanded nodes open.`
         )->a( n = `type`     v = `Information`

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -79,8 +79,9 @@ CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
   METHOD popup_display.
 
     DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
-        )->a( n = `xmlns`      v = `sap.m`
-        )->a( n = `xmlns:core` v = `sap.ui.core` ).
+        )->a( n = `xmlns`       v = `sap.m`
+        )->a( n = `xmlns:core`  v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5` v = `z2ui5.cc` ).
     DATA(dialog) = popup->ele( `Dialog`
         )->a( n = `title` v = `abap2UI5 - Tree in a dialog` ).
 
@@ -121,7 +122,7 @@ CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `The button opens a Dialog whose content is a sap.m.Tree over a nested ABAP ` &&
+        )->a( n = `text` v = `The button opens a Dialog whose content is a sap.m.Tree over a nested ABAP ` &&
                    `table. Expand some nodes, close and reopen: the z2ui5.cc.Tree companion ` &&
                    `preserves the expand state across the roundtrips.`
         )->a( n = `type`     v = `Information`

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -78,24 +78,28 @@ CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
 
   METHOD popup_display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog( `abap2UI5 - Tree in a dialog` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title` v = `abap2UI5 - Tree in a dialog` ).
 
     " the popup view slot gets its own copy of the model - the nested table
     " bound here renders in the dialog exactly like in a main view
-    dialog->tree( id         = `treePopup`
-                  headertext = `Documents`
-                  items      = client->_bind( t_nodes )
-        )->standard_tree_item( title = `{TEXT}` ).
+    dialog->ele( `Tree`
+        )->a( n = `id`         v = `treePopup`
+        )->a( n = `items`      v = client->_bind( t_nodes )
+        )->a( n = `headerText` v = `Documents` )->tag( `StandardTreeItem`
+            )->a( n = `title` v = `{TEXT}` ).
 
     " invisible companion: snapshots the tree's expand state before each
     " roundtrip and re-applies it after rendering - reopening the dialog
     " shows the same nodes expanded as when it was closed
-    dialog->_z2ui5( )->tree( `treePopup` ).
+    dialog->tag( n = `Tree` ns = `z2ui5` ).
 
-    dialog->buttons(
-        )->button( text  = `Close`
-                   press = client->_event( `CLOSE_POPUP` ) ).
+    dialog->ele( `buttons` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CLOSE_POPUP` )
+            )->a( n = `text`  v = `Close` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -104,26 +108,31 @@ CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Tree - Inside a Dialog`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Tree - Inside a Dialog`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The button opens a Dialog whose content is a sap.m.Tree over a nested ABAP ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The button opens a Dialog whose content is a sap.m.Tree over a nested ABAP ` &&
                    `table. Expand some nodes, close and reopen: the z2ui5.cc.Tree companion ` &&
                    `preserves the expand state across the roundtrips.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Open tree popup`
-                   icon  = `sap-icon://tree`
-                   press = client->_event( `OPEN_POPUP` ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `OPEN_POPUP` )
+            )->a( n = `text`  v = `Open tree popup`
+            )->a( n = `icon`  v = `sap-icon://tree` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -75,42 +75,46 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Tree - Editable Nodes with CustomTreeItem`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Tree - Editable Nodes with CustomTreeItem`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Each node is a CustomTreeItem holding an Input bound to the node text. ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Each node is a CustomTreeItem holding an Input bound to the node text. ` &&
                    `Rename any node and press "Show model": the edits have already written back into ` &&
                    `the nested ABAP table. The expand state is preserved across the roundtrip.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Show model`
-                   icon  = `sap-icon://show`
-                   press = client->_event( `SHOW_MODEL` ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `SHOW_MODEL` )
+            )->a( n = `text`  v = `Show model`
+            )->a( n = `icon`  v = `sap-icon://show` ).
 
     " CustomTreeItem is not a typed builder method - build it via _generic;
     " its content aggregation holds the editable Input, bound to
     " {TEXT} because the items aggregation itself is bound with _bind
-    DATA(tree) = page->tree( id         = `tree1`
-                             headertext = `Files (editable)`
-                             items      = client->_bind( t_nodes ) ).
+    DATA(tree) = page->ele( `Tree`
+        )->a( n = `id`         v = `tree1`
+        )->a( n = `items`      v = client->_bind( t_nodes )
+        )->a( n = `headerText` v = `Files (editable)` ).
 
-    tree->_generic( `CustomTreeItem`
-        )->content(
-            )->input(
-                value = `{TEXT}`
-                width = `24rem` ).
+    tree->ele( `CustomTreeItem` )->ele( `content` )->tag( `Input`
+                )->a( n = `value` v = `{TEXT}`
+                )->a( n = `width` v = `24rem` ).
 
     " invisible companion: keeps the expanded nodes open across the roundtrip
-    page->_z2ui5( )->tree( `tree1` ).
+    page->tag( n = `Tree` ns = `z2ui5` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -80,7 +80,8 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - Tree - Editable Nodes with CustomTreeItem`
@@ -88,7 +89,7 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Each node is a CustomTreeItem holding an Input bound to the node text. ` &&
+        )->a( n = `text` v = `Each node is a CustomTreeItem holding an Input bound to the node text. ` &&
                    `Rename any node and press "Show model": the edits have already written back into ` &&
                    `the nested ABAP table. The expand state is preserved across the roundtrip.`
         )->a( n = `type`     v = `Information`

--- a/src/01/z2ui5_cl_smp_app_464.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_464.clas.abap
@@ -51,37 +51,41 @@ CLASS z2ui5_cl_smp_app_464 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Navigation - Uncaught Error and Error Popup`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Navigation - Uncaught Error and Error Popup`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Trigger an unexpected error. The client shows a popup "An unexpected error ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Trigger an unexpected error. The client shows a popup "An unexpected error ` &&
                    `occurred" with two buttons: Details jumps into the DebugTool's Error tab (full ` &&
                    `error text plus Retry/Refresh/Logout), Restart reloads the app. Open the ` &&
                    `DebugTool any time with Ctrl+F12.`
-        type     = `Warning`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Warning`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Raise an exception`
-                   icon  = `sap-icon://error`
-                   type  = `Reject`
-                   press = client->_event( `RAISE_EXCEPTION` )
-        )->button( text  = `Trigger a runtime dump (divide by zero)`
-                   icon  = `sap-icon://alert`
-                   press = client->_event( `DIVIDE_BY_ZERO` )
-                   class = `sapUiTinyMarginTop`
-        )->button( text  = `Trigger an Assert`
-                   icon  = `sap-icon://alert`
-                   press = client->_event( `ASSERT` )
-                   class = `sapUiTinyMarginTop`
-                   ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `RAISE_EXCEPTION` )
+            )->a( n = `text`  v = `Raise an exception`
+            )->a( n = `icon`  v = `sap-icon://error`
+            )->a( n = `type`  v = `Reject` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `DIVIDE_BY_ZERO` )
+            )->a( n = `text`  v = `Trigger a runtime dump (divide by zero)`
+            )->a( n = `icon`  v = `sap-icon://alert`
+            )->a( n = `class` v = `sapUiTinyMarginTop` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `ASSERT` )
+            )->a( n = `text`  v = `Trigger an Assert`
+            )->a( n = `icon`  v = `sap-icon://alert`
+            )->a( n = `class` v = `sapUiTinyMarginTop` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_465.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_465.clas.abap
@@ -50,38 +50,42 @@ CLASS z2ui5_cl_smp_app_465 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popover - Toggle by ID (toggleBy)`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popover - Toggle by ID (toggleBy)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     " the popover kept as a dependent of the page; opened and closed
     " imperatively from the backend, anchored to the button that fired
-    page->dependents(
-        )->popover( id           = `demoPopover`
-                    title        = `Details`
-                    placement    = `Bottom`
-                    contentwidth = `18rem`
-            )->text( `Toggled open and closed from the backend - the same button opens ` &&
-                     `it when closed and closes it when open, no view rebuild and no payload.`
-                     )->get_parent( ).
+    page->ele( `dependents` )->ele( `Popover`
+            )->a( n = `id`           v = `demoPopover`
+            )->a( n = `title`        v = `Details`
+            )->a( n = `placement`    v = `Bottom`
+            )->a( n = `contentWidth` v = `18rem` )->tag( `Text`
+                )->a( n = `text` v = `Toggled open and closed from the backend - the same button opens ` &&
+                     `it when closed and closes it when open, no view rebuild and no payload.` )->end( ).
 
-    page->message_strip(
-        text     = `The button toggles the popover via the whitelisted toggleBy method ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The button toggles the popover via the whitelisted toggleBy method ` &&
                    `(follow_up_action with cs_event-control_by_id), anchored to the button's DOM ref ` &&
                    `passed as $event.oSource.sId - open-if-closed, close-if-open, client-side after render.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( text  = `Toggle popover`
-                   icon  = `sap-icon://email`
-                   press = client->_event( val   = `TOGGLE`
-                                           t_arg = VALUE #( ( `$event.oSource.sId` ) ) ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( val   = `TOGGLE`
+                                           t_arg = VALUE #( ( `$event.oSource.sId` ) ) )
+            )->a( n = `text`  v = `Toggle popover`
+            )->a( n = `icon`  v = `sap-icon://email` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_466.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_466.clas.abap
@@ -35,7 +35,12 @@ CLASS z2ui5_cl_smp_app_466 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     " require the framework's curated formatter module into the view -
     " expandInlineIcons is the sap.m.MessageStripUtilities.getInlineIcon()
@@ -43,30 +48,28 @@ CLASS z2ui5_cl_smp_app_466 IMPLEMENTATION.
     " %%icon:sap-icon://<name>%% placeholder with inline-icon markup (the
     " glyph resolved via IconPool), so the app never hardcodes icon-font
     " codepoints. Rendered by MessageStrip with enableFormattedText.
-    view->_generic_property( VALUE #( n = `core:require`
-                                      v = `{Formatter: 'z2ui5/model/formatter'}` ) ).
+    view->a( n = `core:require` v = `{Formatter: 'z2ui5/model/formatter'}` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Formatter - Inline Icons in a Text`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Formatter - Inline Icons in a Text`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The status line below binds a plain string carrying %%icon:sap-icon://...%% placeholders ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The status line below binds a plain string carrying %%icon:sap-icon://...%% placeholders ` &&
                    `through Formatter.expandInlineIcons - each placeholder becomes an inline icon glyph, ` &&
                    `no codepoints in the app.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->message_strip(
-        text                = |\{ path: '{ client->_bind( val = status_text path = abap_true ) }', | &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`                v = |\{ path: '{ client->_bind( val = status_text path = abap_true ) }', | &&
                               |formatter: 'Formatter.expandInlineIcons' \}|
-        type                = `Success`
-        enableformattedtext = abap_true
-        showicon            = abap_true
-        class               = `sapUiSmallMargin` ).
+        )->a( n = `type`                v = `Success`
+        )->a( n = `showIcon`            b = abap_true
+        )->a( n = `class`               v = `sapUiSmallMargin`
+        )->a( n = `enableFormattedText` b = abap_true ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_467.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_467.clas.abap
@@ -57,47 +57,52 @@ CLASS z2ui5_cl_smp_app_467 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Message - Message Model and MessageManager`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Message - Message Model and MessageManager`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Both sources of the central message> model in one page: the Name messages ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Both sources of the central message> model in one page: the Name messages ` &&
                    `are AUTHORED BY THE APP (pushed from an ABAP table by the invisible ` &&
                    `z2ui5.cc.MessageManager companion - the Error targets the Name field and ` &&
                    `colours it), while typing letters into the Amount field collects the failed ` &&
                    `Integer validation AUTOMATICALLY - no app code, no roundtrip. Both render ` &&
                    `in the list below.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " invisible companion control: reconciles /T_MESSAGES into the message
     " manager (adds the app's messages, removes its own when they drop out,
     " leaves auto-collected validation untouched)
-    page->_generic( name   = `MessageManager`
-                    ns     = `z2ui5`
-                    t_prop = VALUE #( ( n = `items` v = client->_bind( t_messages ) ) ) ).
+    page->ele( n = `MessageManager` ns = `z2ui5`
+        )->a( n = `items` v = client->_bind( t_messages ) ).
 
-    page->vbox( `sapUiSmallMargin`
-            )->label( `Name (message authored by the app)`
-            )->input( client->_bind( name )
-            )->label( `Amount (integer only - validation collected automatically)`
-            )->input( width = `12rem`
-                      value = |\{ path: '{ client->_bind( val = amount path = abap_true ) }', | &&
-                              |type: 'sap.ui.model.type.Integer' \}| ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
+                )->a( n = `text` v = `Name (message authored by the app)` )->tag( `Input`
+                )->a( n = `value` v = client->_bind( name ) )->tag( `Label`
+                )->a( n = `text` v = `Amount (integer only - validation collected automatically)` )->tag( `Input`
+                )->a( n = `value` v = |\{ path: '{ client->_bind( val = amount path = abap_true ) }', | &&
+                              |type: 'sap.ui.model.type.Integer' \}|
+                )->a( n = `width` v = `12rem` ).
 
-    page->list( headertext = `Collected messages (message> model)`
-                items      = `{message>/}`
-                nodatatext = `no messages`
-                class      = `sapUiSmallMargin`
-        )->standard_list_item( title       = `{message>message}`
-                               description = `{message>additionalText}`
-                               info        = `{message>type}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Collected messages (message> model)`
+        )->a( n = `items`      v = `{message>/}`
+        )->a( n = `class`      v = `sapUiSmallMargin`
+        )->a( n = `noDataText` v = `no messages` )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{message>message}`
+            )->a( n = `description` v = `{message>additionalText}`
+            )->a( n = `info`        v = `{message>type}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_467.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_467.clas.abap
@@ -62,7 +62,8 @@ CLASS z2ui5_cl_smp_app_467 IMPLEMENTATION.
         )->a( n = `height`       v = `100%`
         )->a( n = `xmlns`        v = `sap.m`
         )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:z2ui5`  v = `z2ui5.cc` ).
 
     DATA(page) = view->ele( `Shell` )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - Message - Message Model and MessageManager`
@@ -70,7 +71,7 @@ CLASS z2ui5_cl_smp_app_467 IMPLEMENTATION.
             )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
     page->tag( `MessageStrip`
-        )->a( n = `text`     v = `Both sources of the central message> model in one page: the Name messages ` &&
+        )->a( n = `text` v = `Both sources of the central message> model in one page: the Name messages ` &&
                    `are AUTHORED BY THE APP (pushed from an ABAP table by the invisible ` &&
                    `z2ui5.cc.MessageManager companion - the Error targets the Name field and ` &&
                    `colours it), while typing letters into the Amount field collects the failed ` &&
@@ -88,9 +89,9 @@ CLASS z2ui5_cl_smp_app_467 IMPLEMENTATION.
 
     page->ele( `VBox`
         )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Label`
-                )->a( n = `text` v = `Name (message authored by the app)` )->tag( `Input`
+                )->a( n = `text`  v = `Name (message authored by the app)` )->tag( `Input`
                 )->a( n = `value` v = client->_bind( name ) )->tag( `Label`
-                )->a( n = `text` v = `Amount (integer only - validation collected automatically)` )->tag( `Input`
+                )->a( n = `text`  v = `Amount (integer only - validation collected automatically)` )->tag( `Input`
                 )->a( n = `value` v = |\{ path: '{ client->_bind( val = amount path = abap_true ) }', | &&
                               |type: 'sap.ui.model.type.Integer' \}|
                 )->a( n = `width` v = `12rem` ).

--- a/src/01/z2ui5_cl_smp_app_469.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_469.clas.abap
@@ -46,25 +46,30 @@ CLASS z2ui5_cl_smp_app_469 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Navigation - Detail Page`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Navigation - Detail Page`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `You navigated here from a routing-mode hub via nav_app_call. Now press your ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `You navigated here from a routing-mode hub via nav_app_call. Now press your ` &&
                    `BROWSER Back button and watch the hub: mode keep restores its state, mode fresh ` &&
                    `restarts it empty.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->button(
-        text  = `back (in-app)`
-        icon  = `sap-icon://nav-back`
-        press = client->_event_nav_app_leave( )
-        class = `sapUiSmallMargin` ).
+    page->tag( `Button`
+        )->a( n = `press` v = client->_event_nav_app_leave( )
+        )->a( n = `text`  v = `back (in-app)`
+        )->a( n = `icon`  v = `sap-icon://nav-back`
+        )->a( n = `class` v = `sapUiSmallMargin` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -81,40 +81,43 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-            title          = `abap2UI5 - Popup - Element Binding to the Selected Row`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Popup - Element Binding to the Selected Row`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The table is bound to the product aggregation. Press a row's "components" button - the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The table is bound to the product aggregation. Press a row's "components" button - the ` &&
                    `popup is element-bound to that product, so its relative bindings (incl. the component ` &&
                    `list's aggregation binding) resolve without copying any data into event args.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(tab) = page->table( client->_bind( t_product ) ).
+    DATA(tab) = page->ele( `Table`
+        )->a( n = `items` v = client->_bind( t_product ) ).
 
-    tab->columns(
-        )->column( )->text( `Product` )->get_parent(
-        )->column( )->text( `Category` )->get_parent(
-        )->column( )->text( `Price` )->get_parent(
-        )->column( )->text( `Components` ).
+    tab->ele( `columns` )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Product` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Category` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Price` )->end( )->ele( `Column` )->tag( `Text`
+            )->a( n = `text` v = `Components` ).
 
-    tab->items(
-        )->column_list_item(
-            )->cells(
-                )->text( `{NAME}`
-                )->text( `{CATEGORY}`
-                )->text( `{PRICE} EUR`
-                )->button(
-                    text  = `components`
-                    icon  = `sap-icon://product`
-                    press = client->_event(
+    tab->ele( `items` )->ele( `ColumnListItem` )->ele( `cells` )->tag( `Text`
+                    )->a( n = `text` v = `{NAME}` )->tag( `Text`
+                    )->a( n = `text` v = `{CATEGORY}` )->tag( `Text`
+                    )->a( n = `text` v = `{PRICE} EUR` )->tag( `Button`
+                    )->a( n = `press` v = client->_event(
                         val   = `SHOW`
-                        t_arg = VALUE #( ( `$event.oSource.getBindingContext().getPath().split('/').pop()` ) ) ) ).
+                        t_arg = VALUE #( ( `$event.oSource.getBindingContext().getPath().split('/').pop()` ) ) )
+                    )->a( n = `text`  v = `components`
+                    )->a( n = `icon`  v = `sap-icon://product` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -123,29 +126,34 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
 
   METHOD popup_components.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    DATA(dialog) = popup->dialog(
-        title        = `{NAME}`
-        contentwidth = `24rem` ).
+    DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
+    DATA(dialog) = popup->ele( `Dialog`
+        )->a( n = `title`        v = `{NAME}`
+        )->a( n = `contentWidth` v = `24rem` ).
 
     " relative bindings - resolved by the element bind below
-    DATA(box) = dialog->vbox( `sapUiSmallMarginBegin sapUiSmallMarginTop` ).
-    box->object_status( title = `Category` text = `{CATEGORY}` ).
-    box->object_status( title = `Price` text = `{PRICE} EUR` ).
+    DATA(box) = dialog->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMarginBegin sapUiSmallMarginTop` ).
+    box->ele( `ObjectStatus`
+        )->a( n = `text`  v = `{CATEGORY}`
+        )->a( n = `title` v = `Category` ).
+    box->ele( `ObjectStatus`
+        )->a( n = `text`  v = `{PRICE} EUR`
+        )->a( n = `title` v = `Price` ).
 
     " the popup's own aggregation binding: the product's component list ({T_ITEM})
-    dialog->list(
-        items      = `{T_ITEM}`
-        headertext = `Components`
-        )->standard_list_item(
-            title = `{NAME}`
-            info  = `{QTY} {UNIT}` ).
+    dialog->ele( `List`
+        )->a( n = `headerText` v = `Components`
+        )->a( n = `items`      v = `{T_ITEM}` )->tag( `StandardListItem`
+            )->a( n = `title` v = `{NAME}`
+            )->a( n = `info`  v = `{QTY} {UNIT}` ).
 
-    dialog->buttons(
-        )->button(
-            text  = `Close`
-            type  = `Emphasized`
-            press = client->follow_up_action( client->cs_event-popup_close ) ).
+    dialog->ele( `buttons` )->tag( `Button`
+            )->a( n = `press` v = client->follow_up_action( client->cs_event-popup_close )
+            )->a( n = `text`  v = `Close`
+            )->a( n = `type`  v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_471.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_471.clas.abap
@@ -105,48 +105,49 @@ CLASS z2ui5_cl_smp_app_471 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Event - Keyboard Shortcuts, Ctrl+S`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Event - Keyboard Shortcuts, Ctrl+S`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Ctrl+S and Ctrl+D fire the backend events SAVE and DELETE - the same events the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Ctrl+S and Ctrl+D fire the backend events SAVE and DELETE - the same events the ` &&
                    `buttons below send, but from the keyboard and without a control. The binding is ` &&
                    `pure data (cs_event-keyboard_shortcut with the combination and the event name), ` &&
                    `the browser default for the combination is suppressed.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->hbox( class = `sapUiSmallMargin`
-        )->button(
-            text  = COND #( WHEN registered = abap_true
+    page->ele( `HBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `TOGGLE_REGISTRATION` )
+            )->a( n = `text`  v = COND #( WHEN registered = abap_true
                             THEN `Unregister the shortcuts`
                             ELSE `Register the shortcuts` )
-            icon  = `sap-icon://keyboard-and-mouse`
-            press = client->_event( `TOGGLE_REGISTRATION` )
-        )->button(
-            text  = `Save (Ctrl+S)`
-            type  = `Emphasized`
-            class = `sapUiTinyMarginBegin`
-            press = client->_event( `SAVE` )
-        )->button(
-            text  = `Delete (Ctrl+D)`
-            class = `sapUiTinyMarginBegin`
-            press = client->_event( `DELETE` )
-        )->button(
-            text  = `Clear log`
-            class = `sapUiTinyMarginBegin`
-            press = client->_event( `CLEAR` ) ).
+            )->a( n = `icon`  v = `sap-icon://keyboard-and-mouse` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `SAVE` )
+            )->a( n = `text`  v = `Save (Ctrl+S)`
+            )->a( n = `type`  v = `Emphasized`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `DELETE` )
+            )->a( n = `text`  v = `Delete (Ctrl+D)`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CLEAR` )
+            )->a( n = `text`  v = `Clear log`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` ).
 
-    page->list(
-        headertext = `Triggered events`
-        items      = client->_bind( t_log )
-        )->standard_list_item( title = `{ENTRY}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Triggered events`
+        )->a( n = `items`      v = client->_bind( t_log ) )->tag( `StandardListItem`
+            )->a( n = `title` v = `{ENTRY}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_472.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_472.clas.abap
@@ -58,42 +58,45 @@ CLASS z2ui5_cl_smp_app_472 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Event - Link with preventDefault`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Event - Link with preventDefault`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `A sap.m.Link normally follows its href when pressed. Registered with ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `A sap.m.Link normally follows its href when pressed. Registered with ` &&
                    `s_ctrl-check_prevent_default the event cancels that built-in default ` &&
                    `(oEvent.preventDefault()) before the roundtrip - the event still reaches the ` &&
                    `backend, so the app decides what happens instead. Flip the switch to compare.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->simple_form(
-        title    = `Link with a cancelled default`
-        editable = abap_true
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Link with a cancelled default`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Cancel the browser navigation`
-        )->switch(
-            state  = client->_bind( block_navigation )
-            change = client->_event( `TOGGLE` )
-        )->label( `Link`
-        )->link(
-            text   = `Open abap2ui5.org`
-            href   = `https://abap2ui5.org`
-            target = `_blank`
-            press  = client->_event(
+    form->tag( `Label`
+        )->a( n = `text` v = `Cancel the browser navigation` )->tag( `Switch`
+            )->a( n = `state`  v = client->_bind( block_navigation )
+            )->a( n = `change` v = client->_event( `TOGGLE` ) )->tag( `Label`
+            )->a( n = `text` v = `Link` )->tag( `Link`
+            )->a( n = `text`   v = `Open abap2ui5.org`
+            )->a( n = `target` v = `_blank`
+            )->a( n = `href`   v = `https://abap2ui5.org`
+            )->a( n = `press`  v = client->_event(
                 val    = `LINK_PRESS`
-                s_ctrl = VALUE #( check_prevent_default = block_navigation ) )
-        )->label( `Result`
-        )->text( client->_bind( last_press ) ).
+                s_ctrl = VALUE #( check_prevent_default = block_navigation ) ) )->tag( `Label`
+            )->a( n = `text` v = `Result` )->tag( `Text`
+            )->a( n = `text` v = client->_bind( last_press ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_473.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_473.clas.abap
@@ -27,23 +27,27 @@ CLASS z2ui5_cl_smp_app_473 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Menu - Full Path of the Selected Item`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Menu - Full Path of the Selected Item`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `The toast shows the full path of the selected menu item ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The toast shows the full path of the selected menu item ` &&
                    `("Create New Site > Official Store"), not only its own text. ` &&
                    `$controller.textPath( ) walks the item's parent chain in the control tree ` &&
                    `and joins the texts - a walk no binding path can express. Everything happens ` &&
                    `on the client, the menu selection needs no roundtrip at all.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
     " the item's breadcrumb is resolved on the client and substituted into the
     " toast template ({0}); an argument starting with $ is a client-side
@@ -55,24 +59,24 @@ CLASS z2ui5_cl_smp_app_473 IMPLEMENTATION.
                          ( `Action triggered on item: {0}` )
                          ( `$controller.textPath(${$parameters>/item})` ) ) ).
 
-    DATA(menu) = page->hbox( class = `sapUiSmallMargin`
-        )->menu_button( text = `Actions`
-            )->menu( itemselected = menu_selected ).
+    DATA(menu) = page->ele( `HBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->ele( `MenuButton`
+            )->a( n = `text` v = `Actions` )->ele( `Menu`
+                )->a( n = `itemSelected` v = menu_selected ).
 
-    menu->_generic(
-        name   = `MenuItem`
-        t_prop = VALUE #( ( n = `text` v = `Create New Site` ) )
-        )->menu_item( text = `Official Store`
-        )->menu_item( text = `Franchise Store`
-        )->menu_item( text = `Pop-up Store` ).
+    menu->ele( `MenuItem`
+        )->a( n = `text` v = `Create New Site` )->tag( `MenuItem`
+            )->a( n = `text` v = `Official Store` )->tag( `MenuItem`
+            )->a( n = `text` v = `Franchise Store` )->tag( `MenuItem`
+            )->a( n = `text` v = `Pop-up Store` ).
 
-    menu->_generic(
-        name   = `MenuItem`
-        t_prop = VALUE #( ( n = `text` v = `Manage Users` ) )
-        )->menu_item( text = `Add User`
-        )->menu_item( text = `Remove User` ).
+    menu->ele( `MenuItem`
+        )->a( n = `text` v = `Manage Users` )->tag( `MenuItem`
+            )->a( n = `text` v = `Add User` )->tag( `MenuItem`
+            )->a( n = `text` v = `Remove User` ).
 
-    menu->menu_item( text = `Log Out` ).
+    menu->tag( `MenuItem`
+        )->a( n = `text` v = `Log Out` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_474.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_474.clas.abap
@@ -73,58 +73,55 @@ CLASS z2ui5_cl_smp_app_474 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Message - MessagePopover URL Policy`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Message - MessagePopover URL Policy`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Each message below carries an in-app link and an external one. The policy ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Each message below carries an in-app link and an external one. The policy ` &&
                    `applied when opening decides which of them the popover keeps clickable - ` &&
                    `RELATIVE_ONLY blocks everything that leaves the app, ALLOW_ALL keeps every ` &&
                    `link, DENY_ALL blocks all of them. The policy travels as data, the frontend ` &&
                    `installs the validator (setAsyncURLHandler).`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->dependents(
-        )->message_popover( id = `msgPopover`
-            )->message_item(
-                type              = `Error`
-                title             = `Order cannot be released`
-                markupdescription = abap_true
-                description       = `Check the <a href="#/orders/4711">order details</a> or the ` &&
+    page->ele( `dependents` )->ele( `MessagePopover`
+            )->a( n = `id` v = `msgPopover` )->ele( `MessageItem`
+                )->a( n = `type`              v = `Error`
+                )->a( n = `title`             v = `Order cannot be released`
+                )->a( n = `description`       v = `Check the <a href="#/orders/4711">order details</a> or the ` &&
                                     `<a href="https://abap2ui5.org">documentation</a>.`
-            )->get_parent(
-            )->message_item(
-                type              = `Warning`
-                title             = `Delivery date in the past`
-                markupdescription = abap_true
-                description       = `Open the <a href="#/deliveries">delivery list</a> or the ` &&
+                )->a( n = `markupDescription` b = abap_true )->end( )->ele( `MessageItem`
+                )->a( n = `type`              v = `Warning`
+                )->a( n = `title`             v = `Delivery date in the past`
+                )->a( n = `description`       v = `Open the <a href="#/deliveries">delivery list</a> or the ` &&
                                     `<a href="https://ui5.sap.com">UI5 demo kit</a>.`
-            )->get_parent(
-            )->get_parent( ).
+                )->a( n = `markupDescription` b = abap_true )->end( )->end( ).
 
-    page->hbox( class = `sapUiSmallMargin`
-        )->button(
-            text  = `Open with RELATIVE_ONLY`
-            type  = `Emphasized`
-            press = client->_event( val   = `OPEN_RELATIVE_ONLY`
+    page->ele( `HBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( val   = `OPEN_RELATIVE_ONLY`
                                     t_arg = VALUE #( ( `$event.oSource.sId` ) ) )
-        )->button(
-            text  = `Open with ALLOW_ALL`
-            class = `sapUiTinyMarginBegin`
-            press = client->_event( val   = `OPEN_ALLOW_ALL`
+            )->a( n = `text`  v = `Open with RELATIVE_ONLY`
+            )->a( n = `type`  v = `Emphasized` )->tag( `Button`
+            )->a( n = `press` v = client->_event( val   = `OPEN_ALLOW_ALL`
                                     t_arg = VALUE #( ( `$event.oSource.sId` ) ) )
-        )->button(
-            text  = `Open with DENY_ALL`
-            class = `sapUiTinyMarginBegin`
-            press = client->_event( val   = `OPEN_DENY_ALL`
-                                    t_arg = VALUE #( ( `$event.oSource.sId` ) ) ) ).
+            )->a( n = `text`  v = `Open with ALLOW_ALL`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( val   = `OPEN_DENY_ALL`
+                                    t_arg = VALUE #( ( `$event.oSource.sId` ) ) )
+            )->a( n = `text`  v = `Open with DENY_ALL`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_488.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_488.clas.abap
@@ -75,47 +75,56 @@ CLASS z2ui5_cl_smp_app_488 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Navigation - Return Data and Events to the Caller`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Navigation - Return Data and Events to the Caller`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Calls a second app that returns via nav_app_leave with an event and a data ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Calls a second app that returns via nav_app_leave with an event and a data ` &&
                    `payload (r_data). On return this app reads both from client->get( ) in its ` &&
                    `check_on_navigated( ) branch and shows them below.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form(
-            title    = `Result returned by the called app`
-            editable = abap_true
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title`    v = `Result returned by the called app`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Open the input app` ).
-    form->button(
-        text  = `call app (nav_app_call)`
-        type  = `Emphasized`
-        press = client->_event( `CALL_APP` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Open the input app` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `CALL_APP` )
+        )->a( n = `text`  v = `call app (nav_app_call)`
+        )->a( n = `type`  v = `Emphasized` ).
 
-    form->label( `Returned event` ).
-    form->input(
-        value   = client->_bind( returned_event )
-        enabled = abap_false ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Returned event` ).
+    form->tag( `Input`
+        )->a( n = `enabled` b = abap_false
+        )->a( n = `value`   v = client->_bind( returned_event ) ).
 
-    form->label( `Returned product` ).
-    form->input(
-        value   = client->_bind( s_result-product )
-        enabled = abap_false ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Returned product` ).
+    form->tag( `Input`
+        )->a( n = `enabled` b = abap_false
+        )->a( n = `value`   v = client->_bind( s_result-product ) ).
 
-    form->label( `Returned quantity` ).
-    form->input(
-        value   = client->_bind( s_result-quantity )
-        enabled = abap_false ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Returned quantity` ).
+    form->tag( `Input`
+        )->a( n = `enabled` b = abap_false
+        )->a( n = `value`   v = client->_bind( s_result-quantity ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_489.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_489.clas.abap
@@ -52,41 +52,51 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell( )->page(
-        title          = `abap2UI5 - Navigation - Data Input App`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+        )->a( n = `xmlns:layout` v = `sap.ui.layout` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `title`          v = `abap2UI5 - Navigation - Data Input App`
+        )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+        )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Change the data and return: 'confirm' leaves with event DATA_CONFIRMED plus the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Change the data and return: 'confirm' leaves with event DATA_CONFIRMED plus the ` &&
                    `entered data as r_data, 'cancel' leaves with event DATA_CANCELLED and no data. ` &&
                    `The nav-back button of the page leaves without an event.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    DATA(form) = page->grid( `L6 M12 S12`
-        )->content( `layout`
-        )->simple_form(
-            title    = `Data returned to the caller`
-            editable = abap_true
-        )->content( `form` ).
+    DATA(form) = page->ele( n = `Grid` ns = `layout`
+        )->a( n = `defaultSpan` v = `L6 M12 S12` )->ele( n = `content` ns = `layout` )->ele( n = `SimpleForm` ns = `form`
+            )->a( n = `title`    v = `Data returned to the caller`
+            )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` ).
 
-    form->label( `Product` ).
-    form->input( client->_bind( s_result-product ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Product` ).
+    form->tag( `Input`
+        )->a( n = `value` v = client->_bind( s_result-product ) ).
 
-    form->label( `Quantity` ).
-    form->input( client->_bind( s_result-quantity ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Quantity` ).
+    form->tag( `Input`
+        )->a( n = `value` v = client->_bind( s_result-quantity ) ).
 
-    form->label( `Return to the caller` ).
-    form->button(
-        text  = `confirm (event + r_data)`
-        type  = `Emphasized`
-        press = client->_event( `CONFIRM` ) ).
-    form->button(
-        text  = `cancel (event only)`
-        press = client->_event( `CANCEL` ) ).
+    form->tag( `Label`
+        )->a( n = `text` v = `Return to the caller` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `CONFIRM` )
+        )->a( n = `text`  v = `confirm (event + r_data)`
+        )->a( n = `type`  v = `Emphasized` ).
+    form->tag( `Button`
+        )->a( n = `press` v = client->_event( `CANCEL` )
+        )->a( n = `text`  v = `cancel (event only)` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_490.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_490.clas.abap
@@ -50,30 +50,35 @@ CLASS z2ui5_cl_smp_app_490 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Popover - Open Together with the View Build`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Popover - Open Together with the View Build`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `This response built the page AND opened the popover in one roundtrip - ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `This response built the page AND opened the popover in one roundtrip - ` &&
                    `the popover anchors to the button below, which only exists once this ` &&
                    `view is rendered. Both buttons re-open it: the first rebuilds the view ` &&
                    `with it, the second opens it alone.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->vbox( `sapUiSmallMargin`
-        )->button( id    = `btnAnchor`
-                   text  = `rebuild view + open popover`
-                   icon  = `sap-icon://refresh`
-                   press = client->_event( `REBUILD_AND_OPEN` )
-        )->button( text  = `open popover only (view untouched)`
-                   press = client->_event( `OPEN_ONLY` ) ).
+    page->ele( `VBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `REBUILD_AND_OPEN` )
+            )->a( n = `text`  v = `rebuild view + open popover`
+            )->a( n = `icon`  v = `sap-icon://refresh`
+            )->a( n = `id`    v = `btnAnchor` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `OPEN_ONLY` )
+            )->a( n = `text`  v = `open popover only (view untouched)` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -82,15 +87,18 @@ CLASS z2ui5_cl_smp_app_490 IMPLEMENTATION.
 
   METHOD popover_display.
 
-    DATA(popover) = z2ui5_cl_xml_view=>factory_popup( ).
-    popover->popover( title        = `Opened with the view`
-                      placement    = `Bottom`
-                      contentwidth = `20rem`
-        )->vbox( `sapUiSmallMargin`
-            )->text( `This popover travelled in the SAME response as the view it is ` &&
-                     `anchored to.`
-            )->object_status( text  = |roundtrips so far: { counter }|
-                              state = `Information` ).
+    DATA(popover) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
+    popover->ele( `Popover`
+        )->a( n = `title`        v = `Opened with the view`
+        )->a( n = `placement`    v = `Bottom`
+        )->a( n = `contentWidth` v = `20rem` )->ele( `VBox`
+            )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Text`
+                )->a( n = `text` v = `This popover travelled in the SAME response as the view it is ` &&
+                     `anchored to.` )->ele( `ObjectStatus`
+                )->a( n = `state` v = `Information`
+                )->a( n = `text`  v = |roundtrips so far: { counter }| ).
 
     client->popover_display( xml   = popover->stringify( )
                              by_id = `btnAnchor` ).

--- a/src/01/z2ui5_cl_smp_app_491.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_491.clas.abap
@@ -17,29 +17,32 @@ CLASS z2ui5_cl_smp_app_491 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Browser - Set the Tab Favicon`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Browser - Set the Tab Favicon`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `Enter an image URL (or data URI) and press the button to run the set_favicon front-end action, ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `Enter an image URL (or data URI) and press the button to run the set_favicon front-end action, ` &&
                      `which updates the browser tab icon (the link rel="icon" tag) without reloading the page.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      page->simple_form(
-          title    = `Favicon`
-          editable = abap_true
-          )->content( `form`
-          )->label( `favicon url`
-          )->input( client->_bind( favicon )
-          )->button(
-              text  = `Set Favicon`
-              press = client->_event( `SET_FAVICON` ) ).
+      page->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `title`    v = `Favicon`
+          )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `favicon url` )->tag( `Input`
+              )->a( n = `value` v = client->_bind( favicon ) )->tag( `Button`
+              )->a( n = `press` v = client->_event( `SET_FAVICON` )
+              )->a( n = `text`  v = `Set Favicon` ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `SET_FAVICON` ).

--- a/src/01/z2ui5_cl_smp_app_492.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_492.clas.abap
@@ -21,34 +21,36 @@ CLASS z2ui5_cl_smp_app_492 IMPLEMENTATION.
       DATA(s_config) = client->get( )-s_config.
       url = s_config-pathname && s_config-search.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Browser - Reload the Page`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Browser - Reload the Page`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `The location_reload front-end action navigates the browser to a same-domain URL. The url field is ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `The location_reload front-end action navigates the browser to a same-domain URL. The url field is ` &&
                      `prefilled with this page's own address, so the button reloads the app from scratch - type something ` &&
                      `into the scratch field first and watch it get lost. Cross-origin URLs are blocked by the framework.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      page->simple_form(
-          title    = `Reload`
-          editable = abap_true
-          )->content( `form`
-          )->label( `scratch input`
-          )->input(
-              value       = client->_bind( scratch )
-              placeholder = `type something - it is lost after the reload`
-          )->label( `url`
-          )->input( client->_bind( url )
-          )->button(
-              text  = `Reload Page`
-              press = client->_event( `RELOAD` ) ).
+      page->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `title`    v = `Reload`
+          )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `scratch input` )->tag( `Input`
+              )->a( n = `placeholder` v = `type something - it is lost after the reload`
+              )->a( n = `value`       v = client->_bind( scratch ) )->tag( `Label`
+              )->a( n = `text` v = `url` )->tag( `Input`
+              )->a( n = `value` v = client->_bind( url ) )->tag( `Button`
+              )->a( n = `press` v = client->_event( `RELOAD` )
+              )->a( n = `text`  v = `Reload Page` ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `RELOAD` ).

--- a/src/01/z2ui5_cl_smp_app_493.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_493.clas.abap
@@ -15,27 +15,31 @@ CLASS z2ui5_cl_smp_app_493 IMPLEMENTATION.
 
     IF client->check_on_init( ).
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Basics I - Hello World, the Smallest App`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Basics I - Hello World, the Smallest App`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `The whole app is what you see below: a class implementing z2ui5_if_app, ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `The whole app is what you see below: a class implementing z2ui5_if_app, ` &&
                      `one main( ) method, a view built as XML and handed to client->view_display( ). ` &&
                      `abap2UI5 calls main( ) on every roundtrip - here only the first one matters, ` &&
                      `which is what check_on_init( ) asks. Copy this class as the starting point ` &&
                      `for your own app.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      page->title(
-          text  = `Hello World`
-          level = `H2`
-          class = `sapUiSmallMargin` ).
+      page->tag( `Title`
+          )->a( n = `text`  v = `Hello World`
+          )->a( n = `class` v = `sapUiSmallMargin`
+          )->a( n = `level` v = `H2` ).
       client->view_display( view->stringify( ) ).
 
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_494.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_494.clas.abap
@@ -20,36 +20,39 @@ CLASS z2ui5_cl_smp_app_494 IMPLEMENTATION.
 
       name = `World`.
 
-      DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      DATA(page) = view->shell(
-          )->page(
-              title          = `abap2UI5 - Basics II - Data Binding: Input and Button`
-              navbuttonpress = client->_event_nav_app_leave( )
-              shownavbutton  = client->check_app_prev_stack( ) ).
+      DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+          )->a( n = `displayBlock` v = `true`
+          )->a( n = `height`       v = `100%`
+          )->a( n = `xmlns`        v = `sap.m`
+          )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`   v = `sap.ui.core`
+          )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+      DATA(page) = view->ele( `Shell` )->ele( `Page`
+              )->a( n = `title`          v = `abap2UI5 - Basics II - Data Binding: Input and Button`
+              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-      page->message_strip(
-          text     = `client->_bind( name ) connects the public attribute NAME with the input ` &&
+      page->tag( `MessageStrip`
+          )->a( n = `text`     v = `client->_bind( name ) connects the public attribute NAME with the input ` &&
                      `below - in both directions. Type a name and leave the field: the text ` &&
                      `next to it changes without any ABAP code, because both are bound to the ` &&
                      `same attribute. Press Greet and the backend reads NAME - already filled ` &&
                      `in, no event argument needed - and writes GREETING back into the view.`
-          type     = `Information`
-          showicon = abap_true
-          class    = `sapUiSmallMargin` ).
+          )->a( n = `type`     v = `Information`
+          )->a( n = `showIcon` b = abap_true
+          )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-      page->simple_form(
-          title    = `Data Binding`
-          editable = abap_true
-          )->content( `form`
-          )->label( `your name`
-          )->input( client->_bind( name )
-          )->label( `bound to the same attribute`
-          )->text( client->_bind( name )
-          )->label( `written by the backend`
-          )->text( client->_bind( greeting )
-          )->button(
-              text  = `Greet`
-              press = client->_event( `GREET` ) ).
+      page->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `title`    v = `Data Binding`
+          )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `your name` )->tag( `Input`
+              )->a( n = `value` v = client->_bind( name ) )->tag( `Label`
+              )->a( n = `text` v = `bound to the same attribute` )->tag( `Text`
+              )->a( n = `text` v = client->_bind( name ) )->tag( `Label`
+              )->a( n = `text` v = `written by the backend` )->tag( `Text`
+              )->a( n = `text` v = client->_bind( greeting ) )->tag( `Button`
+              )->a( n = `press` v = client->_event( `GREET` )
+              )->a( n = `text`  v = `Greet` ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `GREET` ).

--- a/src/01/z2ui5_cl_smp_app_495.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_495.clas.abap
@@ -62,40 +62,42 @@ CLASS z2ui5_cl_smp_app_495 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Basics III - Lifecycle: Init, Event, Navigated`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics III - Lifecycle: Init, Event, Navigated`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `main( ) runs on every roundtrip - the three checks tell it what the ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `main( ) runs on every roundtrip - the three checks tell it what the ` &&
                    `roundtrip is about. The list logs each call, and it survives them all: ` &&
                    `every public attribute is serialized between the roundtrips, so the app ` &&
                    `keeps its state without a database. Press Log - only the model is pushed, ` &&
                    `the view is not rebuilt. Call the sub-app and come back with its back ` &&
                    `button - that is the roundtrip check_on_navigated( ) answers.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->hbox( class = `sapUiSmallMargin`
-        )->button(
-            text  = `Log an Event`
-            press = client->_event( `LOG` )
-        )->button(
-            text  = `Call a Sub-App`
-            press = client->_event( `CALL` )
-            class = `sapUiTinyMarginBegin` ).
+    page->ele( `HBox`
+        )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `LOG` )
+            )->a( n = `text`  v = `Log an Event` )->tag( `Button`
+            )->a( n = `press` v = client->_event( `CALL` )
+            )->a( n = `text`  v = `Call a Sub-App`
+            )->a( n = `class` v = `sapUiTinyMarginBegin` ).
 
-    page->list(
-        headertext = `Calls of main( )`
-        items      = client->_bind( t_log )
-        class      = `sapUiSmallMargin`
-        )->standard_list_item(
-            title       = `{CHECK}`
-            description = `call {NO}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `Calls of main( )`
+        )->a( n = `items`      v = client->_bind( t_log )
+        )->a( n = `class`      v = `sapUiSmallMargin` )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{CHECK}`
+            )->a( n = `description` v = `call {NO}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/z2ui5_cl_smp_app_496.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_496.clas.abap
@@ -79,7 +79,7 @@ CLASS z2ui5_cl_smp_app_496 IMPLEMENTATION.
       ( name  = `Source Code`
         descr = `The ABAP class behind the running app, with an ADT jump link in the dialog footer.` )
       ( name  = `View`
-        descr = `The XML view your ABAP built - what z2ui5_cl_xml_view stringified into the response.` )
+        descr = `The XML view your ABAP built - what z2ui5_cl_ui5_view_builder stringified into the response.` )
       ( name  = `View Model`
         descr = `The model behind that view: every bound attribute of this class with its live value.` )
       ( name  = `Popup, Popover, Nest1, Nest2`
@@ -90,49 +90,50 @@ CLASS z2ui5_cl_smp_app_496 IMPLEMENTATION.
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = view->shell(
-        )->page(
-            title          = `abap2UI5 - Basics V - The Developer Tools (Ctrl+F12)`
-            navbuttonpress = client->_event_nav_app_leave( )
-            shownavbutton  = client->check_app_prev_stack( ) ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core`
+        )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics V - The Developer Tools (Ctrl+F12)`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
 
-    page->message_strip(
-        text     = `Press Ctrl+F12 - here and in every other abap2UI5 app - and the developer tools ` &&
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Press Ctrl+F12 - here and in every other abap2UI5 app - and the developer tools ` &&
                    `open over the app. They show what travels between this class and the browser: the ` &&
                    `XML view your ABAP built, the model behind it, and the JSON of the last request and ` &&
                    `response. Change the text below, press Send, and look at Previous Request: the value ` &&
                    `you typed is in it. Then look at View Model - it is there too, because a public ` &&
                    `attribute is the model.`
-        type     = `Information`
-        showicon = abap_true
-        class    = `sapUiSmallMargin` ).
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
 
-    page->simple_form(
-        title    = `Something to look at`
-        editable = abap_true
-        )->content( `form`
-        )->label( `bound to the public attribute TEXT`
-        )->input( client->_bind( text )
-        )->label( `roundtrips so far`
-        )->text( client->_bind( roundtrips )
-        )->label( `send it to the backend`
-        )->button(
-            text  = `Send`
-            press = client->_event( cs_event-ping )
-        )->label( `how do I open the tools?`
-        )->button(
-            text  = `Show me`
-            icon  = `sap-icon://sys-help`
-            press = client->_event( cs_event-where ) ).
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Something to look at`
+        )->a( n = `editable` b = abap_true )->ele( n = `content` ns = `form` )->tag( `Label`
+            )->a( n = `text` v = `bound to the public attribute TEXT` )->tag( `Input`
+            )->a( n = `value` v = client->_bind( text ) )->tag( `Label`
+            )->a( n = `text` v = `roundtrips so far` )->tag( `Text`
+            )->a( n = `text` v = client->_bind( roundtrips ) )->tag( `Label`
+            )->a( n = `text` v = `send it to the backend` )->tag( `Button`
+            )->a( n = `press` v = client->_event( cs_event-ping )
+            )->a( n = `text`  v = `Send` )->tag( `Label`
+            )->a( n = `text` v = `how do I open the tools?` )->tag( `Button`
+            )->a( n = `press` v = client->_event( cs_event-where )
+            )->a( n = `text`  v = `Show me`
+            )->a( n = `icon`  v = `sap-icon://sys-help` ).
 
-    page->list(
-        headertext = `What the tabs of the tools show`
-        items      = client->_bind( t_tab )
-        class      = `sapUiSmallMargin`
-        )->standard_list_item(
-            title       = `{NAME}`
-            description = `{DESCR}` ).
+    page->ele( `List`
+        )->a( n = `headerText` v = `What the tabs of the tools show`
+        )->a( n = `items`      v = client->_bind( t_tab )
+        )->a( n = `class`      v = `sapUiSmallMargin` )->tag( `StandardListItem`
+            )->a( n = `title`       v = `{NAME}`
+            )->a( n = `description` v = `{DESCR}` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -97,11 +97,11 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
     "! repository you are looking at, there is nowhere to go from it.
     METHODS render_header
       IMPORTING
-        page TYPE REF TO z2ui5_cl_xml_view.
+        page TYPE REF TO z2ui5_cl_ui5_view_builder.
     "! The second header row: the filter over the tile list.
     METHODS render_sub_header
       IMPORTING
-        page TYPE REF TO z2ui5_cl_xml_view.
+        page TYPE REF TO z2ui5_cl_ui5_view_builder.
     "! A repository that is not on this system stays clickable and says what is
     "! missing - a popover on the icon that was pressed, with the GitHub link
     "! to install it from.
@@ -121,7 +121,7 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
     "!                          two groups apart - see render_header( )
     METHODS header_button
       IMPORTING
-        toolbar     TYPE REF TO z2ui5_cl_xml_view
+        toolbar     TYPE REF TO z2ui5_cl_ui5_view_builder
         icon        TYPE string
         name        TYPE string
         descr       TYPE string
@@ -293,11 +293,17 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
     DATA(t_catalog) = catalog_filter( t_catalog_all ).
     DATA(t_blocks) = block_widths( t_catalog ).
 
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `View` ns = `mvc`
+        )->a( n = `displayBlock` v = `true`
+        )->a( n = `height`       v = `100%`
+        )->a( n = `xmlns`        v = `sap.m`
+        )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:core`   v = `sap.ui.core` ).
 
     " title and back button come with the custom header (render_header), not
     " with the page - a Page renders either its own header or a custom one
-    DATA(page) = view->shell( )->page( id = `page` ).
+    DATA(page) = view->ele( `Shell` )->ele( `Page`
+        )->a( n = `id` v = `page` ).
 
     render_header( page ).
     render_sub_header( page ).
@@ -315,10 +321,10 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       IF tile-group <> prev_group.
 
         IF show_groups = abap_true.
-          page->title(
-              text  = tile-group
-              level = `H3`
-              class = `sapUiSmallMarginTop sapUiTinyMarginBottom` ).
+          page->tag( `Title`
+              )->a( n = `text`  v = tile-group
+              )->a( n = `class` v = `sapUiSmallMarginTop sapUiTinyMarginBottom`
+              )->a( n = `level` v = `H3` ).
 
         ELSE.
           " no heading that could set the first block apart from the header
@@ -337,25 +343,25 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       " widest header of the block plus roughly one space, in 1/100 em
       DATA(tenths) = ( t_blocks[ group = tile-group base = base ]-width + 45 ) DIV 10.
       DATA(width) = |{ tenths DIV 10 }.{ tenths MOD 10 }em|.
-      DATA(row) = page->hbox(
-          alignitems = `Center`
-          wrap       = `Wrap`
-          class      = COND #( WHEN new_block = abap_true
+      DATA(row) = page->ele( `HBox`
+          )->a( n = `class`      v = COND #( WHEN new_block = abap_true
                                THEN `sapUiSmallMarginBegin sapUiSmallMarginTop`
-                               ELSE `sapUiSmallMarginBegin` ) ).
+                               ELSE `sapUiSmallMarginBegin` )
+          )->a( n = `alignItems` v = `Center`
+          )->a( n = `wrap`       v = `Wrap` ).
 
       IF tile-sub IS INITIAL.
-        row->link(
-            text  = tile-header
-            width = width
-            press = client->_event( tile-app ) ).
+        row->tag( `Link`
+            )->a( n = `text`  v = tile-header
+            )->a( n = `press` v = client->_event( tile-app )
+            )->a( n = `width` v = width ).
 
       ELSE.
-        row->link(
-            text  = tile-header
-            width = width
-            press = client->_event( tile-app )
-            )->text( tile-sub ).
+        row->tag( `Link`
+            )->a( n = `text`  v = tile-header
+            )->a( n = `press` v = client->_event( tile-app )
+            )->a( n = `width` v = width )->tag( `Text`
+                )->a( n = `text` v = tile-sub ).
       ENDIF.
 
       " straight to the ABAP behind the sample - the tile shows what it does,
@@ -364,25 +370,24 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       " A core:Icon, not a Button: a Button brings its own height (2rem even in
       " compact density) and would set the line height of every row - the icon
       " is as tall as the text next to it, which is what keeps the list tight
-      row->_generic(
-          name   = `Icon`
-          ns     = `core`
-          t_prop = VALUE #( ( n = `src`     v = `sap-icon://source-code` )
-                            ( n = `size`    v = `0.875rem` )
-                            ( n = `class`   v = `sapUiTinyMarginBegin` )
-                            ( n = `tooltip` v = |{ tile-app } - show the ABAP source on GitHub| )
-                            ( n = `press`   v = open_url( source_url( tile ) ) ) ) ).
+      row->ele( n = `Icon` ns = `core`
+          )->a( n = `src`     v = `sap-icon://source-code`
+          )->a( n = `size`    v = `0.875rem`
+          )->a( n = `class`   v = `sapUiTinyMarginBegin`
+          )->a( n = `tooltip` v = |{ tile-app } - show the ABAP source on GitHub|
+          )->a( n = `press`   v = open_url( source_url( tile ) ) ).
 
     ENDLOOP.
 
     IF t_catalog IS INITIAL.
-      page->text(
-          text  = `No sample matches the filter.`
-          class = `sapUiSmallMarginBegin` ).
+      page->tag( `Text`
+          )->a( n = `text`  v = `No sample matches the filter.`
+          )->a( n = `class` v = `sapUiSmallMarginBegin` ).
     ENDIF.
 
     " a few blank lines so the last tiles do not end glued to the page bottom
-    page->vbox( height = `4rem` ).
+    page->ele( `VBox`
+        )->a( n = `height` v = `4rem` ).
 
     client->view_display( view->stringify( ) ).
 
@@ -401,22 +406,24 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
     " 3rem. This row used to put a ToolbarSeparator between its two groups and
     " lost the documentation and GitHub icons on 1.71 because of it; the gap
     " now rides on the first icon of the second group (group_start).
-    DATA(bar) = page->custom_header( )->bar( ).
+    DATA(bar) = page->ele( `customHeader` )->ele( `Bar` ).
 
     " left: what the stock page header would render on its own
-    DATA(left) = bar->content_left( ).
+    DATA(left) = bar->ele( `contentLeft` ).
 
-    left->button( icon    = `sap-icon://nav-back`
-                  type    = `Transparent`
-                  tooltip = `Back`
-                  visible = client->check_app_prev_stack( )
-                  press   = client->_event_nav_app_leave( ) ).
+    left->tag( `Button`
+        )->a( n = `press`   v = client->_event_nav_app_leave( )
+        )->a( n = `visible` b = client->check_app_prev_stack( )
+        )->a( n = `icon`    v = `sap-icon://nav-back`
+        )->a( n = `type`    v = `Transparent`
+        )->a( n = `tooltip` v = `Back` ).
 
-    left->title( text  = `abap2UI5 - Samples`
-                 level = `H2` ).
+    left->tag( `Title`
+        )->a( n = `text`  v = `abap2UI5 - Samples`
+        )->a( n = `level` v = `H2` ).
 
     " right: the sample repositories of the abap2UI5 family, one icon each ...
-    DATA(right) = bar->content_right( ).
+    DATA(right) = bar->ele( `contentRight` ).
 
     header_button( toolbar = right
                    icon    = `sap-icon://lightbulb`
@@ -462,16 +469,16 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
   METHOD render_sub_header.
 
-    DATA(toolbar) = page->sub_header( )->overflow_toolbar( ).
+    DATA(toolbar) = page->ele( `subHeader` )->ele( `OverflowToolbar` ).
 
     " the filter sits in the header, not above the list: it stays in place
     " while the list below it grows and shrinks
-    toolbar->search_field(
-        id          = `search`
-        value       = client->_bind( search )
-        search      = client->_event( cs_event-search )
-        width       = `24rem`
-        placeholder = `Filter samples` ).
+    toolbar->tag( `SearchField`
+        )->a( n = `width`       v = `24rem`
+        )->a( n = `search`      v = client->_event( cs_event-search )
+        )->a( n = `value`       v = client->_bind( search )
+        )->a( n = `id`          v = `search`
+        )->a( n = `placeholder` v = `Filter samples` ).
 
   ENDMETHOD.
 
@@ -545,35 +552,35 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
                                    THEN `sapUiMediumMarginBegin sapUiTinyMarginEnd`
                                    ELSE `sapUiTinyMarginBeginEnd` ).
 
-    toolbar->_generic(
-        name   = `Icon`
-        ns     = `core`
-        t_prop = VALUE #( ( n = `src`     v = icon )
-                          ( n = `id`      v = class )
-                          ( n = `size`    v = `1.125rem` )
-                          ( n = `class`   v = css_class )
-                          ( n = `color`   v = color )
-                          ( n = `tooltip` v = hint )
-                          ( n = `press`   v = press ) ) ).
+    toolbar->ele( n = `Icon` ns = `core`
+        )->a( n = `src`     v = icon
+        )->a( n = `id`      v = class
+        )->a( n = `size`    v = `1.125rem`
+        )->a( n = `class`   v = css_class
+        )->a( n = `color`   v = color
+        )->a( n = `tooltip` v = hint
+        )->a( n = `press`   v = press ).
 
   ENDMETHOD.
 
 
   METHOD install_display.
 
-    DATA(view) = z2ui5_cl_xml_view=>factory_popup( ).
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory( )->ele( n = `FragmentDefinition` ns = `core`
+        )->a( n = `xmlns`      v = `sap.m`
+        )->a( n = `xmlns:core` v = `sap.ui.core` ).
 
-    view->popover(
-            title        = |{ name } - not installed|
-            placement    = `Bottom`
-            contentwidth = `26rem`
-        )->vbox( `sapUiSmallMargin`
-            )->text( |This system does not have { name } installed, so there is no app to jump to. | &&
-                     |Install the repository with abapGit, then this icon opens it right here.|
-            )->link( text   = href
-                     href   = href
-                     target = `_blank`
-                     class  = `sapUiSmallMarginTop` ).
+    view->ele( `Popover`
+        )->a( n = `title`        v = |{ name } - not installed|
+        )->a( n = `placement`    v = `Bottom`
+        )->a( n = `contentWidth` v = `26rem` )->ele( `VBox`
+            )->a( n = `class` v = `sapUiSmallMargin` )->tag( `Text`
+                )->a( n = `text` v = |This system does not have { name } installed, so there is no app to jump to. | &&
+                     |Install the repository with abapGit, then this icon opens it right here.| )->tag( `Link`
+                )->a( n = `text`   v = href
+                )->a( n = `target` v = `_blank`
+                )->a( n = `href`   v = href
+                )->a( n = `class`  v = `sapUiSmallMarginTop` ).
 
     client->popover_display( xml   = view->stringify( )
                              by_id = anchor ).


### PR DESCRIPTION
All 150 view-building classes still used the frozen `z2ui5_cl_xml_view` from abap2UI5's `src/99`. The released builder is `z2ui5_cl_ui5_view_builder` in `src/02`; samples-controls moved its corpus already, and this brings the teaching samples to the same builder.

## How the translation was made

The two are not the same API: the legacy one is a typed fluent builder with 452 control methods, the new one is generic (`ele`/`tag`/`a`/`end`). The mapping was **derived from the legacy source** rather than written by hand — every method there names its control, its namespace, its parameter-to-attribute mapping and which parameters are booleans, and `result = me` versus `result = _generic( )` is exactly the `tag( )`/`ele( )` distinction. All 441 methods mapped.

Attributes are emitted in the legacy builder's own property order, so **the rendered XML is unchanged**.

## Semantics that needed care — none of them visible to abaplint

- The legacy builder **skipped empty attributes** while the new one renders `attr=""`, so only arguments a caller actually passes become `a( )` calls.
- Its renderer turned **any** value equal to `abap_true` into `"true"`, not just the parameters it wrapped — so a boolean expression becomes `a( b = )`, which renders `true`/`false` itself.
- A single positional argument binds the way ABAP binds it: to `PREFERRED PARAMETER`, else to the only importing parameter. That is how `content( \`form\` )` is a namespace and `table( client->_bind( t ) )` is the items binding.
- `_cc_plain_xml( )` created a node the legacy renderer emitted as **raw text with no tag**. The new builder has no raw-text node, so the mechanical translation produced a real `<html:ZZPLAIN VALUE="…"/>` element — valid ABAP, valid XML, and not a stylesheet. Samples 050, 255 and 305 now carry their CSS in the `content` attribute of a `core:HTML` leaf, the idiom samples-controls uses; app 255 already used it for its FlexBox items.
- The legacy root **collected namespace prefixes on the fly**. The released one does not, so every prefix a view uses is now declared on the root that governs it.

## Constructs with no counterpart, restructured

- `get( \`Page\` )` walked up to a named ancestor. The eight nested-view samples now take the Page they render into (`mo_parent_page`) instead of searching for it — the embedder passes it, which is also the clearer contract.
- `get( )` after a control returned the node just created; that is what `ele( )` already does, so `tag( X )->get( )` collapses to `ele( X )`.

## The linter pin

The pin moves to `51cce10`, the first version that reads `z2ui5_cl_ui5_view_builder` and models the attribute verb by what it does rather than how a dialect spells it. Until now it looked for the builder's former name `z2ui5_cl_ai_xml` and reported "no checkable files" — which is why AGENTS.md §11 could say the gate would become effective once the samples moved. They have; this makes it true.

Running it immediately caught a defect this migration had introduced: 12 views shipped an element whose prefix was never declared, which fails view creation rather than rendering wrong. Fixed here.

## Worth knowing

- The legacy `tree( finished = )` and `dirty( title = )` parameters **were never rendered** — they sit in the signature but in no property table. The four call sites keep passing nothing, exactly as before.
- **The `abap2UI5` gate now reports findings.** After the fix above, what remains predates this change and was simply invisible while the gate was blind — e.g. app 190 adds a `footer` to the view root rather than to a `Page` (the variable is only *named* `page`). Working that backlog off is a separate change; with `failOn: warning` the gate is red until then.

## Docs

AGENTS.md §10 taught the typed fluent API on ~100 lines. It now teaches the builder that exists: `factory`/`ele`/`tag`/`a`/`end`/`stringify`, the chain layout, the namespaces a view has to declare itself, the popup root, and the two gaps above. The `_generic( )` section is gone — the builder is generic — and its binding rules, which never depended on the builder, are kept verbatim.

## Verification

`abaplint` 0 issues across 317 files, `check-agents` and `check-strip` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115fquCgXZfTzCGjn81e11x

---
_Generated by [Claude Code](https://claude.ai/code/session_0115fquCgXZfTzCGjn81e11x)_