### PR TITLE
Refactor popover_display chain for clarity and add linting rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -989,6 +989,31 @@ The hierarchy is `mvc:View` → `Shell` → `Page` → `form:SimpleForm` →
 `form:content` → leaves. `Label`, `Input` and `Button` are siblings inside
 `content`, so they are added with `tag( )` and stay at the same indent.
 
+Three rules keep that picture true, and the port of the corpus onto this
+builder (#752) broke all three in a handful of classes:
+
+- **The indent states the depth.** One level per container, the same step
+  throughout the file — a chain that steps by 2 and then by 4 and then stops
+  moving is no longer describing the tree, it is decorating it.
+- **Never unwind with a run of `end( )` to start a sibling.** A line ending in
+  `` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar` `` changes four
+  levels where nobody can see them, and every line after it starts in a column
+  that means nothing. When you need a node again, **keep it in a variable** —
+  `DATA(page)`, `DATA(cont)`, `DATA(lo_columns)` in the sample above — and
+  start a new statement per subtree. That is what the corpus does, and it is
+  what lets a statement indent monotonically.
+- **A control may share its line with its own attributes**
+  (`` )->tag( `Label` )->a( n = `text` … ``) **and with the container it opens**
+  (`` view->ele( `Shell` )->ele( `Page` ``) — but a line carrying a whole
+  subtree hides the tree.
+
+The abap2UI5-linter judges this (`chain-indentation`, `chain-element-per-line`),
+but read `abap2ui5lint.jsonc` before relying on it: `chain-element-per-line` is
+still a hint with 339 findings in the baseline, so it fails nothing today. The
+layout is on the author and the reviewer. `z2ui5_cl_smp_app_052` is the worked
+example — its `popover_display` was the broken shape above and is now the
+sound one.
+
 #### Namespaces
 
 Every namespace prefix a view uses must be declared on the view element —

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -74,6 +74,24 @@
   //     helper, so there is nothing to render. A gate can say nothing about
   //     them either way.
   "rules": {
+    // The chain's layout is the only picture of the view's tree there is, and
+    // nothing else formats it: abaplint's `indentation` is off for app code on
+    // purpose, so a mangled chain is lint-green everywhere else. Both layout
+    // rules ship as `hint`, which `failOn: warning` does not even print - the
+    // port to z2ui5_cl_ui5_view_builder (#752) therefore left classes like
+    // z2ui5_cl_smp_app_052 with an indent that steps by 2, then by 4, then
+    // stops moving, and every gate stayed green.
+    //
+    // `chain-indentation` is raised here because it costs one baseline entry:
+    // it judges only that a chain keeps its OWN rhythm (a sibling in a
+    // different column than its siblings, a call written left of the element
+    // it belongs to), never the step size, so the corpus already passes it.
+    //
+    // `chain-element-per-line` is NOT raised, and that is deliberate: it flags
+    // 339 findings here, and one of them is the idiom AGENTS.md section 10
+    // documents - `view->ele( `Shell` )->ele( `Page`` on one line. Raising it
+    // means changing that convention first.
+    "chain-indentation": { "severity": "warning" },
     "render-error": {
       "exclude": [
         // (a) not served by the harness

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -58,6 +58,15 @@
     "parser_error": true,
     "superclass_final": true,
     "unknown_types": true,
+    // The ABAP editor strips a trailing blank when it saves, so a line that
+    // ends in one comes back changed on the next pull - for everyone. Nothing
+    // here caught that: the port of the corpus onto z2ui5_cl_ui5_view_builder
+    // (#752) left a trailing blank on seven lines in seven app classes, all
+    // four workflows stayed green, and b7edbc6 "fix abaplint diffs" had to be
+    // found and pushed by hand. The tree is clean as of that commit, so the
+    // rule costs nothing and closes the hole. abap2UI5 has carried it for
+    // src/01 and src/02 all along.
+    "whitespace_end": true,
     "xml_consistency": true
   }
 }

--- a/src/01/z2ui5_cl_smp_app_052.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_052.clas.abap
@@ -41,23 +41,30 @@ CLASS z2ui5_cl_smp_app_052 IMPLEMENTATION.
         )->a( n = `xmlns:f`    v = `sap.f`
         )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    lo_popover->ele( `Popover`
+    DATA(popover) = lo_popover->ele( `Popover`
         )->a( n = `title`        v = |abap2UI5 - Popover - { mv_product }|
         )->a( n = `placement`    v = `Right`
-        )->a( n = `contentWidth` v = `20rem` )->ele( n = `SimpleForm` ns = `form`
-          )->a( n = `layout`   v = `ColumnLayout`
-          )->a( n = `editable` b = abap_false )->ele( n = `content` ns = `form` )->tag( `Label`
-              )->a( n = `text` v = `Product` )->tag( `Text`
-              )->a( n = `text` v = mv_product )->tag( `Label`
-              )->a( n = `text` v = `info2` )->tag( `Text`
-              )->a( n = `text` v = `this is a text` )->tag( `Label`
-              )->a( n = `text` v = `info3` )->tag( `Text`
-              )->a( n = `text` v = `this is a text` )->tag( `Text`
-              )->a( n = `text` v = `this is a text` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar`
-              )->tag( `ToolbarSpacer` )->tag( `Button`
-                )->a( n = `press` v = client->_event( `BUTTON_DETAILS` )
-                )->a( n = `text`  v = `details`
-                )->a( n = `type`  v = `Emphasized` ).
+        )->a( n = `contentWidth` v = `20rem` ).
+
+    popover->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`   v = `ColumnLayout`
+        )->a( n = `editable` b = abap_false
+        )->ele( n = `content` ns = `form`
+            )->tag( `Label` )->a( n = `text` v = `Product`
+            )->tag( `Text`  )->a( n = `text` v = mv_product
+            )->tag( `Label` )->a( n = `text` v = `info2`
+            )->tag( `Text`  )->a( n = `text` v = `this is a text`
+            )->tag( `Label` )->a( n = `text` v = `info3`
+            )->tag( `Text`  )->a( n = `text` v = `this is a text`
+            )->tag( `Text`  )->a( n = `text` v = `this is a text` ).
+
+    popover->ele( `footer` )->ele( `OverflowToolbar`
+        )->tag( `ToolbarSpacer`
+        )->tag( `Button`
+            )->a( n = `press` v = client->_event( `BUTTON_DETAILS` )
+            )->a( n = `text`  v = `details`
+            )->a( n = `type`  v = `Emphasized` ).
+
     client->popover_display( xml   = lo_popover->stringify( )
                              by_id = id ).
 


### PR DESCRIPTION
## Summary

This PR refactors the `popover_display` method in `z2ui5_cl_smp_app_052` to follow the chain-building conventions documented in AGENTS.md, and adds linting rules to enforce these patterns across the codebase.

## Key Changes

- **Refactored popover chain structure**: Split the deeply nested method chain into separate statements using intermediate variables (`DATA(popover)`), improving readability and making the XML tree structure explicit through indentation. Each subtree now starts on its own line with consistent indentation that reflects the hierarchy.

- **Improved chain formatting**: 
  - Removed long runs of `end()` calls that obscured the tree structure
  - Aligned attributes and elements to show their relationship clearly
  - Ensured each statement's indentation monotonically reflects nesting depth

- **Added `chain-indentation` linting rule**: Enabled in `abap2ui5lint.jsonc` as a warning to catch chains that break their own rhythm (siblings at different indentation levels, calls misaligned with their elements).

- **Added `whitespace_end` linting rule**: Enabled in `abaplint.jsonc` to catch trailing whitespace that the ABAP editor strips on save, preventing spurious diffs in future commits.

- **Updated AGENTS.md**: Documented the three rules that keep chain layouts truthful:
  1. Indent states depth — one level per container with consistent step size
  2. Never unwind with `end()` runs to start siblings — use variables instead
  3. Controls may share lines with their attributes or opening containers, but not whole subtrees

## Implementation Details

The refactored `popover_display` now demonstrates the documented pattern: intermediate variables (`popover`) are assigned once, then reused in separate statements for each major subtree (SimpleForm content, footer toolbar). This makes the XML hierarchy immediately visible from indentation alone, matching the corpus conventions described in AGENTS.md section 10.

https://claude.ai/code/session_01947Lexmmz1RTWAWrERCnpp