### PR TITLE
Take the linter from npm, and declare the render runtime it no longer brings

### DIFF
--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "83 rules passed",
+  "message": "84 rules passed",
   "color": "4c1",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/.github/workflows/check-abap2UI5.yaml
+++ b/.github/workflows/check-abap2UI5.yaml
@@ -6,8 +6,18 @@ name: check-abap2UI5
 # UI5 version and deprecation floor, the data and usability of the result,
 # and the abap2ui5 semantics - the defects that live in the relationship
 # between the ABAP class and the view it builds, which no UI5 tooling sees.
-# Configuration lives in abap2ui5lint.jsonc; the linter is pinned as a
-# devDependency so CI and `npm run check:abap2ui5` run the same version.
+# Configuration lives in abap2ui5lint.jsonc; the linter is a devDependency
+# resolved through package-lock.json, so CI and `npm run check:abap2ui5` run
+# the same version.
+#
+# @abap2ui5/render-runtime is the SECOND devDependency, and the render gate
+# below is the only reason for it: it carries the @openui5 source packages and
+# playwright the gate serves. The linter names it as an OPTIONAL PEER, which
+# is the one dependency kind npm does not install on its own - so it has to be
+# declared here, or `npx abap2ui5lint` reports the runtime missing and the 172
+# documents stop being rendered. It used to arrive by itself, as an optional
+# DEPENDENCY of the linter, which npm does install by default; splitting it
+# out is what keeps a plain `npx @abap2ui5/linter` a small download.
 #
 # The run reports what it LOOKED at, not only what it found: the gates log
 # every file into a collapsed group while they run, and the job closes with

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#146974f",
+        "@abap2ui5/linter": "^0.1.0",
+        "@abap2ui5/render-runtime": "^0.1.0",
         "@abaplint/cli": "^2.119.66"
       },
       "engines": {
@@ -18,17 +19,35 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#146974f108838b60f7cc104cef91f1e666854c2f",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.1.0.tgz",
+      "integrity": "sha512-/bz0tZgmNNWLMFYNtu6/hTdMYZbo5195tHWObYKaFHetz4fLmW7ftW2IsMzOGVcLcqByxIiGAJEY6hAhLLkpfA==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "render-runtime"
+      ],
       "bin": {
-        "abap2ui5-linter": "cli.mjs",
         "abap2ui5lint": "cli.mjs"
       },
       "engines": {
         "node": ">=22"
       },
