### PR TITLE
Refuse a tile nobody can find

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -513,7 +513,7 @@ One row per app; `group`, `header`, `sub` and `app` are always present,
 | `group`  | **Exactly** the CTEXT of the subpackage the app physically lives in. Becomes the H3 section title (rendered once, when the group changes). |
 | `header` | Link text shown to the user. **Derived from the class short text** (see below). |
 | `sub`    | Short description shown next to the link. **Derived from the class short text** (see below). May be empty (`` `` ``) → then only the link is rendered. |
-| `keywords` | **Never rendered — search only.** Extra terms so a sample is found by words that do not fit into the 60 characters of its DESCRIPT (see below). |
+| `keywords` | **Never rendered — search only.** Extra terms so a sample is found by words that do not fit into the 60 characters of its DESCRIPT (see below). **Required on every tile** — `npm run launchpad` refuses an area's overview app if one of its tiles has no `@keywords` line. Three readers depend on them and all three fail the same silent way (the sample stays listed, stays correct, and never comes up): the overview app's search box, `Ctrl+F` on SAMPLES.md, and an agent asking whether a sample for X exists. ZZZ helpers are exempt — a helper is reached BY another sample, never looked up. |
 | `path`   | The class's folder relative to the repository root (`src/01`). Generated, because the class name does **not** encode the folder — `source_url( )` builds the GitHub link of the sample from it. |
 | `app`    | The app's class name in **lowercase** (folder-independent). Drives navigation. |
 

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -257,12 +257,12 @@ is absent there.
 
 | Sample | Class |
 |---|---|
-| **Navigation** — app state | [`Z2UI5_CL_SMP_APP_321`](src/00/97/z2ui5_cl_smp_app_321.clas.abap) |
-| **Navigation** — app state share | [`Z2UI5_CL_SMP_APP_323`](src/00/97/z2ui5_cl_smp_app_323.clas.abap) |
-| **Navigation** — push state | [`Z2UI5_CL_SMP_APP_322`](src/00/97/z2ui5_cl_smp_app_322.clas.abap) |
-| **Navigation** — Routing mode fresh | [`Z2UI5_CL_SMP_APP_468`](src/00/97/z2ui5_cl_smp_app_468.clas.abap) |
-| **Navigation** — Routing mode keep | [`Z2UI5_CL_SMP_APP_480`](src/00/97/z2ui5_cl_smp_app_480.clas.abap) |
-| **Popup** — change a popup control from the backend | [`Z2UI5_CL_SMP_APP_141`](src/00/97/z2ui5_cl_smp_app_141.clas.abap) |
+| **Navigation** — app state<br><sub>app state url bookmark restore set_app_state_active reload deep link</sub> | [`Z2UI5_CL_SMP_APP_321`](src/00/97/z2ui5_cl_smp_app_321.clas.abap) |
+| **Navigation** — app state share<br><sub>app state share clipboard copy link colleague send url</sub> | [`Z2UI5_CL_SMP_APP_323`](src/00/97/z2ui5_cl_smp_app_323.clas.abap) |
+| **Navigation** — push state<br><sub>push state browser history back button hash url set_push_state</sub> | [`Z2UI5_CL_SMP_APP_322`](src/00/97/z2ui5_cl_smp_app_322.clas.abap) |
+| **Navigation** — Routing mode fresh<br><sub>routing mode fresh navigation restart new instance nav_app_call</sub> | [`Z2UI5_CL_SMP_APP_468`](src/00/97/z2ui5_cl_smp_app_468.clas.abap) |
+| **Navigation** — Routing mode keep<br><sub>routing mode keep navigation state preserved back nav_app_call</sub> | [`Z2UI5_CL_SMP_APP_480`](src/00/97/z2ui5_cl_smp_app_480.clas.abap) |
+| **Popup** — change a popup control from the backend<br><sub>popup dialog change control backend control_by_id update running</sub> | [`Z2UI5_CL_SMP_APP_141`](src/00/97/z2ui5_cl_smp_app_141.clas.abap) |
 
 ### testing — `src/00/98`
 

--- a/scripts/generate-launchpad.js
+++ b/scripts/generate-launchpad.js
@@ -116,6 +116,31 @@ function rewrite(file, list) {
   fs.writeFileSync(file, text);
 }
 
