### PR TITLE
Split abap2UI5-linter badge into corpus and checks badges

### DIFF
--- a/.github/badges/abap2ui5.json
+++ b/.github/badges/abap2ui5.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "label": "abap2UI5",
+  "message": "148 apps · 172 views · 2,176 controls",
+  "color": "007ec6",
+  "labelColor": "555",
+  "cacheSeconds": 3600
+}

--- a/.github/badges/abap2ui5lint.json
+++ b/.github/badges/abap2ui5lint.json
@@ -1,8 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "abap2UI5-linter 148 apps · 172 views · 2,176 controls",
-  "message": "clean",
-  "color": "4c1",
-  "labelColor": "555",
-  "cacheSeconds": 3600
-}

--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "label": "check-abap2UI5",
+  "message": "83 rules passed",
+  "color": "4c1",
+  "labelColor": "555",
+  "cacheSeconds": 3600
+}

--- a/.github/workflows/check-abap2UI5.yaml
+++ b/.github/workflows/check-abap2UI5.yaml
@@ -17,7 +17,7 @@ name: check-abap2UI5
 # between "148 classes were checked" and "nothing was checkable" - a
 # distinction this repository has been on the wrong side of before
 # (AGENTS.md 6). It also goes into the job summary of the run, and into the
-# README badge below.
+# two README badges below.
 
 on:
   pull_request:
@@ -60,18 +60,19 @@ jobs:
       if: always()
       run: npx abap2ui5lint --no-render --advisory --no-progress --no-badge --format markdown >> "$GITHUB_STEP_SUMMARY"
 
-    # abap2ui5lint.jsonc points "badge" at .github/badges/abap2ui5lint.json,
-    # so the step above already rewrote it with what the corpus now is. The
-    # default branch is protected and github-actions[bot] can never be added
-    # to a bypass list, so the badge is committed onto the PULL REQUEST branch
-    # - the pull request that changes the corpus is what changes the badge,
-    # and main picks it up when that pull request merges. Same mechanism as
-    # publish-overview-apps, including the fallback for refs that cannot be
-    # pushed to: there the stale badge is reported, never silently accepted.
-    # only after a green gate: a red pull request cannot merge, so its badge
-    # would never reach main anyway - and a badge commit on top of a failing
-    # run reads as if something had been fixed
-    - name: Publish the badge
+    # abap2ui5lint.jsonc points "badge" at .github/badges/abap2ui5.json (what
+    # the corpus is) and .github/badges/check-abap2ui5.json (what this gate
+    # made of it), so the step above already rewrote both with what the corpus
+    # now is. The default branch is protected and github-actions[bot] can
+    # never be added to a bypass list, so they are committed onto the PULL
+    # REQUEST branch - the pull request that changes the corpus is what
+    # changes the badges, and main picks them up when that pull request
+    # merges. Same mechanism as publish-overview-apps, including the fallback
+    # for refs that cannot be pushed to: there the stale badge is reported,
+    # never silently accepted. Only after a green gate: a red pull request
+    # cannot merge, so its badges would never reach main anyway - and a badge
+    # commit on top of a failing run reads as if something had been fixed
+    - name: Publish the badges
       if: success()
       env:
         # only a same-repository pull request can be pushed to with
@@ -80,16 +81,16 @@ jobs:
                       && github.event.pull_request.head.repo.full_name == github.repository }}
       run: |
         if git diff --quiet -- .github/badges; then
-          echo "The linter badge is up to date."
+          echo "The linter badges are up to date."
           exit 0
         fi
         git diff -- .github/badges
         if [ "$PUSHABLE" != "true" ]; then
-          echo "::warning::The linter badge is out of date and this ref cannot be pushed to. Run 'npm run check:abap2ui5' and commit .github/badges/abap2ui5lint.json."
+          echo "::warning::The linter badges are out of date and this ref cannot be pushed to. Run 'npm run check:abap2ui5' and commit .github/badges/."
           exit 0
         fi
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
-        git commit -qm 'Refresh the abap2UI5-linter badge' -- .github/badges
+        git commit -qm 'Refresh the abap2UI5-linter badges' -- .github/badges
         git push
