### PR TITLE
Make abap2UI5-linter gate effective with badge and reporting

### DIFF
--- a/.github/badges/abap2ui5lint.json
+++ b/.github/badges/abap2ui5lint.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "abap2UI5-linter",
-  "message": "148 apps · UI5 1.71 · clean",
+  "message": "148 apps · 172 views · 2,176 controls · clean",
   "color": "4c1",
   "labelColor": "0a6ed1",
   "namedLogo": "sap",

--- a/.github/badges/abap2ui5lint.json
+++ b/.github/badges/abap2ui5lint.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "label": "abap2UI5-linter",
+  "message": "148 apps · UI5 1.71 · clean",
+  "color": "4c1",
+  "labelColor": "0a6ed1",
+  "namedLogo": "sap",
+  "logoColor": "white",
+  "cacheSeconds": 3600
+}

--- a/.github/workflows/check-abap2UI5.yaml
+++ b/.github/workflows/check-abap2UI5.yaml
@@ -8,12 +8,24 @@ name: check-abap2UI5
 # between the ABAP class and the view it builds, which no UI5 tooling sees.
 # Configuration lives in abap2ui5lint.jsonc; the linter is pinned as a
 # devDependency so CI and `npm run check:abap2ui5` run the same version.
+#
+# The run reports what it LOOKED at, not only what it found: the gates log
+# every file into a collapsed group while they run, and the job closes with
+# the run summary (how many classes, views, controls, bindings and icons were
+# judged, what the baseline swallowed, how long each gate took). On a corpus
+# whose findings are all baselined that summary is the only thing standing
+# between "148 classes were checked" and "nothing was checkable" - a
+# distinction this repository has been on the wrong side of before
+# (AGENTS.md 6). It also goes into the job summary of the run, and into the
+# README badge below.
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: check-abap2UI5-${{ github.ref }}
@@ -24,7 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v7
+    - name: Checkout Repository
+      uses: actions/checkout@v7
+      with:
+        # check out the branch, not the merge commit, so the badge can go back
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -33,3 +50,46 @@ jobs:
     # the render gate drives a headless browser
     - run: npx playwright install chromium --with-deps
     - run: npx abap2ui5lint
+
+    # The same corpus once more as markdown, into the job summary - findings
+    # and run summary on the run's own page, without expanding a log. A second
+    # pass, costing the property gate only (--no-render: whether the views
+    # load was decided by the step above), and --no-badge because a pass that
+    # skipped a gate must not overwrite the badge the real run wrote.
+    - name: Job summary
+      if: always()
+      run: npx abap2ui5lint --no-render --advisory --no-progress --no-badge --format markdown >> "$GITHUB_STEP_SUMMARY"
+
+    # abap2ui5lint.jsonc points "badge" at .github/badges/abap2ui5lint.json,
+    # so the step above already rewrote it with what the corpus now is. The
+    # default branch is protected and github-actions[bot] can never be added
+    # to a bypass list, so the badge is committed onto the PULL REQUEST branch
+    # - the pull request that changes the corpus is what changes the badge,
+    # and main picks it up when that pull request merges. Same mechanism as
+    # publish-overview-apps, including the fallback for refs that cannot be
+    # pushed to: there the stale badge is reported, never silently accepted.
+    # only after a green gate: a red pull request cannot merge, so its badge
+    # would never reach main anyway - and a badge commit on top of a failing
+    # run reads as if something had been fixed
+    - name: Publish the badge
+      if: success()
+      env:
+        # only a same-repository pull request can be pushed to with
+        # GITHUB_TOKEN; on main and from a fork the badge is only reported
+        PUSHABLE: ${{ github.event_name == 'pull_request'
+                      && github.event.pull_request.head.repo.full_name == github.repository }}
+      run: |
+        if git diff --quiet -- .github/badges; then
+          echo "The linter badge is up to date."
+          exit 0
+        fi
+        git diff -- .github/badges
+        if [ "$PUSHABLE" != "true" ]; then
+          echo "::warning::The linter badge is out of date and this ref cannot be pushed to. Run 'npm run check:abap2ui5' and commit .github/badges/abap2ui5lint.json."
+          exit 0
+        fi
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git commit -qm 'Refresh the abap2UI5-linter badge' -- .github/badges
+        git push
+        echo "Badge refreshed and pushed onto the pull request branch."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,19 +655,39 @@ newline). **Run `abaplint` — 0 issues — before committing.**
   | `abap2ui5` | defects living in the relationship between the ABAP class and the view it builds; silent at runtime, invisible to any UI5 tooling |
 
 - Configuration: `abap2ui5lint.jsonc` (UI5 floor `1.71`, distribution
-  `openui5`, `failOn: warning`)
+  `openui5`, `failOn: warning`, baseline, badge)
 - Run: `npm run check:abap2ui5`
 - CI: `abap2UI5` — as opposed to `abap-standard` / `abap-cloud` /
   `abap-702`, which lint ABAP itself against three target releases