+/* A TILE without `@keywords` is a tile nobody can find.
+ *
+ * DESCRIPT caps the short text at 60 characters, so it carries the name of the
+ * thing and little else; `@keywords` is where the words a newcomer actually
+ * types go ("f4 search help suggestion input"). Three readers use them - the
+ * overview app's search box, `Ctrl+F` on SAMPLES.md, and an agent asking
+ * whether a sample for X exists - and all three degrade the same silent way:
+ * the sample is still listed, still correct, and simply never comes up.
+ *
+ * Scoped to the areas that HAVE an overview app, because that is what a tile
+ * is. The ZZZ helpers are already out (scanSamples flags them): a helper is
+ * reached BY another sample, never looked up, so search terms for it would be
+ * words nobody will type. */
+for (const [area, list] of Object.entries(tiles)) {
+  if (!TARGETS[area]) continue;
+  const unsearchable = list.filter((t) => !t.keywords);
+  if (unsearchable.length) {
+    console.error(`${unsearchable.length} tile(s) in src/${area} carry no \` @keywords\` line, so nothing can find them:`);
+    for (const t of unsearchable) console.error(`  ${t.app}  (${t.header})`);
+    console.error('\nAdd it as the FIRST line of the class (AGENTS.md section 4, tile schema):');
+    console.error('  " @keywords <words a newcomer would type, lowercase, space separated>');
+    process.exit(1);
+  }
+}
+
 let total = 0;
 for (const [area, list] of Object.entries(tiles)) {
   const file = TARGETS[area];

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -1,3 +1,4 @@
+" @keywords popup dialog change control backend control_by_id update running
 CLASS z2ui5_cl_smp_app_141 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_321.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_321.clas.abap
@@ -1,3 +1,4 @@
+" @keywords app state url bookmark restore set_app_state_active reload deep link
 CLASS z2ui5_cl_smp_app_321 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -1,3 +1,4 @@
+" @keywords push state browser history back button hash url set_push_state
 CLASS z2ui5_cl_smp_app_322 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_323.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_323.clas.abap
@@ -1,3 +1,4 @@
+" @keywords app state share clipboard copy link colleague send url
 CLASS z2ui5_cl_smp_app_323 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_468.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_468.clas.abap
@@ -1,3 +1,4 @@
+" @keywords routing mode fresh navigation restart new instance nav_app_call
 "! Hash-based app routing (UI5 Router style), mode FRESH:
 "! follow_up_action( cs_event-set_nav_routing ) with mode FRESH makes the URL
 "! mirror the running app by CLASS only ('#/app/[CLASS]'). Browser Back/Forward - and a

--- a/src/00/97/z2ui5_cl_smp_app_480.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_480.clas.abap
@@ -1,3 +1,4 @@
+" @keywords routing mode keep navigation state preserved back nav_app_call
 "! Hash-based app routing (UI5 Router style), mode KEEP:
 "! follow_up_action( cs_event-set_nav_routing ) with mode KEEP makes the URL
 "! carry the app-state draft as well ('#/app/[CLASS]/[DRAFT]'), so Back/Forward


### PR DESCRIPTION
`@keywords` is where the words a newcomer actually types go — `DESCRIPT` caps the short text at 60 characters, so it carries the name of the thing and little else.

Three readers depend on that line, and all three fail the same silent way when it is missing — the sample stays listed, stays correct, and simply never comes up:

- the overview app's search box
- `Ctrl+F` on `SAMPLES.md`
- an agent asking whether a sample for X exists

The third one is why this is being nailed down now: [abap2UI5/ai-mcp](https://github.com/abap2UI5/ai-mcp) is getting an `examples` tool that queries this catalogue, and a query is only as good as the data under it.

## What changes

`npm run launchpad` now refuses to write an overview app when one of its tiles has no `@keywords`. **All 97 already had one**, so this locks in a true state rather than fixing a broken one — the drift it stops is the *next* sample.

Scoped to the areas that have an overview app, because that is what a tile is. ZZZ helpers are already out (`scanSamples` flags them): a helper is reached *by* another sample, never looked up, so search terms for it would be words nobody will type.

`src/00/97`'s six experimental samples are catalogued in `SAMPLES.md` but are not tiles anywhere, so the gate does not reach them — they had no keywords and now do. They are real patterns somebody looks for: app state, push state, sharing a state link, the two routing modes, changing a popup control from the backend.

`src/00/98` is deliberately left alone. Those are test apps that exercise the framework from outside, and inventing "words a newcomer would type" for them would be manufacturing search terms for an audience of one.

## Verification

- `npm run launchpad` → green, 97 tiles, no diff in the generated catalog
- negative test: removing a `@keywords` line fails the gate and names the class
- `npx abaplint` → 0 issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_