-      "optionalDependencies": {
+      "peerDependencies": {
+        "@abap2ui5/render-runtime": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@abap2ui5/render-runtime": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@abap2ui5/render-runtime": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/render-runtime/-/render-runtime-0.1.0.tgz",
+      "integrity": "sha512-vG+faxfgmSuqu898L8ruzh/2TE9uTQMKIP0A0DzKAY8mEtr7gXMISk4cAYx5nEveN/pmmvdL6xYTLis+ri/0BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@openui5/sap.f": "1.151.0",
         "@openui5/sap.m": "1.151.0",
         "@openui5/sap.tnt": "1.151.0",
@@ -41,6 +60,9 @@
         "@openui5/sap.uxap": "1.151.0",
         "@openui5/themelib_sap_horizon": "1.151.0",
         "playwright": "^1.61.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@abaplint/cli": {
@@ -65,7 +87,6 @@
       "integrity": "sha512-nSNAM+/Gqniqk53rakq0heM2dJ0I14ert6s3sA93DjHBZpQOcaAchfY5idzI2OSU3G7OHtbOZKCrfwSZ2eSVZQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.m": "1.151.0",
         "@openui5/sap.ui.core": "1.151.0",
@@ -78,7 +99,6 @@
       "integrity": "sha512-CzGB4/ckoCHrlpSvsah2seGYvb/nOqoWqYtKHI0TncGaQ/bKq0omqsa3Z0rGApqXWv/wWS6O1EYBgDlv5NWFPQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.ui.core": "1.151.0",
         "@openui5/sap.ui.layout": "1.151.0",
@@ -91,7 +111,6 @@
       "integrity": "sha512-BEV7fShRmvq+mroDZASzT+jYyWPxNQI1k0y1ZXG/fYUhQ1pJYSphm1ZL0b+QCcc13o+m5jGQyy2WNJdiFJPnLw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.m": "1.151.0",
         "@openui5/sap.ui.core": "1.151.0"
@@ -103,7 +122,6 @@
       "integrity": "sha512-rQ0Hdv+0HJLHrPjXMV1MC13QTa7z0OsG9nwxY5Rdk4GuFIfd0QM1IcQISFg77Jl+ng+SIJS09frIjz4oO/a8/g==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.ui.core": "1.151.0"
       }
@@ -113,8 +131,7 @@
       "resolved": "https://registry.npmjs.org/@openui5/sap.ui.core/-/sap.ui.core-1.151.0.tgz",
       "integrity": "sha512-0cIWVWZ4mmsAl+b+HKiK50mY0Pq4mBE10wC79xIwvK904f7yTUQW+TIqAmYIsXm0TrcxCqGY7DvfHnrVJTao5Q==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/@openui5/sap.ui.integration": {
       "version": "1.151.0",
@@ -122,7 +139,6 @@
       "integrity": "sha512-dOUbakjdziJRIE+jy2S363A5W+1BqoPWJwbJ9IQDHq6VCoNDTYCaol+YXN2mpUH5IZfYCNMaW8OpBdDaZ7kBng==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.f": "1.151.0",
         "@openui5/sap.m": "1.151.0",
@@ -137,7 +153,6 @@
       "integrity": "sha512-TNhwtKkZLDcSfhxa5p6dpw7NvJ0qb9K70lq0fa15ahTi/RQKE3AAH4lz8Y40UwtJwtRGZN6TPz/hhBrfCvqC0A==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.ui.core": "1.151.0"
       }
@@ -148,7 +163,6 @@
       "integrity": "sha512-TmSLiL/FclgO1k0cjMbBn1zYW1D4eE1Nw3D0gcCeWBX+Ph080TWaPkULBAyO+ZLrsFD/YPeDIqHru92JJbOdGA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.ui.core": "1.151.0",
         "@openui5/sap.ui.unified": "1.151.0"
@@ -160,7 +174,6 @@
       "integrity": "sha512-GPnsaXfLwXfgBt0pT1WvbXXZL5xwCz2D2BcFbupHn51abz9FGZsiroASnbZLuP3XFoxXGBJBbNLAbAoWOfX+bQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.ui.core": "1.151.0"
       }
@@ -171,7 +184,6 @@
       "integrity": "sha512-VqdvIaSbGX3Ex7hI3GuTrH33OmWiBhg8/HECNTVSmsVQTwesRYR6lPjZANzKmwPd5k1tL0JanXgSmgt7Akn2yA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@openui5/sap.f": "1.151.0",
         "@openui5/sap.m": "1.151.0",
@@ -184,8 +196,7 @@
       "resolved": "https://registry.npmjs.org/@openui5/themelib_sap_horizon/-/themelib_sap_horizon-1.151.0.tgz",
       "integrity": "sha512-kyNiL/WlEQV1WrYneI8KZBpPmHzwpaPVLn0kqOS61XUgWz0z97ESmarAT3JuX7gzNAx4vxEaV5bXSYZ1VDxWng==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -208,7 +219,6 @@
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "playwright-core": "1.62.1"
       },
@@ -228,7 +238,6 @@
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#146974f",
+    "@abap2ui5/linter": "^0.1.0",
+    "@abap2ui5/render-runtime": "^0.1.0",
     "@abaplint/cli": "^2.119.66"
   },
   "engines": {


### PR DESCRIPTION
`@abap2ui5/linter` 0.1.0 is on the registry, and the pinned `146974f` is an ancestor of the commit it was published from — so this is a forward move. `npm ci` now resolves a tarball with an integrity hash instead of cloning a branch commit that nothing stops from being force-pushed away.

## The part that would have gone wrong silently

`@abap2ui5/render-runtime` is added in the same change, and it is not optional here.

The release that put the linter on npm also moved the UI5 runtime out of it. `@openui5/*` and `playwright` used to be **`optionalDependencies` of the linter, which npm installs by default** — this repository never declared them and got them anyway. They are now an **optional peer**, the one dependency kind npm leaves alone.

So a bump without this line would have left `npx abap2ui5lint` reporting the runtime missing and the render gate quiet over all **172 documents**, and the job would have stayed green. That is the failure mode `AGENTS.md` §6 already has a scar from: a green `check-abap2UI5` badge that meant "nothing was checkable", not "the apps are clean".

The split itself is the right call — it is what keeps a plain `npx @abap2ui5/linter` from being a ~123 MB download before it lints anything. A repository that wants the render gate now asks for it, and the workflow comment says so, so the next person does not have to rediscover it.

## Verification

```
sources    148 app classes
views      172 documents reconstructed, nested 11 deep, 7 classes produced none
judged     2,176 controls of 106 types, 548 bindings, 69 icons, 4,164 attributes
gates      properties 148 files, render 172 documents
abap2ui5-linter: 148 files, 0 failing, 0 skipped
```

The rules badge moves 83 → 84 with the release; the corpus badge is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATRwcRZvAxCfRUmxXsqpAu)_