-- **It currently reports nothing in this repository.** The samples are on
-  `z2ui5_cl_ui5_view_builder` (§10), but the pinned linter still looks for the
-  builder's former name `z2ui5_cl_ai_xml`, so it finds no checkable file. The
-  gate becomes effective when the pin moves to a version that reads the
-  released builder **and** spells its attribute verb `a( )` (the first version
-  that reads the new builder at all still spelled it `att( )`, which drops
-  every attribute including the namespace declarations — see
-  abap2UI5/samples-controls#89). Until then a green `abap2UI5` badge means
+- **The gate is effective**: 148 app classes, 172 reconstructed views, and
+  the adoption-time debt frozen in `abap2ui5lint-baseline.json` (#753). It was
+  not always: while the linter still looked for the view builder's former name
+  it found no checkable file at all, and a green `abap2UI5` badge then meant
   "nothing was checkable", not "the apps are clean".
+- **That is why a run reports what it LOOKED at**, not only what it found.
+  The gates log every file into a collapsed group while they run, and the run
+  closes with a summary — classes, views reconstructed (**and how many
+  classes produced none**), controls, bindings and icons judged, the control
+  histogram, what the baseline swallowed and per rule, the phase times:
+
+  ```
+  sources    148 app classes
+  views      172 documents reconstructed, nested 11 deep, 7 classes produced none
+  judged     2,176 controls of 106 types, 548 bindings, 69 icons, 4,164 attributes
+  gates      properties 148 files, render 172 documents
+  baselined  476 findings suppressed by abap2ui5lint-baseline.json (…)
+  ```
+
+  A `judged` line of zeroes, or `148 classes produced none`, is the earlier
+  failure repeating itself — and now it says so instead of printing
+  "Success! No findings detected."
+- **The README badge** (`.github/badges/abap2ui5lint.json`, a shields.io
+  endpoint file) carries the same statement: *148 apps · UI5 1.71 · clean*.
+  Every run rewrites it, `check-abap2UI5` commits it onto the pull request
+  branch, and main picks it up when that pull request merges — so the number
+  next to "clean" is what the last run actually checked. **A sample added or
+  removed changes this file**; commit it with the change (the workflow pushes
+  it if you forget, and reports it when it cannot).
 
 ### abapGit file consistency
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,10 +682,11 @@ newline). **Run `abaplint` — 0 issues — before committing.**
   failure repeating itself — and now it says so instead of printing
   "Success! No findings detected."
 - **The README badge** (`.github/badges/abap2ui5lint.json`, a shields.io
-  endpoint file) carries the same statement: *148 apps · UI5 1.71 · clean*.
-  Every run rewrites it, `check-abap2UI5` commits it onto the pull request
-  branch, and main picks it up when that pull request merges — so the number
-  next to "clean" is what the last run actually checked. **A sample added or
+  endpoint file) carries the same statement, in the reach of the check:
+  *148 apps · 172 views · 2,176 controls · clean*. Every run rewrites it,
+  `check-abap2UI5` commits it onto the pull request branch, and main picks it
+  up when that pull request merges — so the numbers next to "clean" are what
+  the last run actually checked. **A sample added or
   removed changes this file**; commit it with the change (the workflow pushes
   it if you forget, and reports it when it cannot).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![namespace](https://img.shields.io/badge/namespace-z2ui5__cl__smp-blue)](abaplint.jsonc)
 [![dependency](https://img.shields.io/badge/dependency-abap2UI5-blue)](https://github.com/abap2UI5/abap2UI5)
 <br>
+[![abap2UI5-linter](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fabap2ui5lint.json)](https://github.com/abap2UI5/linter)
+<br>
 <br>
 [![abap-standard](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml)
 [![abap-cloud](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml)

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -25,7 +25,8 @@
   "baseline": "abap2ui5lint-baseline.json",
 
   // The README badge. Every run rewrites this shields.io endpoint file with
-  // what the corpus currently is - "148 apps - UI5 1.71 - clean" - and
+  // how far the check reached - "148 apps - 172 views - 2,176 controls -
+  // clean", the same numbers the run summary prints - and
   // check-abap2UI5 commits it onto the pull request branch, so the badge on
   // main updates when the pull request that changed the corpus merges. It
   // says something the workflow badge next to it cannot: a green workflow

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -24,6 +24,15 @@
   // Refresh it with `npx abap2ui5lint --update-baseline` after fixing things.
   "baseline": "abap2ui5lint-baseline.json",
 
+  // The README badge. Every run rewrites this shields.io endpoint file with
+  // what the corpus currently is - "148 apps - UI5 1.71 - clean" - and
+  // check-abap2UI5 commits it onto the pull request branch, so the badge on
+  // main updates when the pull request that changed the corpus merges. It
+  // says something the workflow badge next to it cannot: a green workflow
+  // means "the job exited zero", which was also true while the linter found
+  // nothing checkable here at all (AGENTS.md 6).
+  "badge": ".github/badges/abap2ui5lint.json",
+
   // A render error carries no line and its message text is unstable, so it
   // cannot be baselined — naming the file is the only instrument. Two groups,
   // and they are NOT the same thing:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#f2f0f9c",
+        "@abap2ui5/linter": "github:abap2UI5/linter#46c655b",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#f2f0f9c7fffac10579c7801d18a13b42c545825a",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#46c655b4d6151067ccc5788171ecf8184936cad8",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#46c655b",
+        "@abap2ui5/linter": "github:abap2UI5/linter#5801349",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#46c655b4d6151067ccc5788171ecf8184936cad8",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#5801349c2500961ccd775d18019bdb938fa7d277",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#5801349",
+        "@abap2ui5/linter": "github:abap2UI5/linter#5cb02a7",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#5801349c2500961ccd775d18019bdb938fa7d277",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#5cb02a73db310fd4b3d252a0e888b69b63770bbb",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#5801349",
+    "@abap2ui5/linter": "github:abap2UI5/linter#5cb02a7",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#46c655b",
+    "@abap2ui5/linter": "github:abap2UI5/linter#5801349",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#f2f0f9c",
+    "@abap2ui5/linter": "github:abap2UI5/linter#46c655b",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {


### PR DESCRIPTION
Activates the abap2UI5-linter gate by upgrading the linter version, adding comprehensive run reporting, and introducing a README badge that reflects actual linter coverage.

## Summary

The abap2UI5-linter gate was previously ineffective because it found no checkable files (the linter looked for the view builder's former name). Now that the linter has been updated to recognize the current builder, the gate is effective and checks 148 app classes and 172 reconstructed views. This change makes the gate's results visible and trustworthy.

## Key Changes

- **Upgraded linter version** (`package.json`): pinned to commit `5cb02a7` (from `f2f0f9c`), which recognizes the current view builder and its attribute syntax
- **Enhanced CI workflow** (`.github/workflows/check-abap2UI5.yaml`):
  - Added `push` trigger on `main` branch to keep badge current
  - Changed permissions to `contents: write` to allow badge commits
  - Improved checkout to handle both pull requests and main branch pushes
  - Added job summary step that reports linter findings in markdown format
  - Added badge publication step that commits updated badge to pull request branches
- **Added linter badge** (`.github/badges/abap2ui5lint.json`): shields.io endpoint file showing "148 apps · 172 views · 2,176 controls · clean"
- **Configured badge output** (`abap2ui5lint.jsonc`): added `badge` setting to generate the endpoint file with run statistics
- **Updated documentation** (`AGENTS.md`): documented that the gate is now effective, explained the run summary reporting, and described the badge mechanism
- **Added README badge**: displays linter status with actual coverage numbers, updates when pull requests merge

## Implementation Details

The workflow now runs the linter twice: once with full rendering (the actual gate), then again with `--no-render --advisory` to generate the job summary without re-running the expensive render phase. The badge file is committed only on successful pull request runs (not on main or fork pushes), ensuring the badge on main always reflects what was actually checked when that code merged.

https://claude.ai/code/session_01QsFPwT1vkkN4LT7ybVdr7x