### PR TITLE
Point a sample back at the chapter that explains it

### DIFF
--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "85 rules passed",
+  "message": "84 rules passed",
   "color": "4c1",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "84 rules passed",
+  "message": "85 rules passed",
   "color": "4c1",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,6 +463,26 @@ lists what that branch actually ships.
 the overview app, and `publish-overview-apps` checks and pushes both together
 (§4).
 
+**It has readers outside this repository, and they parse the ROWS.** Two of
+them today:
+
+| | |
+|---|---|
+| [ai-mcp](https://github.com/abap2UI5/ai-mcp) `lib/examples.mjs` | the `examples` MCP tool — an agent asking "has somebody already built X" |
+| [docs](https://github.com/abap2UI5/docs) `scripts/link-samples.mjs` | the *Working Samples* block under a cookbook page |
+
+Both read this file live rather than a generated index, so what they see is
+always what it says — and both match a row with a regex. **Changing the shape
+of a row breaks them silently.** Adding the `@docs` line as a second
+`<br><sub>` block did exactly that: a parser expecting one small-type block
+matched no rows at all, and the `examples` tool would have answered "no sample
+for that" to every query — no error, no log, just an agent taking it at face
+value and writing the app from scratch.
+
+So a change to `row( )` in `generate-samples-md.js` is a change to their input.
+Grep both repositories for the row regex before merging one, and give them a
+fixture with the new shape.
+
 ---
 
 ## 4. The overview is ALWAYS (re)generated — schema & rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,20 +438,22 @@ the names.
 
 [`SAMPLES.md`](SAMPLES.md) answers it. Every app, its description, its
 `@keywords` (the app keeps them for its search box; on a page the reader *is*
-the search box, so they are rendered) and a link to the source. Written by
+the search box, so they are rendered), the `@docs` chapter that explains what
+it demonstrates, and a link to the source. Written by
 `scripts/generate-samples-md.js` from the **same scan** as the overview app —
 `scripts/lib/scan-samples.js`, which is the single place that knows what counts
 as a sample, where its title comes from and which classes are hidden helpers.
 Two copies of that would drift silently: the app and the page would simply
 disagree about what this repository contains, and nothing would fail.
 
-Three things it shows that the app does not, on purpose:
+Four things it shows that the app does not, on purpose:
 
 | | Why |
 |---|---|
 | the `src/00` packages | they have no overview app (§3); listing them nowhere is how 49 apps became invisible |
 | the `ZZZ` helper apps | they must not get a tile — but a catalogue claiming to account for the tree has to say they exist |
 | the `@keywords` | never rendered in the app (§4); here they are what `Ctrl+F` finds |
+| the `@docs` link | the chapter that explains the pattern the sample demonstrates (§4) — the app has no room for it, and a page does |
 
 The `702` branch carries its own: `npm run downport` strips `src/00/97` and
 `src/00/98` and regenerates the file afterwards, so the copy on that branch
@@ -533,6 +535,29 @@ text cannot hold: **synonyms** (`f4` for value help, `alv` for the grid table),
 and the **abap2UI5 API** it demonstrates (`nav_app_call`, `binding_call`,
 `control_by_id`). Four to eight terms, no backticks. The line is optional — a
 sample without one is simply found by its header, sub and class name.
+
+**`@docs` is the way back to the documentation**, a second optional comment
+line directly under `@keywords`, holding one or more full URLs into
+`https://abap2ui5.github.io/docs/`:
+
+```abap
+" @keywords f4 search help suggestion input dialog select
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/value_help
+CLASS z2ui5_cl_smp_app_009 DEFINITION PUBLIC.
+```
+
+It is rendered in `SAMPLES.md` (never in the app — the tile has no room, and a
+reader who is already inside the overview is not looking for a link out).
+Full URLs rather than paths, because the line has to be useful where somebody
+actually meets it: a search engine drops people into a class, and the code was
+all they got.
+
+**Do not add one by hand.** The pairing is declared on the documentation side —
+a cookbook page lists its samples in frontmatter, and `scripts/link-samples.mjs`
+in [abap2UI5/docs](https://github.com/abap2UI5/docs) generates the block of
+sample links on the page *and* fails when a class it links to does not point
+back. Adding a line here that no page declares makes that check red. Add the
+page's `samples:` entry first; this line follows from it.
 
 **`header` and `sub` come from the class, not from hand-written labels.** The
 source of truth is the app class's abapGit short text `<DESCRIPT>` in its

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -32,106 +32,106 @@ plain OpenUI5 1.71. Each adds one idea.
 
 | Sample | Class |
 |---|---|
-| **Basics I** — Hello World, the Smallest App<br><sub>hello world smallest first app minimal start here template</sub> | [`Z2UI5_CL_SMP_APP_493`](src/01/z2ui5_cl_smp_app_493.clas.abap) |
-| **Basics II** — Data Binding: Input and Button<br><sub>binding _bind model attribute value input button serialize</sub> | [`Z2UI5_CL_SMP_APP_494`](src/01/z2ui5_cl_smp_app_494.clas.abap) |
-| **Basics III** — Lifecycle: Init, Event, Navigated<br><sub>lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated</sub> | [`Z2UI5_CL_SMP_APP_495`](src/01/z2ui5_cl_smp_app_495.clas.abap) |
-| **Basics IV** — Events, Views and Roundtrips<br><sub>roundtrip restart second view uncaught error controller basics</sub> | [`Z2UI5_CL_SMP_APP_004`](src/01/z2ui5_cl_smp_app_004.clas.abap) |
-| **Basics V** — The Developer Tools (Ctrl+F12)<br><sub>developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export</sub> | [`Z2UI5_CL_SMP_APP_496`](src/01/z2ui5_cl_smp_app_496.clas.abap) |
+| **Basics I** — Hello World, the Smallest App<br><sub>hello world smallest first app minimal start here template</sub><br><sub>docs: [get_started/hello_world](https://abap2ui5.github.io/docs/get_started/hello_world), [cookbook/view/definition](https://abap2ui5.github.io/docs/cookbook/view/definition), [cookbook/expert_more/snippets](https://abap2ui5.github.io/docs/cookbook/expert_more/snippets)</sub> | [`Z2UI5_CL_SMP_APP_493`](src/01/z2ui5_cl_smp_app_493.clas.abap) |
+| **Basics II** — Data Binding: Input and Button<br><sub>binding _bind model attribute value input button serialize</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_494`](src/01/z2ui5_cl_smp_app_494.clas.abap) |
+| **Basics III** — Lifecycle: Init, Event, Navigated<br><sub>lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated</sub><br><sub>docs: [cookbook/event_navigation/life_cycle](https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle), [cookbook/expert_more/snippets](https://abap2ui5.github.io/docs/cookbook/expert_more/snippets)</sub> | [`Z2UI5_CL_SMP_APP_495`](src/01/z2ui5_cl_smp_app_495.clas.abap) |
+| **Basics IV** — Events, Views and Roundtrips<br><sub>roundtrip restart second view uncaught error controller basics</sub><br><sub>docs: [cookbook/event_navigation/life_cycle](https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle), [cookbook/expert_more/snippets](https://abap2ui5.github.io/docs/cookbook/expert_more/snippets)</sub> | [`Z2UI5_CL_SMP_APP_004`](src/01/z2ui5_cl_smp_app_004.clas.abap) |
+| **Basics V** — The Developer Tools (Ctrl+F12)<br><sub>developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export</sub><br><sub>docs: [cookbook/troubleshooting/common_failures](https://abap2ui5.github.io/docs/cookbook/troubleshooting/common_failures)</sub> | [`Z2UI5_CL_SMP_APP_496`](src/01/z2ui5_cl_smp_app_496.clas.abap) |
 
 ### Binding
 
 | Sample | Class |
 |---|---|
-| Currency Amounts (sap.ui.model.type.Currency)<br><sub>amount decimals leading zeros number format</sub> | [`Z2UI5_CL_SMP_APP_067`](src/01/z2ui5_cl_smp_app_067.clas.abap) |
-| Dynamic Table Typed at Runtime (RTTI)<br><sub>generic data reference create data ddic dynamic itab</sub> | [`Z2UI5_CL_SMP_APP_061`](src/01/z2ui5_cl_smp_app_061.clas.abap) |
-| Expression Binding, Types and Composite Parts<br><sub>formatter parts conditional regexp visible enabled syntax</sub> | [`Z2UI5_CL_SMP_APP_027`](src/01/z2ui5_cl_smp_app_027.clas.abap) |
-| Model setSizeLimit for Large Tables (A)<br><sub>combobox jsonmodel size limit large itab 100 entries</sub> | [`Z2UI5_CL_SMP_APP_071`](src/01/z2ui5_cl_smp_app_071.clas.abap) |
-| Single Table Cell (tab_index)<br><sub>cell input internal table row field level</sub> | [`Z2UI5_CL_SMP_APP_144`](src/01/z2ui5_cl_smp_app_144.clas.abap) |
-| Structure Fields and INCLUDEs<br><sub>structure component include flat form level</sub> | [`Z2UI5_CL_SMP_APP_166`](src/01/z2ui5_cl_smp_app_166.clas.abap) |
-| Types for Integer, Decimal, Date and Time<br><sub>type conversion sum amount number field</sub> | [`Z2UI5_CL_SMP_APP_047`](src/01/z2ui5_cl_smp_app_047.clas.abap) |
+| Currency Amounts (sap.ui.model.type.Currency)<br><sub>amount decimals leading zeros number format</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_067`](src/01/z2ui5_cl_smp_app_067.clas.abap) |
+| Dynamic Table Typed at Runtime (RTTI)<br><sub>generic data reference create data ddic dynamic itab</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_061`](src/01/z2ui5_cl_smp_app_061.clas.abap) |
+| Expression Binding, Types and Composite Parts<br><sub>formatter parts conditional regexp visible enabled syntax</sub><br><sub>docs: [cookbook/model/expression_binding](https://abap2ui5.github.io/docs/cookbook/model/expression_binding)</sub> | [`Z2UI5_CL_SMP_APP_027`](src/01/z2ui5_cl_smp_app_027.clas.abap) |
+| Model setSizeLimit for Large Tables (A)<br><sub>combobox jsonmodel size limit large itab 100 entries</sub><br><sub>docs: [cookbook/model/size_limit](https://abap2ui5.github.io/docs/cookbook/model/size_limit)</sub> | [`Z2UI5_CL_SMP_APP_071`](src/01/z2ui5_cl_smp_app_071.clas.abap) |
+| Single Table Cell (tab_index)<br><sub>cell input internal table row field level</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_144`](src/01/z2ui5_cl_smp_app_144.clas.abap) |
+| Structure Fields and INCLUDEs<br><sub>structure component include flat form level</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_166`](src/01/z2ui5_cl_smp_app_166.clas.abap) |
+| Types for Integer, Decimal, Date and Time<br><sub>type conversion sum amount number field</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_047`](src/01/z2ui5_cl_smp_app_047.clas.abap) |
 
 ### Browser
 
 | Sample | Class |
 |---|---|