-        echo "Badge refreshed and pushed onto the pull request branch."
+        echo "Badges refreshed and pushed onto the pull request branch."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,15 +655,15 @@ newline). **Run `abaplint` — 0 issues — before committing.**
   | `abap2ui5` | defects living in the relationship between the ABAP class and the view it builds; silent at runtime, invisible to any UI5 tooling |
 
 - Configuration: `abap2ui5lint.jsonc` (UI5 floor `1.71`, distribution
-  `openui5`, `failOn: warning`, baseline, badge)
+  `openui5`, `failOn: warning`, baseline, badges)
 - Run: `npm run check:abap2ui5`
 - CI: `abap2UI5` — as opposed to `abap-standard` / `abap-cloud` /
   `abap-702`, which lint ABAP itself against three target releases
 - **The gate is effective**: 148 app classes, 172 reconstructed views, and
   the adoption-time debt frozen in `abap2ui5lint-baseline.json` (#753). It was
   not always: while the linter still looked for the view builder's former name
-  it found no checkable file at all, and a green `abap2UI5` badge then meant
-  "nothing was checkable", not "the apps are clean".
+  it found no checkable file at all, and a green `check-abap2UI5` badge then
+  meant "nothing was checkable", not "the apps are clean".
 - **That is why a run reports what it LOOKED at**, not only what it found.
   The gates log every file into a collapsed group while they run, and the run
   closes with a summary — classes, views reconstructed (**and how many
@@ -681,15 +681,17 @@ newline). **Run `abaplint` — 0 issues — before committing.**
   A `judged` line of zeroes, or `148 classes produced none`, is the earlier
   failure repeating itself — and now it says so instead of printing
   "Success! No findings detected."
-- **The README badge** (`.github/badges/abap2ui5lint.json`, a shields.io
-  endpoint file) carries the same statement: the grey half is the reach —
-  *abap2UI5-linter 148 apps · 172 views · 2,176 controls* — and the green (or
-  red) half next to it is the verdict, *clean*. Every run rewrites it,
-  `check-abap2UI5` commits it onto the pull request branch, and main picks it
-  up when that pull request merges — so the numbers next to "clean" are what
-  the last run actually checked. **A sample added or
-  removed changes this file**; commit it with the change (the workflow pushes
-  it if you forget, and reports it when it cannot).
+- **The two README badges** (`.github/badges/abap2ui5.json` and
+  `.github/badges/check-abap2ui5.json`, shields.io endpoint files) carry the
+  same statement, split along what they mean: *abap2UI5 | 148 apps · 172 views
+  · 2,176 controls* is what is here, blue, a fact; *check-abap2UI5 | 83 rules
+  passed* is what the gate made of it, green (or *3 problems*, *7 errors*,
+  red). A run that finds nothing checkable turns both grey and says so. Every
+  run rewrites them, `check-abap2UI5` commits them onto the pull request
+  branch, and main picks them up when that pull request merges — so the counts
+  are what the last run actually checked. **A sample added or removed changes
+  these files**; commit them with the change (the workflow pushes them if you
+  forget, and reports it when it cannot).
 
 ### abapGit file consistency
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![namespace](https://img.shields.io/badge/namespace-z2ui5__cl__smp-blue)](abaplint.jsonc)
 [![dependency](https://img.shields.io/badge/dependency-abap2UI5-blue)](https://github.com/abap2UI5/abap2UI5)
 <br>
-[![abap2UI5-linter](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fabap2ui5lint.json)](https://github.com/abap2UI5/linter)
+[![abap2UI5](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fabap2ui5.json)](#learn-abap2ui5)
+[![check-abap2UI5](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fcheck-abap2ui5.json)](https://github.com/abap2UI5/samples/actions/workflows/check-abap2UI5.yaml)
 <br>
 <br>
 [![abap-standard](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml)
 [![abap-cloud](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml)
 <br>
-[![check-abap2UI5](https://github.com/abap2UI5/samples/actions/workflows/check-abap2UI5.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/check-abap2UI5.yaml)
 [![check-rename](https://github.com/abap2UI5/samples/actions/workflows/check-rename.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/check-rename.yaml)
 <br>
 [![publish-702](https://github.com/abap2UI5/samples/actions/workflows/publish-702.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/publish-702.yaml)

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -24,15 +24,22 @@
   // Refresh it with `npx abap2ui5lint --update-baseline` after fixing things.
   "baseline": "abap2ui5lint-baseline.json",
 
-  // The README badge. Every run rewrites this shields.io endpoint file: grey
-  // half how far the check reached ("148 apps - 172 views - 2,176 controls",
-  // the numbers the run summary prints), coloured half the verdict - and
-  // check-abap2UI5 commits it onto the pull request branch, so the badge on
-  // main updates when the pull request that changed the corpus merges. It
-  // says something the workflow badge next to it cannot: a green workflow
+  // The two README badges. Every run rewrites these shields.io endpoint
+  // files, and they are two because they say two different things:
+  //
+  //   abap2UI5       | 148 apps - 172 views - 2,176 controls   what is here
+  //   check-abap2UI5 | 83 rules passed                         what CI made of it
+  //
+  // check-abap2UI5 commits them onto the pull request branch, so the badges
+  // on main update when the pull request that changed the corpus merges.
+  // Together they say something a workflow badge cannot: a green workflow
   // means "the job exited zero", which was also true while the linter found
-  // nothing checkable here at all (AGENTS.md 6).
-  "badge": ".github/badges/abap2ui5lint.json",
+  // nothing checkable here at all (AGENTS.md 6) - and that run would now
+  // print "nothing checkable", grey, on both.
+  "badge": [
+    { "kind": "corpus", "file": ".github/badges/abap2ui5.json" },
+    { "kind": "checks", "file": ".github/badges/check-abap2ui5.json" }
+  ],
 
   // A render error carries no line and its message text is unstable, so it
   // cannot be baselined — naming the file is the only instrument. Two groups,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#e0a145c",
+        "@abap2ui5/linter": "github:abap2UI5/linter#146974f",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,7 +18,7 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#e0a145c8806b85f15b4f32bdc734a15154b7737b",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#146974f108838b60f7cc104cef91f1e666854c2f",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#e0a145c",
+    "@abap2ui5/linter": "github:abap2UI5/linter#146974f",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {


### PR DESCRIPTION
## Summary
Refactors the single abap2UI5-linter badge into two separate badges that communicate distinct information: what corpus exists (`abap2UI5`) and what the gate made of it (`check-abap2UI5`).

## Changes
- **Badge split**: Replaced `.github/badges/abap2ui5lint.json` with two new badges:
  - `abap2ui5.json`: Shows corpus facts (148 apps · 172 views · 2,176 controls), blue
  - `check-abap2ui5.json`: Shows gate verdict (83 rules passed), green/red
  
- **Configuration**: Updated `abap2ui5lint.jsonc` to define both badges with `kind` field distinguishing corpus from checks

- **Workflow**: Updated `.github/workflows/check-abap2UI5.yaml` to:
  - Rewrite both badge files on each run
  - Commit and push both badges together
  - Updated all messaging from singular "badge" to plural "badges"

- **Documentation**: 
  - Updated `AGENTS.md` to explain the two-badge approach and why it matters (distinguishes "nothing checkable" from "clean")
  - Updated `README.md` to display both badges with appropriate links

- **Dependencies**: Updated `@abap2ui5/linter` to commit `146974f` (supports the new badge configuration format)

## Rationale
A single badge showing "clean" could mask the case where the linter found nothing checkable at all—both would appear green. Two badges clarify: the corpus badge is always blue (a fact), while the checks badge is green/red (a verdict). When nothing is checkable, both turn grey, making the distinction explicit.

https://claude.ai/code/session_014VWtytAbCHJemSFJtUqYhm