### PR TITLE
Badge: the reach grey on the left, the verdict coloured on the right

### DIFF
--- a/.github/badges/abap2ui5lint.json
+++ b/.github/badges/abap2ui5lint.json
@@ -1,10 +1,8 @@
 {
   "schemaVersion": 1,
-  "label": "abap2UI5-linter",
-  "message": "148 apps · 172 views · 2,176 controls · clean",
+  "label": "abap2UI5-linter 148 apps · 172 views · 2,176 controls",
+  "message": "clean",
   "color": "4c1",
-  "labelColor": "0a6ed1",
-  "namedLogo": "sap",
-  "logoColor": "white",
+  "labelColor": "555",
   "cacheSeconds": 3600
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,8 +682,9 @@ newline). **Run `abaplint` — 0 issues — before committing.**
   failure repeating itself — and now it says so instead of printing
   "Success! No findings detected."
 - **The README badge** (`.github/badges/abap2ui5lint.json`, a shields.io
-  endpoint file) carries the same statement, in the reach of the check:
-  *148 apps · 172 views · 2,176 controls · clean*. Every run rewrites it,
+  endpoint file) carries the same statement: the grey half is the reach —
+  *abap2UI5-linter 148 apps · 172 views · 2,176 controls* — and the green (or
+  red) half next to it is the verdict, *clean*. Every run rewrites it,
   `check-abap2UI5` commits it onto the pull request branch, and main picks it
   up when that pull request merges — so the numbers next to "clean" are what
   the last run actually checked. **A sample added or

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -24,9 +24,9 @@
   // Refresh it with `npx abap2ui5lint --update-baseline` after fixing things.
   "baseline": "abap2ui5lint-baseline.json",
 
-  // The README badge. Every run rewrites this shields.io endpoint file with
-  // how far the check reached - "148 apps - 172 views - 2,176 controls -
-  // clean", the same numbers the run summary prints - and
+  // The README badge. Every run rewrites this shields.io endpoint file: grey
+  // half how far the check reached ("148 apps - 172 views - 2,176 controls",
+  // the numbers the run summary prints), coloured half the verdict - and
   // check-abap2UI5 commits it onto the pull request branch, so the badge on
   // main updates when the pull request that changed the corpus merges. It
   // says something the workflow badge next to it cannot: a green workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#5cb02a7",
+        "@abap2ui5/linter": "github:abap2UI5/linter#e0a145c",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#5cb02a73db310fd4b3d252a0e888b69b63770bbb",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#e0a145c8806b85f15b4f32bdc734a15154b7737b",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#5cb02a7",
+    "@abap2ui5/linter": "github:abap2UI5/linter#e0a145c",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {


### PR DESCRIPTION
Follow-up to #755, which added the linter badge with everything in the
coloured half and an SAP logo in front of it.

## The change

```
abap2UI5-linter 148 apps · 172 views · 2,176 controls | clean
└──────────────────── grey (555) ─────────────────────┘ └green┘
```

The grey half stays factual — the linter's name and how far the check reached,
the same numbers the run summary opens with — and the coloured half carries
the verdict alone (`clean`, or `3 problems` / `7 errors` in yellow / red). No
logo. The colour is a word to see instead of a bar to read to the end.

- `package.json` / `package-lock.json` — linter re-pinned to
  abap2UI5/linter@`e0a145c` (abap2UI5/linter#26), which produces this shape
- `.github/badges/abap2ui5lint.json` — regenerated by a real run over the 148
  sample classes
- `abap2ui5lint.jsonc`, `AGENTS.md` — the comments describing the badge follow

Nothing about the gate itself changes: same rules, same baseline, same run
summary.

## Depends on

abap2UI5/linter#26 must merge first (or together with this). The pin points at
its commit, and with the previously pinned linter this repository's own CI
would regenerate the old badge format and commit it over the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsFPwT1vkkN4LT7ybVdr7x

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsFPwT1vkkN4LT7ybVdr7x)_