-| Copy to Clipboard (A)<br><sub>clipboard paste copy text area</sub> | [`Z2UI5_CL_SMP_APP_325`](src/01/z2ui5_cl_smp_app_325.clas.abap) |
-| Local and Session Storage (A,C)<br><sub>localstorage sessionstorage persist store_data offline</sub> | [`Z2UI5_CL_SMP_APP_327`](src/01/z2ui5_cl_smp_app_327.clas.abap) |
+| Copy to Clipboard (A)<br><sub>clipboard paste copy text area</sub><br><sub>docs: [cookbook/browser_interaction/clipboard](https://abap2ui5.github.io/docs/cookbook/browser_interaction/clipboard)</sub> | [`Z2UI5_CL_SMP_APP_325`](src/01/z2ui5_cl_smp_app_325.clas.abap) |
+| Local and Session Storage (A,C)<br><sub>localstorage sessionstorage persist store_data offline</sub><br><sub>docs: [cookbook/browser_interaction/clipboard](https://abap2ui5.github.io/docs/cookbook/browser_interaction/clipboard)</sub> | [`Z2UI5_CL_SMP_APP_327`](src/01/z2ui5_cl_smp_app_327.clas.abap) |
 | Logout from the Client (A)<br><sub>logoff signout icf session end fiori launchpad</sub> | [`Z2UI5_CL_SMP_APP_361`](src/01/z2ui5_cl_smp_app_361.clas.abap) |
-| Open a URL in a New Tab (A)<br><sub>url window open_new_tab link target</sub> | [`Z2UI5_CL_SMP_APP_073`](src/01/z2ui5_cl_smp_app_073.clas.abap) |
-| Open Mail, Phone and SMS Links (A)<br><sub>mailto tel sms urlhelper redirect native link</sub> | [`Z2UI5_CL_SMP_APP_316`](src/01/z2ui5_cl_smp_app_316.clas.abap) |
-| Reload the Page (A)<br><sub>reload refresh restart location_reload url</sub> | [`Z2UI5_CL_SMP_APP_492`](src/01/z2ui5_cl_smp_app_492.clas.abap) |
-| Set the Tab Favicon (A)<br><sub>favicon icon tab image data uri</sub> | [`Z2UI5_CL_SMP_APP_491`](src/01/z2ui5_cl_smp_app_491.clas.abap) |
-| Set the Tab Title (A)<br><sub>document.title tab caption headline set_title</sub> | [`Z2UI5_CL_SMP_APP_125`](src/01/z2ui5_cl_smp_app_125.clas.abap) |
-| Soft Keyboard Mode on Mobile (A)<br><sub>mobile numeric keypad keyboard_set_mode phone input</sub> | [`Z2UI5_CL_SMP_APP_352`](src/01/z2ui5_cl_smp_app_352.clas.abap) |
+| Open a URL in a New Tab (A)<br><sub>url window open_new_tab link target</sub><br><sub>docs: [cookbook/browser_interaction/url_handling](https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling)</sub> | [`Z2UI5_CL_SMP_APP_073`](src/01/z2ui5_cl_smp_app_073.clas.abap) |
+| Open Mail, Phone and SMS Links (A)<br><sub>mailto tel sms urlhelper redirect native link</sub><br><sub>docs: [cookbook/browser_interaction/url_handling](https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling)</sub> | [`Z2UI5_CL_SMP_APP_316`](src/01/z2ui5_cl_smp_app_316.clas.abap) |
+| Reload the Page (A)<br><sub>reload refresh restart location_reload url</sub><br><sub>docs: [cookbook/browser_interaction/url_handling](https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling)</sub> | [`Z2UI5_CL_SMP_APP_492`](src/01/z2ui5_cl_smp_app_492.clas.abap) |
+| Set the Tab Favicon (A)<br><sub>favicon icon tab image data uri</sub><br><sub>docs: [cookbook/browser_interaction/title](https://abap2ui5.github.io/docs/cookbook/browser_interaction/title)</sub> | [`Z2UI5_CL_SMP_APP_491`](src/01/z2ui5_cl_smp_app_491.clas.abap) |
+| Set the Tab Title (A)<br><sub>document.title tab caption headline set_title</sub><br><sub>docs: [cookbook/browser_interaction/title](https://abap2ui5.github.io/docs/cookbook/browser_interaction/title)</sub> | [`Z2UI5_CL_SMP_APP_125`](src/01/z2ui5_cl_smp_app_125.clas.abap) |
+| Soft Keyboard Mode on Mobile (A)<br><sub>mobile numeric keypad keyboard_set_mode phone input</sub><br><sub>docs: [cookbook/browser_interaction/soft_keyboard](https://abap2ui5.github.io/docs/cookbook/browser_interaction/soft_keyboard)</sub> | [`Z2UI5_CL_SMP_APP_352`](src/01/z2ui5_cl_smp_app_352.clas.abap) |
 
 ### Control
 
 | Sample | Class |
 |---|---|
-| Expand a Panel by ID (setExpanded) (A)<br><sub>panel collapse expand setexpanded control_by_id whitelisted</sub> | [`Z2UI5_CL_SMP_APP_448`](src/01/z2ui5_cl_smp_app_448.clas.abap) |
-| MultiInput with Tokens (C)<br><sub>multiinput token tokens suggestion custom control</sub> | [`Z2UI5_CL_SMP_APP_078`](src/01/z2ui5_cl_smp_app_078.clas.abap) |
-| Open the PDF Viewer by ID (A)<br><sub>pdfviewer pdf document viewer popup control_by_id whitelisted</sub> | [`Z2UI5_CL_SMP_APP_449`](src/01/z2ui5_cl_smp_app_449.clas.abap) |
-| Switch NavContainer Page by ID (A)<br><sub>navcontainer icontabbar icontabheader page switch control_by_id whitelisted</sub> | [`Z2UI5_CL_SMP_APP_088`](src/01/z2ui5_cl_smp_app_088.clas.abap) |
-| Wizard with Steps (A)<br><sub>wizard step branching discardprogress setnextstep control_by_id</sub> | [`Z2UI5_CL_SMP_APP_202`](src/01/z2ui5_cl_smp_app_202.clas.abap) |
+| Expand a Panel by ID (setExpanded) (A)<br><sub>panel collapse expand setexpanded control_by_id whitelisted</sub><br><sub>docs: [cookbook/expert_more/follow_up_action](https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action)</sub> | [`Z2UI5_CL_SMP_APP_448`](src/01/z2ui5_cl_smp_app_448.clas.abap) |
+| MultiInput with Tokens (C)<br><sub>multiinput token tokens suggestion custom control</sub><br><sub>docs: [cookbook/expert_more/value_help](https://abap2ui5.github.io/docs/cookbook/expert_more/value_help)</sub> | [`Z2UI5_CL_SMP_APP_078`](src/01/z2ui5_cl_smp_app_078.clas.abap) |
+| Open the PDF Viewer by ID (A)<br><sub>pdfviewer pdf document viewer popup control_by_id whitelisted</sub><br><sub>docs: [cookbook/device_capabilities/pdf](https://abap2ui5.github.io/docs/cookbook/device_capabilities/pdf), [cookbook/expert_more/follow_up_action](https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action)</sub> | [`Z2UI5_CL_SMP_APP_449`](src/01/z2ui5_cl_smp_app_449.clas.abap) |
+| Switch NavContainer Page by ID (A)<br><sub>navcontainer icontabbar icontabheader page switch control_by_id whitelisted</sub><br><sub>docs: [cookbook/expert_more/follow_up_action](https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action)</sub> | [`Z2UI5_CL_SMP_APP_088`](src/01/z2ui5_cl_smp_app_088.clas.abap) |
+| Wizard with Steps (A)<br><sub>wizard step branching discardprogress setnextstep control_by_id</sub><br><sub>docs: [cookbook/expert_more/follow_up_action](https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action)</sub> | [`Z2UI5_CL_SMP_APP_202`](src/01/z2ui5_cl_smp_app_202.clas.abap) |
 
 ### CSS
 
 | Sample | Class |
 |---|---|
 | Color Table Cells from the Backend<br><sub>color background conditional formatting style data attribute</sub> | [`Z2UI5_CL_SMP_APP_305`](src/01/z2ui5_cl_smp_app_305.clas.abap) |
-| FlexBox Layouts with Custom Classes<br><sub>flexbox layout responsive navigation tile panel</sub> | [`Z2UI5_CL_SMP_APP_255`](src/01/z2ui5_cl_smp_app_255.clas.abap) |
-| Ship Your Own CSS with the View<br><sub>style stylesheet inline html class own design</sub> | [`Z2UI5_CL_SMP_APP_050`](src/01/z2ui5_cl_smp_app_050.clas.abap) |
+| FlexBox Layouts with Custom Classes<br><sub>flexbox layout responsive navigation tile panel</sub><br><sub>docs: [cookbook/view/definition](https://abap2ui5.github.io/docs/cookbook/view/definition)</sub> | [`Z2UI5_CL_SMP_APP_255`](src/01/z2ui5_cl_smp_app_255.clas.abap) |
+| Ship Your Own CSS with the View<br><sub>style stylesheet inline html class own design</sub><br><sub>docs: [cookbook/view/definition](https://abap2ui5.github.io/docs/cookbook/view/definition)</sub> | [`Z2UI5_CL_SMP_APP_050`](src/01/z2ui5_cl_smp_app_050.clas.abap) |
 
 ### Device
 
 | Sample | Class |
 |---|---|
-| Camera, Take Photos (C)<br><sub>camera photo picture webcam capture facing mode</sub> | [`Z2UI5_CL_SMP_APP_306`](src/01/z2ui5_cl_smp_app_306.clas.abap) |
-| Device Model: Phone, Tablet, Desktop (A)<br><sub>sap.ui.device responsive orientation resize media model</sub> | [`Z2UI5_CL_SMP_APP_445`](src/01/z2ui5_cl_smp_app_445.clas.abap) |
-| Frontend Info: UI5 Version, Theme, OS, Browser<br><sub>client info ui5 version theme os user agent device</sub> | [`Z2UI5_CL_SMP_APP_122`](src/01/z2ui5_cl_smp_app_122.clas.abap) |
-| Geolocation from the Browser (C)<br><sub>gps position latitude longitude altitude location</sub> | [`Z2UI5_CL_SMP_APP_120`](src/01/z2ui5_cl_smp_app_120.clas.abap) |
+| Camera, Take Photos (C)<br><sub>camera photo picture webcam capture facing mode</sub><br><sub>docs: [cookbook/device_capabilities/camera](https://abap2ui5.github.io/docs/cookbook/device_capabilities/camera)</sub> | [`Z2UI5_CL_SMP_APP_306`](src/01/z2ui5_cl_smp_app_306.clas.abap) |
+| Device Model: Phone, Tablet, Desktop (A)<br><sub>sap.ui.device responsive orientation resize media model</sub><br><sub>docs: [cookbook/model/device_model](https://abap2ui5.github.io/docs/cookbook/model/device_model), [cookbook/device_capabilities/info](https://abap2ui5.github.io/docs/cookbook/device_capabilities/info)</sub> | [`Z2UI5_CL_SMP_APP_445`](src/01/z2ui5_cl_smp_app_445.clas.abap) |
+| Frontend Info: UI5 Version, Theme, OS, Browser<br><sub>client info ui5 version theme os user agent device</sub><br><sub>docs: [cookbook/device_capabilities/info](https://abap2ui5.github.io/docs/cookbook/device_capabilities/info)</sub> | [`Z2UI5_CL_SMP_APP_122`](src/01/z2ui5_cl_smp_app_122.clas.abap) |
+| Geolocation from the Browser (C)<br><sub>gps position latitude longitude altitude location</sub><br><sub>docs: [cookbook/device_capabilities/geolocation](https://abap2ui5.github.io/docs/cookbook/device_capabilities/geolocation)</sub> | [`Z2UI5_CL_SMP_APP_120`](src/01/z2ui5_cl_smp_app_120.clas.abap) |
 
 ### Event
 
 | Sample | Class |
 |---|---|
-| Control Objects in t_arg (FacetFilter)<br><sub>facetfilter filter object marshalling selected items</sub> | [`Z2UI5_CL_SMP_APP_197`](src/01/z2ui5_cl_smp_app_197.clas.abap) |
-| Extra Arguments with t_arg<br><sub>argument parameter payload event data fixed value</sub> | [`Z2UI5_CL_SMP_APP_167`](src/01/z2ui5_cl_smp_app_167.clas.abap) |
-| Keyboard Shortcuts, Ctrl+S (A)<br><sub>shortcut hotkey ctrl key combination keyboard_shortcut</sub> | [`Z2UI5_CL_SMP_APP_471`](src/01/z2ui5_cl_smp_app_471.clas.abap) |
-| Link with preventDefault (A)<br><sub>link href default action check_prevent_default</sub> | [`Z2UI5_CL_SMP_APP_472`](src/01/z2ui5_cl_smp_app_472.clas.abap) |
+| Control Objects in t_arg (FacetFilter)<br><sub>facetfilter filter object marshalling selected items</sub><br><sub>docs: [cookbook/event_navigation/backend](https://abap2ui5.github.io/docs/cookbook/event_navigation/backend)</sub> | [`Z2UI5_CL_SMP_APP_197`](src/01/z2ui5_cl_smp_app_197.clas.abap) |
+| Extra Arguments with t_arg<br><sub>argument parameter payload event data fixed value</sub><br><sub>docs: [cookbook/event_navigation/backend](https://abap2ui5.github.io/docs/cookbook/event_navigation/backend)</sub> | [`Z2UI5_CL_SMP_APP_167`](src/01/z2ui5_cl_smp_app_167.clas.abap) |
+| Keyboard Shortcuts, Ctrl+S (A)<br><sub>shortcut hotkey ctrl key combination keyboard_shortcut</sub><br><sub>docs: [cookbook/browser_interaction/keyboard_shortcuts](https://abap2ui5.github.io/docs/cookbook/browser_interaction/keyboard_shortcuts)</sub> | [`Z2UI5_CL_SMP_APP_471`](src/01/z2ui5_cl_smp_app_471.clas.abap) |
+| Link with preventDefault (A)<br><sub>link href default action check_prevent_default</sub><br><sub>docs: [cookbook/event_navigation/frontend](https://abap2ui5.github.io/docs/cookbook/event_navigation/frontend)</sub> | [`Z2UI5_CL_SMP_APP_472`](src/01/z2ui5_cl_smp_app_472.clas.abap) |
 
 ### File
 
 | Sample | Class |
 |---|---|
-| Download to the Browser (A)<br><sub>export save base64 attachment xstring document</sub> | [`Z2UI5_CL_SMP_APP_186`](src/01/z2ui5_cl_smp_app_186.clas.abap) |
-| Upload to the Backend (C)<br><sub>fileuploader base64 attachment import picture document</sub> | [`Z2UI5_CL_SMP_APP_074`](src/01/z2ui5_cl_smp_app_074.clas.abap) |
+| Download to the Browser (A)<br><sub>export save base64 attachment xstring document</sub><br><sub>docs: [cookbook/device_capabilities/upload_download](https://abap2ui5.github.io/docs/cookbook/device_capabilities/upload_download)</sub> | [`Z2UI5_CL_SMP_APP_186`](src/01/z2ui5_cl_smp_app_186.clas.abap) |
+| Upload to the Backend (C)<br><sub>fileuploader base64 attachment import picture document</sub><br><sub>docs: [cookbook/device_capabilities/upload_download](https://abap2ui5.github.io/docs/cookbook/device_capabilities/upload_download)</sub> | [`Z2UI5_CL_SMP_APP_074`](src/01/z2ui5_cl_smp_app_074.clas.abap) |
 
 ### Focus
 
 | Sample | Class |
 |---|---|
-| Focus a Table Cell by Column and Row (A)<br><sub>table cell column row aggregation set_focus</sub> | [`Z2UI5_CL_SMP_APP_421`](src/01/z2ui5_cl_smp_app_421.clas.abap) |
-| Jump to the Next Input on Enter (A)<br><sub>cursor enter tab next field form set_focus</sub> | [`Z2UI5_CL_SMP_APP_189`](src/01/z2ui5_cl_smp_app_189.clas.abap) |
-| Set Focus and Select Text in an Input (A)<br><sub>cursor set_focus selection position textfield</sub> | [`Z2UI5_CL_SMP_APP_133`](src/01/z2ui5_cl_smp_app_133.clas.abap) |
+| Focus a Table Cell by Column and Row (A)<br><sub>table cell column row aggregation set_focus</sub><br><sub>docs: [cookbook/browser_interaction/focus](https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus)</sub> | [`Z2UI5_CL_SMP_APP_421`](src/01/z2ui5_cl_smp_app_421.clas.abap) |
+| Jump to the Next Input on Enter (A)<br><sub>cursor enter tab next field form set_focus</sub><br><sub>docs: [cookbook/browser_interaction/focus](https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus)</sub> | [`Z2UI5_CL_SMP_APP_189`](src/01/z2ui5_cl_smp_app_189.clas.abap) |
+| Set Focus and Select Text in an Input (A)<br><sub>cursor set_focus selection position textfield</sub><br><sub>docs: [cookbook/browser_interaction/focus](https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus)</sub> | [`Z2UI5_CL_SMP_APP_133`](src/01/z2ui5_cl_smp_app_133.clas.abap) |
 
 ### Formatter
 
 | Sample | Class |
 |---|---|
-| ABAP Date and Time Strings (DATS/TIMS)<br><sub>dats tims conversion initial date 00000000 sy-datum</sub> | [`Z2UI5_CL_SMP_APP_450`](src/01/z2ui5_cl_smp_app_450.clas.abap) |
-| Date Object for the DatePicker<br><sub>datepicker datevalue javascript date object iso</sub> | [`Z2UI5_CL_SMP_APP_457`](src/01/z2ui5_cl_smp_app_457.clas.abap) |
-| Date Objects for the PlanningCalendar<br><sub>planningcalendar appointment javascript date object iso</sub> | [`Z2UI5_CL_SMP_APP_456`](src/01/z2ui5_cl_smp_app_456.clas.abap) |
-| Inline Icons in a Text<br><sub>icon glyph placeholder text status expandinlineicons</sub> | [`Z2UI5_CL_SMP_APP_466`](src/01/z2ui5_cl_smp_app_466.clas.abap) |
-| When Not to Use One: Compute in ABAP<br><sub>no formatter computed backend thin frontend prepare</sub> | [`Z2UI5_CL_SMP_APP_453`](src/01/z2ui5_cl_smp_app_453.clas.abap) |
+| ABAP Date and Time Strings (DATS/TIMS)<br><sub>dats tims conversion initial date 00000000 sy-datum</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_450`](src/01/z2ui5_cl_smp_app_450.clas.abap) |
+| Date Object for the DatePicker<br><sub>datepicker datevalue javascript date object iso</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_457`](src/01/z2ui5_cl_smp_app_457.clas.abap) |
+| Date Objects for the PlanningCalendar<br><sub>planningcalendar appointment javascript date object iso</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_456`](src/01/z2ui5_cl_smp_app_456.clas.abap) |
+| Inline Icons in a Text<br><sub>icon glyph placeholder text status expandinlineicons</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_466`](src/01/z2ui5_cl_smp_app_466.clas.abap) |
+| When Not to Use One: Compute in ABAP<br><sub>no formatter computed backend thin frontend prepare</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_453`](src/01/z2ui5_cl_smp_app_453.clas.abap) |
 
 ### Grid Table
 
 | Sample | Class |
 |---|---|
-| Events on Cell Level<br><sub>cell enter row index event grid alv</sub> | [`Z2UI5_CL_SMP_APP_160`](src/01/z2ui5_cl_smp_app_160.clas.abap) |
-| Full Example with sap.ui.table<br><sub>grid alv dynamicpage column row action currency search sort filter</sub> | [`Z2UI5_CL_SMP_APP_070`](src/01/z2ui5_cl_smp_app_070.clas.abap) |
-| Keep Column Filters on Refresh (C)<br><sub>column filter reset refresh uitableext grid alv</sub> | [`Z2UI5_CL_SMP_APP_143`](src/01/z2ui5_cl_smp_app_143.clas.abap) |
+| Events on Cell Level<br><sub>cell enter row index event grid alv</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_160`](src/01/z2ui5_cl_smp_app_160.clas.abap) |
+| Full Example with sap.ui.table<br><sub>grid alv dynamicpage column row action currency search sort filter</sub><br><sub>docs: [get_started/full_example](https://abap2ui5.github.io/docs/get_started/full_example), [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_070`](src/01/z2ui5_cl_smp_app_070.clas.abap) |
+| Keep Column Filters on Refresh (C)<br><sub>column filter reset refresh uitableext grid alv</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_143`](src/01/z2ui5_cl_smp_app_143.clas.abap) |
 
 ### List
 
@@ -152,93 +152,93 @@ plain OpenUI5 1.71. Each adds one idea.
 
 | Sample | Class |
 |---|---|
-| Message Model and MessageManager (C)<br><sub>messagemanager validation target field state central model</sub> | [`Z2UI5_CL_SMP_APP_467`](src/01/z2ui5_cl_smp_app_467.clas.abap) |
-| MessageBox from SY, BAPIRET2 or Exception<br><sub>t100 message class number exception cx_root error abend</sub> | [`Z2UI5_CL_SMP_APP_008`](src/01/z2ui5_cl_smp_app_008.clas.abap) |
-| MessageBox, Types and Custom Actions<br><sub>confirm warning error success information dialog action</sub> | [`Z2UI5_CL_SMP_APP_382`](src/01/z2ui5_cl_smp_app_382.clas.abap) |
-| MessagePopover URL Policy (A)<br><sub>url policy link security validator relative allow deny</sub> | [`Z2UI5_CL_SMP_APP_474`](src/01/z2ui5_cl_smp_app_474.clas.abap) |
-| MessageToast, Text and Duration<br><sub>toast notification duration position animation</sub> | [`Z2UI5_CL_SMP_APP_381`](src/01/z2ui5_cl_smp_app_381.clas.abap) |
-| MessageView and MessagePopover (A)<br><sub>messagepopover messageitem dialog grouped message list</sub> | [`Z2UI5_CL_SMP_APP_452`](src/01/z2ui5_cl_smp_app_452.clas.abap) |
+| Message Model and MessageManager (C)<br><sub>messagemanager validation target field state central model</sub><br><sub>docs: [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_467`](src/01/z2ui5_cl_smp_app_467.clas.abap) |
+| MessageBox from SY, BAPIRET2 or Exception<br><sub>t100 message class number exception cx_root error abend</sub><br><sub>docs: [cookbook/event_navigation/exception](https://abap2ui5.github.io/docs/cookbook/event_navigation/exception), [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_008`](src/01/z2ui5_cl_smp_app_008.clas.abap) |
+| MessageBox, Types and Custom Actions<br><sub>confirm warning error success information dialog action</sub><br><sub>docs: [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_382`](src/01/z2ui5_cl_smp_app_382.clas.abap) |
+| MessagePopover URL Policy (A)<br><sub>url policy link security validator relative allow deny</sub><br><sub>docs: [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_474`](src/01/z2ui5_cl_smp_app_474.clas.abap) |
+| MessageToast, Text and Duration<br><sub>toast notification duration position animation</sub><br><sub>docs: [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_381`](src/01/z2ui5_cl_smp_app_381.clas.abap) |
+| MessageView and MessagePopover (A)<br><sub>messagepopover messageitem dialog grouped message list</sub><br><sub>docs: [cookbook/translation_messages/message](https://abap2ui5.github.io/docs/cookbook/translation_messages/message)</sub> | [`Z2UI5_CL_SMP_APP_452`](src/01/z2ui5_cl_smp_app_452.clas.abap) |
 
 ### Navigation
 
 | Sample | Class |
 |---|---|
-| Call and Leave Apps (nav_app_call)<br><sub>nav_app_call nav_app_leave sub app stack call back</sub> | [`Z2UI5_CL_SMP_APP_024`](src/01/z2ui5_cl_smp_app_024.clas.abap) |
-| Data Loss Protection on Leaving (A,C)<br><sub>dirty unsaved changes leave confirmation warning</sub> | [`Z2UI5_CL_SMP_APP_279`](src/01/z2ui5_cl_smp_app_279.clas.abap) |
-| Return Data and Events to the Caller<br><sub>r_data result get_app_prev return event payload</sub> | [`Z2UI5_CL_SMP_APP_488`](src/01/z2ui5_cl_smp_app_488.clas.abap) |
-| Uncaught Error and Error Popup<br><sub>exception dump error handling debugtool restart retry</sub> | [`Z2UI5_CL_SMP_APP_464`](src/01/z2ui5_cl_smp_app_464.clas.abap) |
+| Call and Leave Apps (nav_app_call)<br><sub>nav_app_call nav_app_leave sub app stack call back</sub><br><sub>docs: [cookbook/event_navigation/navigation](https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation)</sub> | [`Z2UI5_CL_SMP_APP_024`](src/01/z2ui5_cl_smp_app_024.clas.abap) |
+| Data Loss Protection on Leaving (A,C)<br><sub>dirty unsaved changes leave confirmation warning</sub><br><sub>docs: [cookbook/event_navigation/navigation](https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation)</sub> | [`Z2UI5_CL_SMP_APP_279`](src/01/z2ui5_cl_smp_app_279.clas.abap) |
+| Return Data and Events to the Caller<br><sub>r_data result get_app_prev return event payload</sub><br><sub>docs: [cookbook/event_navigation/navigation](https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation)</sub> | [`Z2UI5_CL_SMP_APP_488`](src/01/z2ui5_cl_smp_app_488.clas.abap) |
+| Uncaught Error and Error Popup<br><sub>exception dump error handling debugtool restart retry</sub><br><sub>docs: [cookbook/event_navigation/exception](https://abap2ui5.github.io/docs/cookbook/event_navigation/exception)</sub> | [`Z2UI5_CL_SMP_APP_464`](src/01/z2ui5_cl_smp_app_464.clas.abap) |
 
 ### Nested View
 
 | Sample | Class |
 |---|---|
-| Basic Example (nest_view_display)<br><sub>nest_view_display rerender model refresh sub view</sub> | [`Z2UI5_CL_SMP_APP_065`](src/01/z2ui5_cl_smp_app_065.clas.abap) |
-| Embed Another App's View<br><sub>sub app class embed instantiate another app rtti</sub> | [`Z2UI5_CL_SMP_APP_104`](src/01/z2ui5_cl_smp_app_104.clas.abap) |
-| Master-Detail with FlexibleColumnLayout<br><sub>fcl master detail list report two column split</sub> | [`Z2UI5_CL_SMP_APP_097`](src/01/z2ui5_cl_smp_app_097.clas.abap) |
-| Three Columns with FlexibleColumnLayout<br><sub>fcl three column detail detail deep navigation</sub> | [`Z2UI5_CL_SMP_APP_098`](src/01/z2ui5_cl_smp_app_098.clas.abap) |
+| Basic Example (nest_view_display)<br><sub>nest_view_display rerender model refresh sub view</sub><br><sub>docs: [cookbook/view/nested_views](https://abap2ui5.github.io/docs/cookbook/view/nested_views)</sub> | [`Z2UI5_CL_SMP_APP_065`](src/01/z2ui5_cl_smp_app_065.clas.abap) |
+| Embed Another App's View<br><sub>sub app class embed instantiate another app rtti</sub><br><sub>docs: [cookbook/view/nested_views](https://abap2ui5.github.io/docs/cookbook/view/nested_views)</sub> | [`Z2UI5_CL_SMP_APP_104`](src/01/z2ui5_cl_smp_app_104.clas.abap) |
+| Master-Detail with FlexibleColumnLayout<br><sub>fcl master detail list report two column split</sub><br><sub>docs: [cookbook/view/nested_views](https://abap2ui5.github.io/docs/cookbook/view/nested_views)</sub> | [`Z2UI5_CL_SMP_APP_097`](src/01/z2ui5_cl_smp_app_097.clas.abap) |
+| Three Columns with FlexibleColumnLayout<br><sub>fcl three column detail detail deep navigation</sub><br><sub>docs: [cookbook/view/nested_views](https://abap2ui5.github.io/docs/cookbook/view/nested_views)</sub> | [`Z2UI5_CL_SMP_APP_098`](src/01/z2ui5_cl_smp_app_098.clas.abap) |
 
 ### Popover
 
 | Sample | Class |
 |---|---|
-| Basic Example with Placement<br><sub>placement anchor button confirm cancel popover_display</sub> | [`Z2UI5_CL_SMP_APP_026`](src/01/z2ui5_cl_smp_app_026.clas.abap) |
-| Open from a Table Row<br><sub>list report dynamicpage row link details table</sub> | [`Z2UI5_CL_SMP_APP_052`](src/01/z2ui5_cl_smp_app_052.clas.abap) |
-| Open Together with the View Build<br><sub>initial render one roundtrip anchor button</sub> | [`Z2UI5_CL_SMP_APP_490`](src/01/z2ui5_cl_smp_app_490.clas.abap) |
-| QuickView Contact Card<br><sub>quickview contact card links grouped fields</sub> | [`Z2UI5_CL_SMP_APP_109`](src/01/z2ui5_cl_smp_app_109.clas.abap) |
-| Select from a List<br><sub>list selection placement anchor</sub> | [`Z2UI5_CL_SMP_APP_081`](src/01/z2ui5_cl_smp_app_081.clas.abap) |
-| Toggle by ID (toggleBy) (A)<br><sub>toggleby open close control_by_id whitelisted</sub> | [`Z2UI5_CL_SMP_APP_465`](src/01/z2ui5_cl_smp_app_465.clas.abap) |
+| Basic Example with Placement<br><sub>placement anchor button confirm cancel popover_display</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover)</sub> | [`Z2UI5_CL_SMP_APP_026`](src/01/z2ui5_cl_smp_app_026.clas.abap) |
+| Open from a Table Row<br><sub>list report dynamicpage row link details table</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover)</sub> | [`Z2UI5_CL_SMP_APP_052`](src/01/z2ui5_cl_smp_app_052.clas.abap) |
+| Open Together with the View Build<br><sub>initial render one roundtrip anchor button</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover)</sub> | [`Z2UI5_CL_SMP_APP_490`](src/01/z2ui5_cl_smp_app_490.clas.abap) |
+| QuickView Contact Card<br><sub>quickview contact card links grouped fields</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover)</sub> | [`Z2UI5_CL_SMP_APP_109`](src/01/z2ui5_cl_smp_app_109.clas.abap) |
+| Select from a List<br><sub>list selection placement anchor</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover)</sub> | [`Z2UI5_CL_SMP_APP_081`](src/01/z2ui5_cl_smp_app_081.clas.abap) |
+| Toggle by ID (toggleBy) (A)<br><sub>toggleby open close control_by_id whitelisted</sub><br><sub>docs: [cookbook/popup_popover/popover](https://abap2ui5.github.io/docs/cookbook/popup_popover/popover), [cookbook/expert_more/follow_up_action](https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action)</sub> | [`Z2UI5_CL_SMP_APP_465`](src/01/z2ui5_cl_smp_app_465.clas.abap) |
 
 ### Popup
 
 | Sample | Class |
 |---|---|
-| Dialog inside a Dialog<br><sub>nested stack popup in popup second dialog</sub> | [`Z2UI5_CL_SMP_APP_161`](src/01/z2ui5_cl_smp_app_161.clas.abap) |
-| Element Binding to the Selected Row (A)<br><sub>element binding relative path aggregation dialog row</sub> | [`Z2UI5_CL_SMP_APP_470`](src/01/z2ui5_cl_smp_app_470.clas.abap) |
-| Navigate between Dialogs (NavContainer) (A)<br><sub>navcontainer dialog pages back forward</sub> | [`Z2UI5_CL_SMP_APP_170`](src/01/z2ui5_cl_smp_app_170.clas.abap) |
-| Value Help: Suggestions and F4 Dialog<br><sub>f4 search help suggestion input dialog select</sub> | [`Z2UI5_CL_SMP_APP_009`](src/01/z2ui5_cl_smp_app_009.clas.abap) |
-| Ways to Open a Dialog (A)<br><sub>dialog sub app destroy rerender background view</sub> | [`Z2UI5_CL_SMP_APP_012`](src/01/z2ui5_cl_smp_app_012.clas.abap) |
+| Dialog inside a Dialog<br><sub>nested stack popup in popup second dialog</sub><br><sub>docs: [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup)</sub> | [`Z2UI5_CL_SMP_APP_161`](src/01/z2ui5_cl_smp_app_161.clas.abap) |
+| Element Binding to the Selected Row (A)<br><sub>element binding relative path aggregation dialog row</sub><br><sub>docs: [cookbook/event_navigation/frontend](https://abap2ui5.github.io/docs/cookbook/event_navigation/frontend), [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup)</sub> | [`Z2UI5_CL_SMP_APP_470`](src/01/z2ui5_cl_smp_app_470.clas.abap) |
+| Navigate between Dialogs (NavContainer) (A)<br><sub>navcontainer dialog pages back forward</sub><br><sub>docs: [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup)</sub> | [`Z2UI5_CL_SMP_APP_170`](src/01/z2ui5_cl_smp_app_170.clas.abap) |
+| Value Help: Suggestions and F4 Dialog<br><sub>f4 search help suggestion input dialog select</sub><br><sub>docs: [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup), [cookbook/expert_more/value_help](https://abap2ui5.github.io/docs/cookbook/expert_more/value_help)</sub> | [`Z2UI5_CL_SMP_APP_009`](src/01/z2ui5_cl_smp_app_009.clas.abap) |
+| Ways to Open a Dialog (A)<br><sub>dialog sub app destroy rerender background view</sub><br><sub>docs: [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup)</sub> | [`Z2UI5_CL_SMP_APP_012`](src/01/z2ui5_cl_smp_app_012.clas.abap) |
 
 ### Scroll
 
 | Sample | Class |
 |---|---|
-| Scroll a Control into View (A)<br><sub>scroll_into_view control id validation jump</sub> | [`Z2UI5_CL_SMP_APP_363`](src/01/z2ui5_cl_smp_app_363.clas.abap) |
-| Scroll to a Pixel Position (A)<br><sub>position pixel scroll_to restore refresh toolbar</sub> | [`Z2UI5_CL_SMP_APP_362`](src/01/z2ui5_cl_smp_app_362.clas.abap) |
+| Scroll a Control into View (A)<br><sub>scroll_into_view control id validation jump</sub><br><sub>docs: [cookbook/browser_interaction/scrolling](https://abap2ui5.github.io/docs/cookbook/browser_interaction/scrolling)</sub> | [`Z2UI5_CL_SMP_APP_363`](src/01/z2ui5_cl_smp_app_363.clas.abap) |
+| Scroll to a Pixel Position (A)<br><sub>position pixel scroll_to restore refresh toolbar</sub><br><sub>docs: [cookbook/browser_interaction/scrolling](https://abap2ui5.github.io/docs/cookbook/browser_interaction/scrolling)</sub> | [`Z2UI5_CL_SMP_APP_362`](src/01/z2ui5_cl_smp_app_362.clas.abap) |
 
 ### Table
 
 | Sample | Class |
 |---|---|
-| Drag and Drop Rows (A)<br><sub>dnd dragdropinfo reorder rows move</sub> | [`Z2UI5_CL_SMP_APP_459`](src/01/z2ui5_cl_smp_app_459.clas.abap) |
-| Editable Cells, Add and Delete Rows<br><sub>edit input add row delete multiselect toolbar</sub> | [`Z2UI5_CL_SMP_APP_011`](src/01/z2ui5_cl_smp_app_011.clas.abap) |
-| Filter Rows in the Backend<br><sub>filter server side form growing where</sub> | [`Z2UI5_CL_SMP_APP_045`](src/01/z2ui5_cl_smp_app_045.clas.abap) |
-| Large Table with Growing and ScrollContainer<br><sub>growing 10000 rows sticky toolbar sort performance</sub> | [`Z2UI5_CL_SMP_APP_006`](src/01/z2ui5_cl_smp_app_006.clas.abap) |
-| Live Search with Parallel Requests<br><sub>live search parallel requests busy queue typing</sub> | [`Z2UI5_CL_SMP_APP_059`](src/01/z2ui5_cl_smp_app_059.clas.abap) |
-| Search in the Backend (SearchField)<br><sub>search go enter server side where</sub> | [`Z2UI5_CL_SMP_APP_053`](src/01/z2ui5_cl_smp_app_053.clas.abap) |
-| Selection Modes: Single and Multi Select<br><sub>selectionmode none single multi segmentedbutton checkbox</sub> | [`Z2UI5_CL_SMP_APP_019`](src/01/z2ui5_cl_smp_app_019.clas.abap) |
+| Drag and Drop Rows (A)<br><sub>dnd dragdropinfo reorder rows move</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_459`](src/01/z2ui5_cl_smp_app_459.clas.abap) |
+| Editable Cells, Add and Delete Rows<br><sub>edit input add row delete multiselect toolbar</sub><br><sub>docs: [get_started/full_example](https://abap2ui5.github.io/docs/get_started/full_example), [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_011`](src/01/z2ui5_cl_smp_app_011.clas.abap) |
+| Filter Rows in the Backend<br><sub>filter server side form growing where</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_045`](src/01/z2ui5_cl_smp_app_045.clas.abap) |
+| Large Table with Growing and ScrollContainer<br><sub>growing 10000 rows sticky toolbar sort performance</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_006`](src/01/z2ui5_cl_smp_app_006.clas.abap) |
+| Live Search with Parallel Requests<br><sub>live search parallel requests busy queue typing</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_059`](src/01/z2ui5_cl_smp_app_059.clas.abap) |
+| Search in the Backend (SearchField)<br><sub>search go enter server side where</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_053`](src/01/z2ui5_cl_smp_app_053.clas.abap) |
+| Selection Modes: Single and Multi Select<br><sub>selectionmode none single multi segmentedbutton checkbox</sub><br><sub>docs: [cookbook/model/tables](https://abap2ui5.github.io/docs/cookbook/model/tables)</sub> | [`Z2UI5_CL_SMP_APP_019`](src/01/z2ui5_cl_smp_app_019.clas.abap) |
 
 ### Templating
 
 | Sample | Class |
 |---|---|
-| Build Columns Dynamically (template:repeat)<br><sub>template repeat runtime generated columns if then else</sub> | [`Z2UI5_CL_SMP_APP_173`](src/01/z2ui5_cl_smp_app_173.clas.abap) |
-| Dynamic Content in a Nested View<br><sub>template repeat runtime generated nested nest_view_display</sub> | [`Z2UI5_CL_SMP_APP_176`](src/01/z2ui5_cl_smp_app_176.clas.abap) |
+| Build Columns Dynamically (template:repeat)<br><sub>template repeat runtime generated columns if then else</sub><br><sub>docs: [cookbook/view/xml_templating](https://abap2ui5.github.io/docs/cookbook/view/xml_templating)</sub> | [`Z2UI5_CL_SMP_APP_173`](src/01/z2ui5_cl_smp_app_173.clas.abap) |
+| Dynamic Content in a Nested View<br><sub>template repeat runtime generated nested nest_view_display</sub><br><sub>docs: [cookbook/view/nested_views](https://abap2ui5.github.io/docs/cookbook/view/nested_views), [cookbook/view/xml_templating](https://abap2ui5.github.io/docs/cookbook/view/xml_templating)</sub> | [`Z2UI5_CL_SMP_APP_176`](src/01/z2ui5_cl_smp_app_176.clas.abap) |
 
 ### Timer
 
 | Sample | Class |
 |---|---|
-| Progress Indicator during a Backend Call (A)<br><sub>progressindicator busy wait long running backend</sub> | [`Z2UI5_CL_SMP_APP_064`](src/01/z2ui5_cl_smp_app_064.clas.abap) |
-| Refresh the View Every n Seconds (A)<br><sub>interval polling auto refresh follow_up_action seconds</sub> | [`Z2UI5_CL_SMP_APP_028`](src/01/z2ui5_cl_smp_app_028.clas.abap) |
+| Progress Indicator during a Backend Call (A)<br><sub>progressindicator busy wait long running backend</sub><br><sub>docs: [cookbook/browser_interaction/timer](https://abap2ui5.github.io/docs/cookbook/browser_interaction/timer)</sub> | [`Z2UI5_CL_SMP_APP_064`](src/01/z2ui5_cl_smp_app_064.clas.abap) |
+| Refresh the View Every n Seconds (A)<br><sub>interval polling auto refresh follow_up_action seconds</sub><br><sub>docs: [cookbook/browser_interaction/timer](https://abap2ui5.github.io/docs/cookbook/browser_interaction/timer)</sub> | [`Z2UI5_CL_SMP_APP_028`](src/01/z2ui5_cl_smp_app_028.clas.abap) |
 
 ### Tree
 
 | Sample | Class |
 |---|---|
-| Drag and Drop Nodes (A,C)<br><sub>dnd move node hierarchy binding context</sub> | [`Z2UI5_CL_SMP_APP_461`](src/01/z2ui5_cl_smp_app_461.clas.abap) |
-| Editable Nodes with CustomTreeItem (C)<br><sub>customtreeitem rename input binding write back</sub> | [`Z2UI5_CL_SMP_APP_463`](src/01/z2ui5_cl_smp_app_463.clas.abap) |
-| Inside a Dialog (C)<br><sub>popup expand state hierarchy nodes</sub> | [`Z2UI5_CL_SMP_APP_462`](src/01/z2ui5_cl_smp_app_462.clas.abap) |
-| Nested ABAP Table in a sap.m.Tree<br><sub>hierarchy nodes nested json items</sub> | [`Z2UI5_CL_SMP_APP_460`](src/01/z2ui5_cl_smp_app_460.clas.abap) |
+| Drag and Drop Nodes (A,C)<br><sub>dnd move node hierarchy binding context</sub><br><sub>docs: [cookbook/model/trees](https://abap2ui5.github.io/docs/cookbook/model/trees)</sub> | [`Z2UI5_CL_SMP_APP_461`](src/01/z2ui5_cl_smp_app_461.clas.abap) |
+| Editable Nodes with CustomTreeItem (C)<br><sub>customtreeitem rename input binding write back</sub><br><sub>docs: [cookbook/model/trees](https://abap2ui5.github.io/docs/cookbook/model/trees)</sub> | [`Z2UI5_CL_SMP_APP_463`](src/01/z2ui5_cl_smp_app_463.clas.abap) |
+| Inside a Dialog (C)<br><sub>popup expand state hierarchy nodes</sub><br><sub>docs: [cookbook/model/trees](https://abap2ui5.github.io/docs/cookbook/model/trees)</sub> | [`Z2UI5_CL_SMP_APP_462`](src/01/z2ui5_cl_smp_app_462.clas.abap) |
+| Nested ABAP Table in a sap.m.Tree<br><sub>hierarchy nodes nested json items</sub><br><sub>docs: [cookbook/model/trees](https://abap2ui5.github.io/docs/cookbook/model/trees)</sub> | [`Z2UI5_CL_SMP_APP_460`](src/01/z2ui5_cl_smp_app_460.clas.abap) |
 
 ---
 
@@ -257,12 +257,12 @@ is absent there.
 
 | Sample | Class |
 |---|---|
-| **Navigation** — app state<br><sub>app state url bookmark restore set_app_state_active reload deep link</sub> | [`Z2UI5_CL_SMP_APP_321`](src/00/97/z2ui5_cl_smp_app_321.clas.abap) |
-| **Navigation** — app state share<br><sub>app state share clipboard copy link colleague send url</sub> | [`Z2UI5_CL_SMP_APP_323`](src/00/97/z2ui5_cl_smp_app_323.clas.abap) |
-| **Navigation** — push state<br><sub>push state browser history back button hash url set_push_state</sub> | [`Z2UI5_CL_SMP_APP_322`](src/00/97/z2ui5_cl_smp_app_322.clas.abap) |
-| **Navigation** — Routing mode fresh<br><sub>routing mode fresh navigation restart new instance nav_app_call</sub> | [`Z2UI5_CL_SMP_APP_468`](src/00/97/z2ui5_cl_smp_app_468.clas.abap) |
-| **Navigation** — Routing mode keep<br><sub>routing mode keep navigation state preserved back nav_app_call</sub> | [`Z2UI5_CL_SMP_APP_480`](src/00/97/z2ui5_cl_smp_app_480.clas.abap) |
-| **Popup** — change a popup control from the backend<br><sub>popup dialog change control backend control_by_id update running</sub> | [`Z2UI5_CL_SMP_APP_141`](src/00/97/z2ui5_cl_smp_app_141.clas.abap) |
+| **Navigation** — app state<br><sub>app state url bookmark restore set_app_state_active reload deep link</sub><br><sub>docs: [cookbook/expert_more/app_state_share](https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share)</sub> | [`Z2UI5_CL_SMP_APP_321`](src/00/97/z2ui5_cl_smp_app_321.clas.abap) |
+| **Navigation** — app state share<br><sub>app state share clipboard copy link colleague send url</sub><br><sub>docs: [cookbook/expert_more/app_state_share](https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share)</sub> | [`Z2UI5_CL_SMP_APP_323`](src/00/97/z2ui5_cl_smp_app_323.clas.abap) |
+| **Navigation** — push state<br><sub>push state browser history back button hash url set_push_state</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_322`](src/00/97/z2ui5_cl_smp_app_322.clas.abap) |
+| **Navigation** — Routing mode fresh<br><sub>routing mode fresh navigation restart new instance nav_app_call</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_468`](src/00/97/z2ui5_cl_smp_app_468.clas.abap) |
+| **Navigation** — Routing mode keep<br><sub>routing mode keep navigation state preserved back nav_app_call</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_480`](src/00/97/z2ui5_cl_smp_app_480.clas.abap) |
+| **Popup** — change a popup control from the backend<br><sub>popup dialog change control backend control_by_id update running</sub><br><sub>docs: [cookbook/popup_popover/popup](https://abap2ui5.github.io/docs/cookbook/popup_popover/popup)</sub> | [`Z2UI5_CL_SMP_APP_141`](src/00/97/z2ui5_cl_smp_app_141.clas.abap) |
 
 ### testing — `src/00/98`
 

--- a/scripts/generate-samples-md.js
+++ b/scripts/generate-samples-md.js
@@ -27,7 +27,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { ROOT, scanSamples } = require('./lib/scan-samples');
+const { ROOT, DOCS_SITE, scanSamples } = require('./lib/scan-samples');
 
 const OUT = path.join(ROOT, 'SAMPLES.md');
 
@@ -60,8 +60,14 @@ function row(tile, underHeading) {
   // never renders them; here the page IS the search box, so they belong in it -
   // quietly, in the small type the summary line of a row deserves.
   const terms = tile.keywords ? `<br><sub>${cell(tile.keywords)}</sub>` : '';
+  // A sample shows HOW; the documentation says WHY and when. Where a chapter
+  // exists, the reader of this page should not have to go looking for it - the
+  // two were written about the same thing.
+  const chapters = tile.docs.length
+    ? `<br><sub>docs: ${tile.docs.map((u) => `[${u.replace(DOCS_SITE, '')}](${u})`).join(', ')}</sub>`
+    : '';
   const source = `${tile.path}/${tile.app}.clas.abap`;
-  return `| ${title}${terms} | [\`${tile.app.toUpperCase()}\`](${source}) |`;
+  return `| ${title}${terms}${chapters} | [\`${tile.app.toUpperCase()}\`](${source}) |`;
 }
 
 function table(tiles, underHeading = false) {

--- a/scripts/lib/scan-samples.js
+++ b/scripts/lib/scan-samples.js
@@ -38,6 +38,11 @@ const OVERVIEW_APPS = new Set(['z2ui5_cl_smp_app_000']);
 // demo token is fully migrated. A class that does not carry it is not a sample.
 const SAMPLE_PREFIX = 'z2ui5_cl_smp_app';
 
+// Where a `" @docs` line has to point. Anything else is a typo or a link to
+// somewhere that is not the documentation, and both are worth refusing rather
+// than rendering.
+const DOCS_SITE = 'https://abap2ui5.github.io/docs/';
+
 function walk(dir, out = []) {
   for (const name of fs.readdirSync(dir)) {
     const full = path.join(dir, name);
@@ -135,6 +140,19 @@ function scanSamples() {
     // is reported by the extended check.
     const keywords = (source.match(/^" @keywords (.+?)\r?$/m) || [, ''])[1].trim();
 
+    // the chapter of abap2UI5/docs that explains what this sample demonstrates,
+    // as full URLs so the line is useful to somebody reading the class itself -
+    // which is the point: a search engine drops people into a class, and until
+    // now the code was all they got. The documentation declares the same pair
+    // from its side (docs/scripts/link-samples.mjs) and its check fails when the
+    // two disagree, so neither direction can rot on its own.
+    const docs = (source.match(/^" @docs (.+?)\r?$/m) || [, ''])[1].trim().split(/\s+/).filter(Boolean);
+    for (const url of docs) {
+      if (!url.startsWith(DOCS_SITE)) {
+        throw new Error(`@docs of ${cls} is not a documentation URL: ${url} (expected ${DOCS_SITE}...)`);
+      }
+    }
+
     // demo kit rebuilds (AGENTS.md section 1) carry the full, untruncated demo
     // kit description as ABAP Doc lines below the URL line - prefer it as sub
     // over the 60-char DESCRIPT. The Rebuild line may be preceded by marker
@@ -158,6 +176,7 @@ function scanSamples() {
       base: headerBase(header),
       sub: fullSub,
       keywords,
+      docs,
       // repository-relative folder of the class, so a link to the source can
       // be built - the class name does not encode the folder
       // (FOLDER_LOGIC=PREFIX), so only the scan knows where a sample lives
@@ -202,4 +221,4 @@ function scanSamples() {
   return { areas, hidden };
 }
 
-module.exports = { ROOT, SRC, AREAS, scanSamples, headerBase };
+module.exports = { ROOT, SRC, AREAS, DOCS_SITE, scanSamples, headerBase };

--- a/src/00/97/z2ui5_cl_smp_app_141.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_141.clas.abap
@@ -1,4 +1,5 @@
 " @keywords popup dialog change control backend control_by_id update running
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popup
 CLASS z2ui5_cl_smp_app_141 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_321.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_321.clas.abap
@@ -1,4 +1,5 @@
 " @keywords app state url bookmark restore set_app_state_active reload deep link
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share
 CLASS z2ui5_cl_smp_app_321 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_322.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_322.clas.abap
@@ -1,4 +1,5 @@
 " @keywords push state browser history back button hash url set_push_state
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/routing
 CLASS z2ui5_cl_smp_app_322 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_323.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_323.clas.abap
@@ -1,4 +1,5 @@
 " @keywords app state share clipboard copy link colleague send url
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share
 CLASS z2ui5_cl_smp_app_323 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/00/97/z2ui5_cl_smp_app_468.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_468.clas.abap
@@ -1,4 +1,5 @@
 " @keywords routing mode fresh navigation restart new instance nav_app_call
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/routing
 "! Hash-based app routing (UI5 Router style), mode FRESH:
 "! follow_up_action( cs_event-set_nav_routing ) with mode FRESH makes the URL
 "! mirror the running app by CLASS only ('#/app/[CLASS]'). Browser Back/Forward - and a

--- a/src/00/97/z2ui5_cl_smp_app_480.clas.abap
+++ b/src/00/97/z2ui5_cl_smp_app_480.clas.abap
@@ -1,4 +1,5 @@
 " @keywords routing mode keep navigation state preserved back nav_app_call
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/routing
 "! Hash-based app routing (UI5 Router style), mode KEEP:
 "! follow_up_action( cs_event-set_nav_routing ) with mode KEEP makes the URL
 "! carry the app-state draft as well ('#/app/[CLASS]/[DRAFT]'), so Back/Forward

--- a/src/01/z2ui5_cl_smp_app_004.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_004.clas.abap
@@ -1,4 +1,5 @@
 " @keywords roundtrip restart second view uncaught error controller basics
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle https://abap2ui5.github.io/docs/cookbook/expert_more/snippets
 CLASS z2ui5_cl_smp_app_004 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_006.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_006.clas.abap
@@ -1,4 +1,5 @@
 " @keywords growing 10000 rows sticky toolbar sort performance
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_006 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_008.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_008.clas.abap
@@ -1,4 +1,5 @@
 " @keywords t100 message class number exception cx_root error abend
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/exception https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_008 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_009.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_009.clas.abap
@@ -1,4 +1,5 @@
 " @keywords f4 search help suggestion input dialog select
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popup https://abap2ui5.github.io/docs/cookbook/expert_more/value_help
 CLASS z2ui5_cl_smp_app_009 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_011.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_011.clas.abap
@@ -1,4 +1,5 @@
 " @keywords edit input add row delete multiselect toolbar
+" @docs https://abap2ui5.github.io/docs/get_started/full_example https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_011 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_012.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_012.clas.abap
@@ -1,4 +1,5 @@
 " @keywords dialog sub app destroy rerender background view
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popup
 CLASS z2ui5_cl_smp_app_012 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_019.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_019.clas.abap
@@ -1,4 +1,5 @@
 " @keywords selectionmode none single multi segmentedbutton checkbox
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_019 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_024.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_024.clas.abap
@@ -1,4 +1,5 @@
 " @keywords nav_app_call nav_app_leave sub app stack call back
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation
 CLASS z2ui5_cl_smp_app_024 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_026.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_026.clas.abap
@@ -1,4 +1,5 @@
 " @keywords placement anchor button confirm cancel popover_display
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover
 CLASS z2ui5_cl_smp_app_026 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_027.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_027.clas.abap
@@ -1,4 +1,5 @@
 " @keywords formatter parts conditional regexp visible enabled syntax
+" @docs https://abap2ui5.github.io/docs/cookbook/model/expression_binding
 CLASS z2ui5_cl_smp_app_027 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_028.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_028.clas.abap
@@ -1,4 +1,5 @@
 " @keywords interval polling auto refresh follow_up_action seconds
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/timer
 CLASS z2ui5_cl_smp_app_028 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_045.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_045.clas.abap
@@ -1,4 +1,5 @@
 " @keywords filter server side form growing where
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_045 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_047.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_047.clas.abap
@@ -1,4 +1,5 @@
 " @keywords type conversion sum amount number field
+" @docs https://abap2ui5.github.io/docs/cookbook/model/binding
 CLASS z2ui5_cl_smp_app_047 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_050.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_050.clas.abap
@@ -1,4 +1,5 @@
 " @keywords style stylesheet inline html class own design
+" @docs https://abap2ui5.github.io/docs/cookbook/view/definition
 CLASS z2ui5_cl_smp_app_050 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_052.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_052.clas.abap
@@ -1,4 +1,5 @@
 " @keywords list report dynamicpage row link details table
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover
 CLASS z2ui5_cl_smp_app_052 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_053.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_053.clas.abap
@@ -1,4 +1,5 @@
 " @keywords search go enter server side where
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_053 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_059.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_059.clas.abap
@@ -1,4 +1,5 @@
 " @keywords live search parallel requests busy queue typing
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_059 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_061.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_061.clas.abap
@@ -1,4 +1,5 @@
 " @keywords generic data reference create data ddic dynamic itab
+" @docs https://abap2ui5.github.io/docs/cookbook/model/binding
 CLASS z2ui5_cl_smp_app_061 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_064.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_064.clas.abap
@@ -1,4 +1,5 @@
 " @keywords progressindicator busy wait long running backend
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/timer
 CLASS z2ui5_cl_smp_app_064 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_065.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_065.clas.abap
@@ -1,4 +1,5 @@
 " @keywords nest_view_display rerender model refresh sub view
+" @docs https://abap2ui5.github.io/docs/cookbook/view/nested_views
 CLASS z2ui5_cl_smp_app_065 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_067.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_067.clas.abap
@@ -1,4 +1,5 @@
 " @keywords amount decimals leading zeros number format
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_067 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -1,4 +1,5 @@
 " @keywords grid alv dynamicpage column row action currency search sort filter
+" @docs https://abap2ui5.github.io/docs/get_started/full_example https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_070 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_071.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_071.clas.abap
@@ -1,4 +1,5 @@
 " @keywords combobox jsonmodel size limit large itab 100 entries
+" @docs https://abap2ui5.github.io/docs/cookbook/model/size_limit
 CLASS z2ui5_cl_smp_app_071 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_073.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_073.clas.abap
@@ -1,4 +1,5 @@
 " @keywords url window open_new_tab link target
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling
 CLASS z2ui5_cl_smp_app_073 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -1,4 +1,5 @@
 " @keywords fileuploader base64 attachment import picture document
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/upload_download
 CLASS z2ui5_cl_smp_app_074 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -1,4 +1,5 @@
 " @keywords multiinput token tokens suggestion custom control
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/value_help
 CLASS z2ui5_cl_smp_app_078 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_081.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_081.clas.abap
@@ -1,4 +1,5 @@
 " @keywords list selection placement anchor
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover
 CLASS z2ui5_cl_smp_app_081 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -1,4 +1,5 @@
 " @keywords navcontainer icontabbar icontabheader page switch control_by_id whitelisted
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action
 CLASS z2ui5_cl_smp_app_088 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_097.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_097.clas.abap
@@ -1,4 +1,5 @@
 " @keywords fcl master detail list report two column split
+" @docs https://abap2ui5.github.io/docs/cookbook/view/nested_views
 CLASS z2ui5_cl_smp_app_097 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_098.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_098.clas.abap
@@ -1,4 +1,5 @@
 " @keywords fcl three column detail detail deep navigation
+" @docs https://abap2ui5.github.io/docs/cookbook/view/nested_views
 CLASS z2ui5_cl_smp_app_098 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_104.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_104.clas.abap
@@ -1,4 +1,5 @@
 " @keywords sub app class embed instantiate another app rtti
+" @docs https://abap2ui5.github.io/docs/cookbook/view/nested_views
 CLASS z2ui5_cl_smp_app_104 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_109.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_109.clas.abap
@@ -1,4 +1,5 @@
 " @keywords quickview contact card links grouped fields
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover
 CLASS z2ui5_cl_smp_app_109 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -1,4 +1,5 @@
 " @keywords gps position latitude longitude altitude location
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/geolocation
 CLASS z2ui5_cl_smp_app_120 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_122.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_122.clas.abap
@@ -1,4 +1,5 @@
 " @keywords client info ui5 version theme os user agent device
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/info
 CLASS z2ui5_cl_smp_app_122 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_125.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_125.clas.abap
@@ -1,4 +1,5 @@
 " @keywords document.title tab caption headline set_title
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/title
 CLASS z2ui5_cl_smp_app_125 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_133.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_133.clas.abap
@@ -1,4 +1,5 @@
 " @keywords cursor set_focus selection position textfield
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus
 CLASS z2ui5_cl_smp_app_133 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_143.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_143.clas.abap
@@ -1,4 +1,5 @@
 " @keywords column filter reset refresh uitableext grid alv
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_143 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_144.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_144.clas.abap
@@ -1,4 +1,5 @@
 " @keywords cell input internal table row field level
+" @docs https://abap2ui5.github.io/docs/cookbook/model/binding
 CLASS z2ui5_cl_smp_app_144 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_160.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_160.clas.abap
@@ -1,4 +1,5 @@
 " @keywords cell enter row index event grid alv
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_160 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_161.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_161.clas.abap
@@ -1,4 +1,5 @@
 " @keywords nested stack popup in popup second dialog
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popup
 CLASS z2ui5_cl_smp_app_161 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_166.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_166.clas.abap
@@ -1,4 +1,5 @@
 " @keywords structure component include flat form level
+" @docs https://abap2ui5.github.io/docs/cookbook/model/binding
 CLASS z2ui5_cl_smp_app_166 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_167.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_167.clas.abap
@@ -1,4 +1,5 @@
 " @keywords argument parameter payload event data fixed value
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/backend
 CLASS z2ui5_cl_smp_app_167 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_170.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_170.clas.abap
@@ -1,4 +1,5 @@
 " @keywords navcontainer dialog pages back forward
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popup
 CLASS z2ui5_cl_smp_app_170 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_173.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_173.clas.abap
@@ -1,4 +1,5 @@
 " @keywords template repeat runtime generated columns if then else
+" @docs https://abap2ui5.github.io/docs/cookbook/view/xml_templating
 CLASS z2ui5_cl_smp_app_173 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_176.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_176.clas.abap
@@ -1,4 +1,5 @@
 " @keywords template repeat runtime generated nested nest_view_display
+" @docs https://abap2ui5.github.io/docs/cookbook/view/nested_views https://abap2ui5.github.io/docs/cookbook/view/xml_templating
 CLASS z2ui5_cl_smp_app_176 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_186.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_186.clas.abap
@@ -1,4 +1,5 @@
 " @keywords export save base64 attachment xstring document
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/upload_download
 CLASS z2ui5_cl_smp_app_186 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_189.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_189.clas.abap
@@ -1,4 +1,5 @@
 " @keywords cursor enter tab next field form set_focus
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus
 CLASS z2ui5_cl_smp_app_189 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_197.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_197.clas.abap
@@ -1,4 +1,5 @@
 " @keywords facetfilter filter object marshalling selected items
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/backend
 CLASS z2ui5_cl_smp_app_197 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_202.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_202.clas.abap
@@ -1,4 +1,5 @@
 " @keywords wizard step branching discardprogress setnextstep control_by_id
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action
 CLASS z2ui5_cl_smp_app_202 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_255.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_255.clas.abap
@@ -1,4 +1,5 @@
 " @keywords flexbox layout responsive navigation tile panel
+" @docs https://abap2ui5.github.io/docs/cookbook/view/definition
 CLASS z2ui5_cl_smp_app_255 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_279.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_279.clas.abap
@@ -1,4 +1,5 @@
 " @keywords dirty unsaved changes leave confirmation warning
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation
 CLASS z2ui5_cl_smp_app_279 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -1,4 +1,5 @@
 " @keywords camera photo picture webcam capture facing mode
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/camera
 CLASS z2ui5_cl_smp_app_306 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_316.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_316.clas.abap
@@ -1,4 +1,5 @@
 " @keywords mailto tel sms urlhelper redirect native link
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling
 CLASS z2ui5_cl_smp_app_316 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -1,4 +1,5 @@
 " @keywords clipboard paste copy text area
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/clipboard
 CLASS z2ui5_cl_smp_app_325 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_327.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_327.clas.abap
@@ -1,4 +1,5 @@
 " @keywords localstorage sessionstorage persist store_data offline
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/clipboard
 CLASS z2ui5_cl_smp_app_327 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_352.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_352.clas.abap
@@ -1,4 +1,5 @@
 " @keywords mobile numeric keypad keyboard_set_mode phone input
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/soft_keyboard
 CLASS z2ui5_cl_smp_app_352 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_362.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_362.clas.abap
@@ -1,4 +1,5 @@
 " @keywords position pixel scroll_to restore refresh toolbar
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/scrolling
 CLASS z2ui5_cl_smp_app_362 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_363.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_363.clas.abap
@@ -1,4 +1,5 @@
 " @keywords scroll_into_view control id validation jump
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/scrolling
 CLASS z2ui5_cl_smp_app_363 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_381.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_381.clas.abap
@@ -1,4 +1,5 @@
 " @keywords toast notification duration position animation
+" @docs https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_381 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_382.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_382.clas.abap
@@ -1,4 +1,5 @@
 " @keywords confirm warning error success information dialog action
+" @docs https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_382 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_421.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_421.clas.abap
@@ -1,4 +1,5 @@
 " @keywords table cell column row aggregation set_focus
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/focus
 CLASS z2ui5_cl_smp_app_421 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_445.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_445.clas.abap
@@ -1,4 +1,5 @@
 " @keywords sap.ui.device responsive orientation resize media model
+" @docs https://abap2ui5.github.io/docs/cookbook/model/device_model https://abap2ui5.github.io/docs/cookbook/device_capabilities/info
 CLASS z2ui5_cl_smp_app_445 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_448.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_448.clas.abap
@@ -1,4 +1,5 @@
 " @keywords panel collapse expand setexpanded control_by_id whitelisted
+" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action
 CLASS z2ui5_cl_smp_app_448 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_449.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_449.clas.abap
@@ -1,4 +1,5 @@
 " @keywords pdfviewer pdf document viewer popup control_by_id whitelisted
+" @docs https://abap2ui5.github.io/docs/cookbook/device_capabilities/pdf https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action
 CLASS z2ui5_cl_smp_app_449 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_450.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_450.clas.abap
@@ -1,4 +1,5 @@
 " @keywords dats tims conversion initial date 00000000 sy-datum
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_450 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_452.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_452.clas.abap
@@ -1,4 +1,5 @@
 " @keywords messagepopover messageitem dialog grouped message list
+" @docs https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_452 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_453.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_453.clas.abap
@@ -1,4 +1,5 @@
 " @keywords no formatter computed backend thin frontend prepare
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_453 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_456.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_456.clas.abap
@@ -1,4 +1,5 @@
 " @keywords planningcalendar appointment javascript date object iso
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_456 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_457.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_457.clas.abap
@@ -1,4 +1,5 @@
 " @keywords datepicker datevalue javascript date object iso
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_457 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -1,4 +1,5 @@
 " @keywords dnd dragdropinfo reorder rows move
+" @docs https://abap2ui5.github.io/docs/cookbook/model/tables
 CLASS z2ui5_cl_smp_app_459 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_460.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_460.clas.abap
@@ -1,4 +1,5 @@
 " @keywords hierarchy nodes nested json items
+" @docs https://abap2ui5.github.io/docs/cookbook/model/trees
 CLASS z2ui5_cl_smp_app_460 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -1,4 +1,5 @@
 " @keywords dnd move node hierarchy binding context
+" @docs https://abap2ui5.github.io/docs/cookbook/model/trees
 CLASS z2ui5_cl_smp_app_461 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -1,4 +1,5 @@
 " @keywords popup expand state hierarchy nodes
+" @docs https://abap2ui5.github.io/docs/cookbook/model/trees
 CLASS z2ui5_cl_smp_app_462 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -1,4 +1,5 @@
 " @keywords customtreeitem rename input binding write back
+" @docs https://abap2ui5.github.io/docs/cookbook/model/trees
 CLASS z2ui5_cl_smp_app_463 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_464.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_464.clas.abap
@@ -1,4 +1,5 @@
 " @keywords exception dump error handling debugtool restart retry
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/exception
 CLASS z2ui5_cl_smp_app_464 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_465.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_465.clas.abap
@@ -1,4 +1,5 @@
 " @keywords toggleby open close control_by_id whitelisted
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover https://abap2ui5.github.io/docs/cookbook/expert_more/follow_up_action
 CLASS z2ui5_cl_smp_app_465 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_466.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_466.clas.abap
@@ -1,4 +1,5 @@
 " @keywords icon glyph placeholder text status expandinlineicons
+" @docs https://abap2ui5.github.io/docs/cookbook/model/formatter
 CLASS z2ui5_cl_smp_app_466 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_467.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_467.clas.abap
@@ -1,4 +1,5 @@
 " @keywords messagemanager validation target field state central model
+" @docs https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_467 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -1,4 +1,5 @@
 " @keywords element binding relative path aggregation dialog row
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/frontend https://abap2ui5.github.io/docs/cookbook/popup_popover/popup
 "! Aggregation binding on a popup via an element bind. The main table is bound
 "! to the product aggregation ({/T_PRODUCT}); pressing a row's "components"
 "! button opens a popup that uses RELATIVE bindings only ({NAME}, {CATEGORY}, and

--- a/src/01/z2ui5_cl_smp_app_471.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_471.clas.abap
@@ -1,4 +1,5 @@
 " @keywords shortcut hotkey ctrl key combination keyboard_shortcut
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/keyboard_shortcuts
 CLASS z2ui5_cl_smp_app_471 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_472.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_472.clas.abap
@@ -1,4 +1,5 @@
 " @keywords link href default action check_prevent_default
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/frontend
 CLASS z2ui5_cl_smp_app_472 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_474.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_474.clas.abap
@@ -1,4 +1,5 @@
 " @keywords url policy link security validator relative allow deny
+" @docs https://abap2ui5.github.io/docs/cookbook/translation_messages/message
 CLASS z2ui5_cl_smp_app_474 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_488.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_488.clas.abap
@@ -1,4 +1,5 @@
 " @keywords r_data result get_app_prev return event payload
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/navigation
 "! Calls a second app (z2ui5_cl_smp_app_489) via client->nav_app_call( ). The
 "! called app comes back with client->nav_app_leave( event = ... r_data = ... ),
 "! handing an event name and a data payload to its caller without knowing who

--- a/src/01/z2ui5_cl_smp_app_490.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_490.clas.abap
@@ -1,4 +1,5 @@
 " @keywords initial render one roundtrip anchor button
+" @docs https://abap2ui5.github.io/docs/cookbook/popup_popover/popover
 "! View and popover in ONE roundtrip: view_display( ) and popover_display( )
 "! from the same main( ) call. The popover anchors to a button of the view
 "! that is built in this very response - the framework runs the display

--- a/src/01/z2ui5_cl_smp_app_491.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_491.clas.abap
@@ -1,4 +1,5 @@
 " @keywords favicon icon tab image data uri
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/title
 CLASS z2ui5_cl_smp_app_491 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_492.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_492.clas.abap
@@ -1,4 +1,5 @@
 " @keywords reload refresh restart location_reload url
+" @docs https://abap2ui5.github.io/docs/cookbook/browser_interaction/url_handling
 CLASS z2ui5_cl_smp_app_492 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_493.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_493.clas.abap
@@ -1,4 +1,5 @@
 " @keywords hello world smallest first app minimal start here template
+" @docs https://abap2ui5.github.io/docs/get_started/hello_world https://abap2ui5.github.io/docs/cookbook/view/definition https://abap2ui5.github.io/docs/cookbook/expert_more/snippets
 CLASS z2ui5_cl_smp_app_493 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_494.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_494.clas.abap
@@ -1,4 +1,5 @@
 " @keywords binding _bind model attribute value input button serialize
+" @docs https://abap2ui5.github.io/docs/cookbook/model/binding
 CLASS z2ui5_cl_smp_app_494 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_495.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_495.clas.abap
@@ -1,4 +1,5 @@
 " @keywords lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated
+" @docs https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle https://abap2ui5.github.io/docs/cookbook/expert_more/snippets
 CLASS z2ui5_cl_smp_app_495 DEFINITION PUBLIC.
 
   PUBLIC SECTION.

--- a/src/01/z2ui5_cl_smp_app_496.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_496.clas.abap
@@ -1,4 +1,5 @@
 " @keywords developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export
+" @docs https://abap2ui5.github.io/docs/cookbook/troubleshooting/common_failures
 CLASS z2ui5_cl_smp_app_496 DEFINITION PUBLIC.
 
   PUBLIC SECTION.


### PR DESCRIPTION
Somebody who lands in this repository from a search engine lands in a class. `z2ui5_cl_smp_app_009` is 200 lines of working ABAP and says nothing about *why* an F4 help is built that way, what the alternatives are, or which release the pattern needs. That is written down — in the documentation — and nothing here pointed at it.

The other direction is worse: an AI agent can query this catalogue by keyword (abap2UI5/ai-mcp, the `examples` tool), and the human reading the docs had only a link to the repository **root** — 300 files whose names encode nothing.

## What changes

The pairing gets written down once, and both sides read it:

```abap
" @keywords f4 search help suggestion input dialog select
" @docs https://abap2ui5.github.io/docs/cookbook/expert_more/value_help
CLASS z2ui5_cl_smp_app_009 DEFINITION PUBLIC.
```

96 classes now carry it, and `SAMPLES.md` renders it under the keywords. Full URLs rather than paths, because the line has to work where it is actually met — in the class, in a browser, from a search result.

## Declared on the documentation side, not here

A cookbook page lists its samples in frontmatter and generates its own block of links from this catalogue, and **that generator fails when a class it links to does not point back** (abap2UI5/docs#138). Neither half can rot quietly, which is the only reason a hand-written cross-repository link is worth having at all.

Adding a `" @docs` line here that no page declares makes that check red — add the page's `samples:` entry first. `AGENTS.md` §4 says so.

The scan refuses a `@docs` line that is not a documentation URL, the same way it already refuses a backtick: a typo here renders as a broken link on a page nobody would think to check.

## Verification

- `npm run launchpad` → 97 tiles, `SAMPLES.md` regenerated
- `npx abaplint` → 0 issues, 317 files
- the overview app is untouched: a tile has no room for a link out, and a reader already inside the overview is not looking for one

## Merge order

**Stacked on #766** — both changes insert a comment line above `CLASS` in the same six `src/00/97` classes, so they conflict if they land independently. The base of this PR is `claude/keywords-gate`; GitHub retargets it to `main` automatically once #766 merges, and the diff shown here is only the `@docs` work.

Then merge this **before** abap2UI5/docs#138 — that PR's new check reads the `" @docs` lines from `main` here.