### PR TITLE
Clarify data binding behavior in documentation and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -847,7 +847,7 @@ Use a `CASE` statement (inside an `ELSEIF client->check_on_event( )` block) only
 | Nested views | `nest_view_display/destroy`, `nest2_view_*` | Embedded sub-views |
 | Popups | `popup_display`, `popup_destroy` | Modal dialogs |
 | Popovers | `popover_display`, `popover_destroy` | Context popovers |
-| Binding | `_bind(val)` | Data binding, values travel in both directions (`_bind_edit` is an obsolete alias) |
+| Binding | `_bind(val)` | Data binding — the value is written back before the event handler runs (`_bind_edit` is an obsolete alias) |
 | Events | `_event(val)`, `follow_up_action(val)`, `check_on_event(val)` | Event registration and checking (`_event_client` is an obsolete alias — `follow_up_action` covers both roles: returned into a view attribute it binds the frontend action to a control, called on `client` it queues the action after the current response renders) |
 | Navigation | `nav_app_call(app)`, `nav_app_leave()`, `get_app_prev()` | App stack navigation |
 | Lifecycle | `check_on_init()`, `check_on_navigated()`, `check_app_prev_stack()` | State checks |
@@ -1028,9 +1028,10 @@ at the call.
 
 **Call it "binding", never "one-way"/"two-way" binding** — in sample titles,
 message strips, comments and `@keywords` alike. With only `_bind( )` left, and
-values always travelling in both directions, the qualifier distinguishes
-nothing and makes readers look for a second mode that does not exist. Say
-"bound attribute", "the value is written back before the event handler runs".
+the value always written back before the event handler runs, the qualifier
+distinguishes nothing and makes readers look for a second mode that does not
+exist. Say "bound attribute", "the value is written back before the event
+handler runs".
 "One-way" is correct only for a real UI5 one-way model that is not `_bind( )`
 — the `device>` JSONModel in `z2ui5_cl_smp_app_445`, for example.
 

--- a/src/01/z2ui5_cl_smp_app_494.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_494.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_smp_app_494 IMPLEMENTATION.
 
       page->tag( `MessageStrip`
           )->a( n = `text`     v = `client->_bind( name ) connects the public attribute NAME with the input ` &&
-                     `below - in both directions. Type a name and leave the field: the text ` &&
+                     `below. Type a name and leave the field: the text ` &&
                      `next to it changes without any ABAP code, because both are bound to the ` &&
                      `same attribute. Press Greet and the backend reads NAME - already filled ` &&
                      `in, no event argument needed - and writes GREETING back into the view.`


### PR DESCRIPTION
## Summary
Updated documentation and code examples to more precisely describe how data binding works in z2ui5, emphasizing that bound values are written back before the event handler runs rather than using the ambiguous "both directions" phrasing.

## Changes
- **AGENTS.md**: 
  - Refined the binding definition in the feature table to clarify that "the value is written back before the event handler runs" instead of "values travel in both directions"
  - Expanded the naming conventions section to explain why "binding" should be used instead of "one-way"/"two-way" terminology, with clearer language about when values are written back and why the old phrasing was misleading

- **z2ui5_cl_smp_app_494.clas.abap**:
  - Updated the MessageStrip example text to remove "in both directions" and replace it with a more accurate description of the binding behavior

## Details
The changes align the documentation with the actual implementation semantics: `_bind()` ensures that bound attribute values are synchronized back to the model before event handlers execute, which is more precise than saying values travel "in both directions." This prevents confusion about whether there's a separate "one-way" binding mode (there isn't) and makes the behavior clearer to developers.

https://claude.ai/code/session_01FiwJTt5DgMF6XGLVLyrn8S