### PR TITLE
Re-pin the linter to its main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#241787b",
+        "@abap2ui5/linter": "github:abap2UI5/linter#f2f0f9c",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#241787ba34a3d93a56083652fa1a35bbe8587a05",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#f2f0f9c7fffac10579c7801d18a13b42c545825a",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#241787b",
+    "@abap2ui5/linter": "github:abap2UI5/linter#f2f0f9c",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {


### PR DESCRIPTION
The follow-up #753 asked for: the `@abap2ui5/linter` pin was parked on the
feature-branch commit `241787b` while abap2UI5/linter#23 was still open. That
has merged, so the pin moves to the linter's main (`f2f0f9c`). Same linter
state, resolved through main — samples, samples-controls and samples-stack
keep judging by one linter.

Verified on this branch: `npx abap2ui5lint` reports **no findings**, 148 files,
0 failing, with the 476 baselined findings suppressed and no stale entry; and
`npx abaplint` is 0 issues over 317 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpUwcfA54MVzsoGBn3a9eT)_