### PR TITLE
Check against every abaplint rule, and give every app the navigated branch

### DIFF
--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "84 rules passed",
-  "color": "4c1",
+  "message": "20 errors",
+  "color": "e05d44",
   "labelColor": "555",
   "cacheSeconds": 3600
 }

--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "85 problems",
-  "color": "dfb317",
+  "message": "86 rules passed",
+  "color": "4c1",
   "labelColor": "555",
   "cacheSeconds": 3600
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,27 +738,50 @@ By hand, because no script covers them:
 - Configuration: `abaplint.jsonc`
 - Install: `npm install -g @abaplint/cli`
 - Run: `abaplint`
+- **The rule block is byte-identical in three repositories** — this one,
+  [samples-controls](https://github.com/abap2UI5/samples-controls) and
+  [samples-stack](https://github.com/abap2UI5/samples-stack) — the same way
+  `scripts/chain-format.mjs` already is. **Change it in one and copy it to
+  the other two**, then re-run that repository's gates: what is checked is a
+  joint decision of the three corpora, not a local preference.
+  - abaplint has no `extends`, so there is no shared file to include — the
+    copy is the mechanism, and the block carries a header saying so.
+  - Only `global`, `dependencies` and `syntax` are per repository (release
+    floor, dependency set, suppressions) — plus exactly **one** rule:
+    `object_naming`, which encodes the repository's token (SMP / SMPC /
+    SMPS). It sits last in the file behind a marker that says so. Everything
+    above that marker must be identical.
 - **Every rule abaplint ships is listed in the config — all 188 of them**
-  (2026-08-16; it was 17 before, the rest defaulting to off unnoticed). 174
-  are on. **A rule is never left out of the file.** When an abaplint upgrade
-  adds one, add the key: on if the corpus passes, off with the reason in a
-  comment above it if it does not. Leaving it unlisted is how the previous
-  gap opened, and an unlisted rule reads as "nobody decided" rather than
-  "decided against".
-- The 14 that are off carry their reason in the file. In short: four rules
+  (2026-08-16; it was 17 here, 44 in samples-controls and 41 in
+  samples-stack, the rest defaulting to off unnoticed). 171 are on. **A rule
+  is never left out of the file.** When an abaplint upgrade adds one, add
+  the key in all three: on if all three corpora pass, off with the reason in
+  a comment above it if they do not. An unlisted rule reads as "nobody
+  decided" rather than "decided against".
+- The 17 that are off carry their reason in the file. In short: four rules
   want Hungarian notation and `no_public_attributes` wants the model hidden,
-  both against §7 and §9; `abapdoc` treats demos as a published API; six
-  rules read a view builder chain as a malformed parameter list, and that
-  layout has its own gate (`npm run check:chains`, §10); `prefer_inline` /
+  both against §7 and §9; `abapdoc` treats demos as a published API; seven
+  rules read a view builder chain or a `VALUE #( )` data table as a
+  malformed parameter list, and that layout has its own gate
+  (`npm run check:chains`, §10); `prefer_inline` /
   `no_inline_in_optional_branches` move declarations the samples place
-  deliberately; and `prefer_corresponding` proposes a rewrite that does not
-  activate on a generic field symbol.
-- Three rules run with flags off rather than wholesale: `check_subrc`
-  (`selectSingle`, `selectTable` — "no rows" is a legitimate state here, and
-  the SELECT either feeds a binding or is read back with `OPTIONAL`),
-  `dangerous_statement` (`dynamicSQL` — it is the subject of the generic
-  table browser samples in `src/00/98`) and `double_space` (`keywords` — it
-  would strip the corpus' column alignment).
+  deliberately; `prefer_corresponding` proposes a rewrite that does not
+  activate on a generic field symbol; and `smim_consistency` cannot resolve
+  a MIME folder that lives on the system.
+- Several rules run with flags off or an `exclude` rather than wholesale.
+  The ones worth knowing here: `check_subrc` (`selectSingle`, `selectTable`
+  — "no rows" is a legitimate state, and the SELECT either feeds a binding
+  or is read back with `OPTIONAL`), `dangerous_statement` (`dynamicSQL` — it
+  is the subject of the generic table browser samples in `src/00/98`),
+  `double_space` (`keywords` and `endParen` — both would strip deliberate
+  column alignment), `no_yoda_conditions` (`onlyConstants` — unrestricted it
+  demands `lines( t ) < i` instead of `i > lines( t )`) and
+  `empty_structure` (`when` — an event that only needs the round-trip is a
+  legitimate empty branch, with a comment where the code would be).
+  - An `exclude` that names another repository's files is **not** noise here:
+    it is what lets one block serve three corpora. `z2ui5_cl_smps_bp_*`
+    matches nothing under this `src/`, and removing it would break
+    samples-stack on the next copy.
 - **Write the flag set out in full when configuring a rule.** abaplint
   replaces the whole options object, so a partial one silently turns every
   flag it omits *off* — `"check_subrc": { "selectTable": false }` disables

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,6 +738,31 @@ By hand, because no script covers them:
 - Configuration: `abaplint.jsonc`
 - Install: `npm install -g @abaplint/cli`
 - Run: `abaplint`
+- **Every rule abaplint ships is listed in the config — all 188 of them**
+  (2026-08-16; it was 17 before, the rest defaulting to off unnoticed). 174
+  are on. **A rule is never left out of the file.** When an abaplint upgrade
+  adds one, add the key: on if the corpus passes, off with the reason in a
+  comment above it if it does not. Leaving it unlisted is how the previous
+  gap opened, and an unlisted rule reads as "nobody decided" rather than
+  "decided against".
+- The 14 that are off carry their reason in the file. In short: four rules
+  want Hungarian notation and `no_public_attributes` wants the model hidden,
+  both against §7 and §9; `abapdoc` treats demos as a published API; six
+  rules read a view builder chain as a malformed parameter list, and that
+  layout has its own gate (`npm run check:chains`, §10); `prefer_inline` /
+  `no_inline_in_optional_branches` move declarations the samples place
+  deliberately; and `prefer_corresponding` proposes a rewrite that does not
+  activate on a generic field symbol.
+- Three rules run with flags off rather than wholesale: `check_subrc`
+  (`selectSingle`, `selectTable` — "no rows" is a legitimate state here, and
+  the SELECT either feeds a binding or is read back with `OPTIONAL`),
+  `dangerous_statement` (`dynamicSQL` — it is the subject of the generic
+  table browser samples in `src/00/98`) and `double_space` (`keywords` — it
+  would strip the corpus' column alignment).
+- **Write the flag set out in full when configuring a rule.** abaplint
+  replaces the whole options object, so a partial one silently turns every
+  flag it omits *off* — `"check_subrc": { "selectTable": false }` disables
+  the rule entirely instead of narrowing it.
 
 ### abap2UI5-linter
 
@@ -877,6 +902,23 @@ manually or via editor tooling that the above rules are met.
 - ABAP Doc is parsed as HTML: escape a literal `<`, `>` or `&` as `&lt;`, `&gt;`, `&amp;`.
 - Always run `abaplint` after every change. It must report 0 issues before committing.
 - Before starting app development, read all active rules in `abaplint.jsonc` and follow them throughout.
+- **The rules that most often bite when writing a new sample** (all of them
+  enforced since 2026-08-16, see §6):
+  - A table type is `WITH EMPTY KEY`, never `WITH DEFAULT KEY`.
+  - A local type name starts with `ty_` (`ty_s_` / `ty_t_`, §7 above).
+  - `CASE` needs two `WHEN` branches. One event is an `IF` — which is what §9
+    asks for anyway; `CASE` starts at four.
+  - Every `SELECT` carries an `ORDER BY` (`ORDER BY PRIMARY KEY` if the order
+    itself does not matter), and `SELECT SINGLE` needs the full key — without
+    it, use `ORDER BY PRIMARY KEY ... UP TO 1 ROWS` and read row 1.
+  - `ASSIGN` and `READ TABLE` are followed by an `sy-subrc` check. Reading an
+    unassigned field symbol dumps; a missed `READ TABLE` leaves the previous
+    work area in place, which is worse than a dump because it looks like data.
+  - An explicit `DATA` belongs at the top of its method (`definitions_top`).
+    An inline `DATA( )` at the point of use is fine and is not affected.
+  - No commented-out code, no unused variable, type or method, no empty
+    `WHEN`, no end-of-line comment, no `!` before a parameter name.
+  - Two blank lines between methods — three is a finding.
 
 ---
 

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -25,9 +25,89 @@
     "version": "v750",
     "errorNamespace": "."
   },
+  // Every rule abaplint ships is listed below - all 188 of them, so that a new
+  // rule in a new abaplint release shows up here as a missing key rather than
+  // silently defaulting. 174 are on. The 14 that are off each say why, and the
+  // reason is always one of two: the repository documents the opposite
+  // convention in AGENTS.md, or the construct belongs to the view builder
+  // chain, whose layout has its own gate (`npm run check:chains`).
+  //
+  // This replaces the 17-rule set the repository ran until 2026-08-16 - the
+  // same move samples-controls made on 2026-07-16 and samples-stack after it.
+  // The gap was not theoretical: the corpus had commented-out code in five
+  // apps, 28 variables and 6 types nobody read, two unreachable methods, seven
+  // dynamic SELECTs whose sy-subrc was never looked at, and a READ TABLE ...
+  // INDEX 1 whose result was used unconditionally (app 097).
   "rules": {
-    "exporting": true,
-    "omit_parameter_name": true,
+
+    // ---------------------------------------------------------------------
+    // Off - the repository documents the opposite convention (AGENTS.md 7)
+    // ---------------------------------------------------------------------
+    // Section 7 spells the naming scheme out: type prefixes are for tables
+    // (`t_`) and structures (`s_`) only, local types carry `ty_s_` / `ty_t_`,
+    // and scalars and object references carry no prefix at all. These four
+    // rules all want Hungarian notation instead (`^L._.+$`, `^M._.+$`,
+    // `^I._.+$`), or want the prefixes gone altogether - both directions
+    // contradict the documented scheme, so all four stay off.
+    "local_variable_names": false,
+    "class_attribute_names": false,
+    "method_parameter_names": false,
+    "no_prefixes": false,
+    // An abap2UI5 app binds its own public attributes into the view -
+    // `client->_bind( quantity )` reads the attribute the view writes back to.
+    // The public attribute IS the model, so it is not an encapsulation leak
+    // to be closed but the framework's contract (AGENTS.md 9, 11).
+    "no_public_attributes": false,
+    // These are demo apps read for their view code, not a published API. The
+    // sample's explanation lives in the overview catalog (AGENTS.md 4) and in
+    // the MessageStrip the app renders, not in an ABAP Doc block above every
+    // method. abap2UI5 itself keeps this off for the same reason.
+    "abapdoc": false,
+
+    // ---------------------------------------------------------------------
+    // Off - the view builder chain owns its own layout
+    // ---------------------------------------------------------------------
+    // A view is one statement spanning up to several hundred lines, laid out
+    // by the rules in AGENTS.md 10: one call per line, four spaces per tree
+    // level, the closing paren leading the next line. `npm run check:chains`
+    // (scripts/chain-format.mjs) is the gate for exactly that shape, and it
+    // is stricter than anything below. Every one of these rules reads the
+    // chain as a malformed parameter list - 5,087 findings from
+    // line_break_multiple_parameters alone, all of them correctly formatted
+    // chains.
+    "line_break_multiple_parameters": false,
+    "keep_single_parameter_on_one_line": false,
+    "align_parameters": false,
+    "in_statement_indentation": false,
+    "indentation": false,
+    // Blank lines inside a chain separate the view's sections - the Shell from
+    // the Page, the header from the form. They are blank lines inside one
+    // statement, which is what this rule forbids.
+    "empty_line_in_statement": false,
+
+    // ---------------------------------------------------------------------
+    // Off - the samples declare deliberately
+    // ---------------------------------------------------------------------
+    // Both rules push declarations into the branch that first uses them. The
+    // corpus does the opposite on purpose: a sample is read top-down, so its
+    // data is declared where the reader looks for it, and the shared context
+    // class carries downported shapes (`DATA temp9`, `DATA comps LIKE temp9`)
+    // that the 702 build writes and that cannot be inlined at all.
+    "prefer_inline": false,
+    "no_inline_in_optional_branches": false,
+    // The single MOVE-CORRESPONDING left in the tree
+    // (z2ui5_cl_smp_context=>itab_corresponding) copies between two generic
+    // `TYPE any` field symbols. `CORRESPONDING #( )` derives its type from the
+    // target, and a generic field symbol has none at compile time, so the
+    // rewrite abaplint proposes here parses but does not activate.
+    "prefer_corresponding": false,
+
+    // ---------------------------------------------------------------------
+    // On, with settings
+    // ---------------------------------------------------------------------
+    // Hard ABAP limit, not a convention: a longer line breaks the abapGit
+    // import with "Literals across more than one line are not allowed"
+    // (AGENTS.md 6).
     "line_length": {
       "length": 255
     },
@@ -46,27 +126,260 @@
       "severity": "Error",
       "clas": "^(?=.{1,25}$)Z2UI5_C(L|X)_SMP_"
     },
-    "downport": true,
+    // `ty_` covers the `ty_s_` / `ty_t_` scheme of AGENTS.md 7; the pattern is
+    // the one samples-controls uses, so a type moved between the two
+    // repositories keeps its name.
+    "types_naming": {
+      "pattern": "^TY_"
+    },
+    // The tree holds classes and packages today. INTF is allowed because a
+    // shared interface is a legitimate addition; anything else - a report, a
+    // table, a message class - is not, and would not survive the 702 build.
+    "allowed_object_types": {
+      "allowed": ["CLAS", "DEVC", "INTF"]
+    },
+    // `keywords` is the one flag that has to stay off: it reads the column
+    // alignment the corpus uses for keyword operands
+    // (`EXPORTING  p_name` over `RECEIVING  p_descr_ref`) as a double space
+    // and would strip it. The three flags that are left catch real
+    // sloppiness - `display(  \`text\`` and `` `text`  )`` - and found three.
+    "double_space": {
+      "keywords": false,
+      "startParen": true,
+      "endParen": true,
+      "afterColon": true
+    },
+    // Two blank lines separate methods (AGENTS.md 7), so three is already one
+    // too many. Same value as samples-controls and samples-stack.
+    "sequential_blank": {
+      "lines": 3
+    },
+    // All eight detectors on. `endselect`, `execSQL`, `kernelCall`,
+    // `communication` and `systemCall` are NOT keys of this rule any more -
+    // they moved to `dangerous_statement` below, which carries them.
+    "avoid_use": {
+      "skipQuickFix": false,
+      "define": true,
+      "statics": true,
+      "defaultKey": true,
+      "break": true,
+      "testSeams": true,
+      "describeLines": true,
+      "exportToMemory": true,
+      "exportToDatabase": true
+    },
+    // Every flag is on except dynamicSQL. `SELECT * FROM (mv_table)` is not an
+    // accident in this corpus - it is the subject of the generic table browser
+    // samples in src/00/98 (184, 190, 194, 212, 339, 342, 344), which exist to
+    // show RTTI-built tables filled from a table name the user types. The
+    // samples are in the testing package and never reach the 702 build.
+    "dangerous_statement": {
+      "execSQL": true,
+      "kernelCall": true,
+      "systemCall": true,
+      "insertReport": true,
+      "generateDynpro": true,
+      "generateReport": true,
+      "generateSubroutine": true,
+      "deleteReport": true,
+      "deleteTextpool": true,
+      "insertTextpool": true,
+      "deleteDynpro": true,
+      "exportDynpro": true,
+      "editorCallForReport": true,
+      "dynamicSQL": false,
+      "ignoreRAPQueryProvider": true
+    },
+    // Every flag is on except the two SELECT ones, and the rule earns its keep
+    // with what is left: it found nine ASSIGN obj->(`NAME`) whose result was
+    // read without checking that the component exists (a dump, not a wrong
+    // value), and three READ TABLE ... INDEX 1 whose work area was used
+    // unconditionally - app 097 inserted a stale row into the target table
+    // whenever the selection was empty. All twelve are fixed.
+    // selectSingle / selectTable are off because in this corpus "no rows" is
+    // never an error: every table SELECT either feeds a binding, where an
+    // empty table is a legitimate view, or is read back through
+    // `VALUE #( lt[ 1 ] OPTIONAL )`, which handles the empty case in the
+    // expression itself. A sy-subrc branch after those would be dead code.
+    "check_subrc": {
+      "openDataset": true,
+      "authorityCheck": true,
+      "selectSingle": false,
+      "selectTable": false,
+      "updateDatabase": true,
+      "insertDatabase": true,
+      "modifyDatabase": true,
+      "deleteDatabase": true,
+      "readTable": true,
+      "assign": true,
+      "find": true
+    },
+
+    // ---------------------------------------------------------------------
+    // On, as shipped
+    // ---------------------------------------------------------------------
+    "7bit_ascii": true,
+    "add_test_attributes": true,
+    "aff_and_xml": true,
+    "align_pseudo_comments": true,
+    "align_type_expressions": true,
+    "allowed_object_naming": true,
+    "ambiguous_statement": true,
     "begin_end_names": true,
+    "begin_single_include": true,
+    "call_transaction_authority_check": true,
+    "catch_and_raise": true,
+    "cds_association_name": true,
+    "cds_comment_style": true,
+    "cds_field_order": true,
+    "cds_legacy_view": true,
+    "cds_naming": true,
+    "cds_parser_error": true,
+    "chain_mainly_declarations": true,
+    "change_if_to_case": true,
+    "check_abstract": true,
+    "check_comments": true,
     "check_ddic": true,
     "check_include": true,
     "check_syntax": true,
+    "check_text_elements": true,
+    "check_transformation_exists": true,
+    "classic_exceptions_overlap": true,
+    "clear_exporting_parameters": true,
+    "cloud_types": true,
+    "colon_missing_space": true,
+    "commented_code": true,
+    "constant_classes": true,
+    "constructor_visibility_public": true,
+    "contains_tab": true,
+    "cyclic_oo": true,
+    "cyclomatic_complexity": true,
+    "db_operation_in_loop": true,
+    "definitions_top": true,
+    "description_empty": true,
+    "downport": true,
+    "dynpro_checks": true,
+    "easy_to_find_messages": true,
+    "empty_event": true,
+    "empty_statement": true,
+    "empty_structure": true,
+    "exit_or_check": true,
+    "expand_macros": true,
+    "exporting": true,
+    "fm_global_parameters_obsolete": true,
+    "forbidden_identifier": true,
+    "forbidden_pseudo_and_pragma": true,
+    "forbidden_void_type": true,
+    "form_tables_obsolete": true,
+    "fully_type_constants": true,
+    "fully_type_itabs": true,
+    "function_module_recommendations": true,
+    "functional_writing": true,
     "global_class": true,
-    "definitions_top": false,
+    "identical_conditions": true,
+    "identical_contents": true,
+    "identical_descriptions": true,
+    "identical_form_names": true,
+    "identical_move": true,
+    "if_in_if": true,
     "implement_methods": true,
+    "implicit_start_of_selection": true,
+    "index_completely_contained": true,
+    "inline_data_old_versions": true,
+    "intf_referencing_clas": true,
+    "invalid_table_index": true,
+    "keyword_case": true,
+    "line_break_style": true,
+    "line_only_punc": true,
+    "local_class_naming": true,
+    "local_testclass_consistency": true,
+    "macro_naming": true,
+    "main_file_contents": true,
+    "many_parentheses": true,
+    "max_one_method_parameter_per_line": true,
+    "max_one_statement": true,
+    "message_exists": true,
     "method_implemented_twice": true,
+    "method_length": true,
+    "method_overwrites_builtin": true,
+    "mix_returning": true,
+    "modify_only_own_db_tables": true,
+    "msag_consistency": true,
+    "names_no_dash": true,
+    "nesting": true,
+    "newline_between_methods": true,
+    "no_aliases": true,
+    "no_chained_assignment": true,
+    "no_comments_between_methods": true,
+    "no_exclamation_escape": true,
+    "no_external_form_calls": true,
+    "no_macros": true,
+    "no_mandt_in_database_operations": true,
+    "no_yoda_conditions": true,
+    "nrob_consistency": true,
+    "obsolete_statement": true,
+    "omit_parameter_name": true,
+    "omit_preceding_zeros": true,
+    "omit_receiving": true,
+    "parser_702_chaining": true,
+    "parser_bad_exceptions": true,
     "parser_error": true,
+    "parser_missing_space": true,
+    "pragma_style": true,
+    "prefer_is_not": true,
+    "prefer_pragmas": true,
+    "prefer_raise_exception_new": true,
+    "prefer_returning_to_exporting": true,
+    "prefer_xsdbool": true,
+    "preferred_compare_operator": true,
+    "prefix_is_current_class": true,
+    "reduce_procedural_code": true,
+    "reduce_string_templates": true,
+    "redundant_conversion": true,
+    "release_idoc": true,
+    "remove_descriptions": true,
+    "rfc_error_handling": true,
+    "select_add_order_by": true,
+    "select_performance": true,
+    "select_single_full_key": true,
+    "selection_screen_naming": true,
+    "selection_screen_texts_missing": true,
+    "short_case": true,
+    "sicf_consistency": true,
+    "slow_parameter_passing": true,
+    "smim_consistency": true,
+    "space_before_colon": true,
+    "space_before_dot": true,
+    "sql_escape_host_variables": true,
+    "sql_value_conversion": true,
+    "start_at_tab": true,
+    "static_call_via_instance": true,
+    "strict_sql": true,
     "superclass_final": true,
+    "superfluous_value": true,
+    "sy_modification": true,
+    "sy_read_restriction": true,
+    "tabl_enhancement_category": true,
+    "tables_declared_locally": true,
+    "try_without_catch": true,
+    "type_form_parameters": true,
+    "uncaught_exception": true,
     "unknown_types": true,
-    // The ABAP editor strips a trailing blank when it saves, so a line that
-    // ends in one comes back changed on the next pull - for everyone. Nothing
-    // here caught that: the port of the corpus onto z2ui5_cl_ui5_view_builder
-    // (#752) left a trailing blank on seven lines in seven app classes, all
-    // four workflows stayed green, and b7edbc6 "fix abaplint diffs" had to be
-    // found and pushed by hand. The tree is clean as of that commit, so the
-    // rule costs nothing and closes the hole. abap2UI5 has carried it for
-    // src/01 and src/02 all along.
+    "unnecessary_chaining": true,
+    "unnecessary_pragma": true,
+    "unnecessary_return": true,
+    "unreachable_code": true,
+    "unsecure_fae": true,
+    "unused_ddic": true,
+    "unused_macros": true,
+    "unused_methods": true,
+    "unused_types": true,
+    "unused_variables": true,
+    "use_bool_expression": true,
+    "use_class_based_exceptions": true,
+    "use_line_exists": true,
+    "use_new": true,
+    "when_others_last": true,
     "whitespace_end": true,
-    "xml_consistency": true
-  }
+    "xml_consistency": true  }
 }

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -2,11 +2,7 @@
   "global": {
     // Nothing is suppressed: every package under src/ is really checked, the
     // experimental and testing packages that the 702 build strips
-    // (AGENTS.md section 2) included - they pass. The
-    // on-premise samples that once needed a `noIssues` entry here, because
-    // they referenced objects no dependency below can provide
-    // (cl_apc_wsp_ext_stateless_base, icfservloc, VBELN_VA, ...), are gone:
-    // main runs on ABAP Cloud, so it carries no on-premise-only ABAP.
+    // (AGENTS.md section 2) included - they pass.
     "files": "/src/**/*.*"
   },
   "dependencies": [
@@ -25,138 +21,141 @@
     "version": "v750",
     "errorNamespace": "."
   },
-  // Every rule abaplint ships is listed below - all 188 of them, so that a new
-  // rule in a new abaplint release shows up here as a missing key rather than
-  // silently defaulting. 174 are on. The 14 that are off each say why, and the
-  // reason is always one of two: the repository documents the opposite
-  // convention in AGENTS.md, or the construct belongs to the view builder
-  // chain, whose layout has its own gate (`npm run check:chains`).
+  // ===================================================================
+  // THE RULE BLOCK BELOW IS KEPT BYTE-IDENTICAL IN THREE REPOSITORIES:
+  // abap2UI5/samples, abap2UI5/samples-controls and abap2UI5/samples-stack.
+  // Change it in one and copy it to the other two - the same rule
+  // scripts/chain-format.mjs already lives under.
   //
-  // This replaces the 17-rule set the repository ran until 2026-08-16 - the
-  // same move samples-controls made on 2026-07-16 and samples-stack after it.
-  // The gap was not theoretical: the corpus had commented-out code in five
-  // apps, 28 variables and 6 types nobody read, two unreachable methods, seven
-  // dynamic SELECTs whose sy-subrc was never looked at, and a READ TABLE ...
-  // INDEX 1 whose result was used unconditionally (app 097).
+  // The ONE exception is "object_naming", the last rule in the file: it
+  // encodes which repository you are in (SMP / SMPC / SMPS) and is the only
+  // thing above the line that may differ. Everything else - what is checked,
+  // what is not, and why - is a joint decision of the three corpora.
+  //
+  // Every rule abaplint ships is listed: all 188. 171 are on, 17 are off and
+  // each says why. A rule is NEVER left out of the file. When an abaplint
+  // upgrade adds one, add the key: on if all three corpora pass, off with the
+  // reason if they do not. An unlisted rule reads as "nobody decided" rather
+  // than "decided against", and that is exactly how samples ran 17 rules for
+  // two years without anyone noticing.
+  //
+  // WRITE A CONFIGURED RULE'S FLAGS OUT IN FULL. abaplint replaces the whole
+  // options object, so a partial one silently turns every flag it omits OFF -
+  // "check_subrc": { "selectTable": false } disables the rule entirely
+  // instead of narrowing it.
+  // ===================================================================
   "rules": {
-
-    // ---------------------------------------------------------------------
-    // Off - the repository documents the opposite convention (AGENTS.md 7)
-    // ---------------------------------------------------------------------
-    // Section 7 spells the naming scheme out: type prefixes are for tables
-    // (`t_`) and structures (`s_`) only, local types carry `ty_s_` / `ty_t_`,
-    // and scalars and object references carry no prefix at all. These four
-    // rules all want Hungarian notation instead (`^L._.+$`, `^M._.+$`,
-    // `^I._.+$`), or want the prefixes gone altogether - both directions
-    // contradict the documented scheme, so all four stay off.
+    // --- off: AGENTS.md documents the opposite convention -------------
+    // Type prefixes are for tables ("t_") and structures ("s_") only, local
+    // types carry "ty_s_" / "ty_t_", and scalars and object references carry
+    // no prefix at all. These four rules want Hungarian notation instead
+    // ("^L._.+$", "^M._.+$", "^I._.+$") or want the prefixes gone altogether.
     "local_variable_names": false,
     "class_attribute_names": false,
     "method_parameter_names": false,
     "no_prefixes": false,
     // An abap2UI5 app binds its own public attributes into the view -
-    // `client->_bind( quantity )` reads the attribute the view writes back to.
-    // The public attribute IS the model, so it is not an encapsulation leak
-    // to be closed but the framework's contract (AGENTS.md 9, 11).
+    // client->_bind( quantity ) reads the attribute the view writes back to.
+    // The public attribute IS the model, not an encapsulation leak.
     "no_public_attributes": false,
-    // These are demo apps read for their view code, not a published API. The
-    // sample's explanation lives in the overview catalog (AGENTS.md 4) and in
-    // the MessageStrip the app renders, not in an ABAP Doc block above every
-    // method. abap2UI5 itself keeps this off for the same reason.
+    // Demo apps, read for their view code, not a published API. The
+    // explanation lives in the overview catalog and in the MessageStrip the
+    // app renders. abap2UI5 keeps this off for the same reason.
     "abapdoc": false,
-
-    // ---------------------------------------------------------------------
-    // Off - the view builder chain owns its own layout
-    // ---------------------------------------------------------------------
+    // --- off: the view builder chain owns its own layout --------------
     // A view is one statement spanning up to several hundred lines, laid out
-    // by the rules in AGENTS.md 10: one call per line, four spaces per tree
-    // level, the closing paren leading the next line. `npm run check:chains`
-    // (scripts/chain-format.mjs) is the gate for exactly that shape, and it
-    // is stricter than anything below. Every one of these rules reads the
-    // chain as a malformed parameter list - 5,087 findings from
-    // line_break_multiple_parameters alone, all of them correctly formatted
-    // chains.
+    // by rules that "npm run check:chains" (scripts/chain-format.mjs) gates -
+    // and that gate is stricter than anything here. Every one of these rules
+    // reads a chain as a malformed parameter list: 5,087 findings from
+    // line_break_multiple_parameters alone, all of them correct chains.
     "line_break_multiple_parameters": false,
     "keep_single_parameter_on_one_line": false,
     "align_parameters": false,
     "in_statement_indentation": false,
     "indentation": false,
-    // Blank lines inside a chain separate the view's sections - the Shell from
-    // the Page, the header from the form. They are blank lines inside one
-    // statement, which is what this rule forbids.
+    // Blank lines inside a chain separate the view's sections - the Shell
+    // from the Page, the header from the form. Blank lines inside one
+    // statement is exactly what this rule forbids.
     "empty_line_in_statement": false,
-
-    // ---------------------------------------------------------------------
-    // Off - the samples declare deliberately
-    // ---------------------------------------------------------------------
-    // Both rules push declarations into the branch that first uses them. The
-    // corpus does the opposite on purpose: a sample is read top-down, so its
-    // data is declared where the reader looks for it, and the shared context
-    // class carries downported shapes (`DATA temp9`, `DATA comps LIKE temp9`)
-    // that the 702 build writes and that cannot be inlined at all.
+    // A chain and a VALUE #( ) data table both close with ")." on its own
+    // line - 70 of them in samples-controls, in 61 files. Same layout
+    // question as the five rules above, same answer.
+    "line_only_punc": false,
+    // --- off: the samples declare deliberately ------------------------
+    // Both rules push declarations into the branch that first uses them. A
+    // sample is read top-down, so its data is declared where the reader
+    // looks for it, and the shared context classes carry downported shapes
+    // (DATA temp9, DATA comps LIKE temp9) that cannot be inlined at all.
     "prefer_inline": false,
     "no_inline_in_optional_branches": false,
-    // The single MOVE-CORRESPONDING left in the tree
-    // (z2ui5_cl_smp_context=>itab_corresponding) copies between two generic
-    // `TYPE any` field symbols. `CORRESPONDING #( )` derives its type from the
-    // target, and a generic field symbol has none at compile time, so the
-    // rewrite abaplint proposes here parses but does not activate.
+    // --- off: the proposed rewrite does not activate ------------------
+    // The MOVE-CORRESPONDING statements left in the tree copy between two
+    // generic "TYPE any" field symbols. CORRESPONDING #( ) derives its type
+    // from the target, and a generic field symbol has none at compile time,
+    // so the rewrite parses but does not activate on a real system.
     "prefer_corresponding": false,
-
-    // ---------------------------------------------------------------------
-    // On, with settings
-    // ---------------------------------------------------------------------
+    // The two .mp3 files in samples-stack (08/01) are SMIM objects whose
+    // parent MIME folder lives on the system, not in the repository, so the
+    // rule cannot resolve it from the sources alone.
+    "smim_consistency": false,
+    // --- on, with settings --------------------------------------------
     // Hard ABAP limit, not a convention: a longer line breaks the abapGit
-    // import with "Literals across more than one line are not allowed"
-    // (AGENTS.md 6).
+    // import with "Literals across more than one line are not allowed".
     "line_length": {
       "length": 255
     },
-    // Every class carries the samples token: Z2UI5_CL_SMP_<object>.
-    // Length is capped at 25 characters by the leading lookahead. ABAP
-    // allows 30, but build_rename (see abap2UI5) replaces the namespace
-    // z2ui5 (5 chars) with up to 9, which costs 4 - so 26 is the hard
-    // ceiling and 25 keeps one character in reserve. A parallel
-    // installation therefore never needs truncation patterns.
-    // "Z2UI5_CL_SMP_" is 13 chars, so 12 remain for the object name.
-    // The legacy tokens DEMO and SAMPLE are gone - the last classes carrying
-    // them were renamed, so the alternation is dropped and only SMP is
-    // accepted.
-    "object_naming": {
-      "patternKind": "required",
-      "severity": "Error",
-      "clas": "^(?=.{1,25}$)Z2UI5_C(L|X)_SMP_"
-    },
-    // `ty_` covers the `ty_s_` / `ty_t_` scheme of AGENTS.md 7; the pattern is
-    // the one samples-controls uses, so a type moved between the two
-    // repositories keeps its name.
+    // "ty_" covers the ty_s_ / ty_t_ scheme all three repositories use.
     "types_naming": {
       "pattern": "^TY_"
     },
-    // The tree holds classes and packages today. INTF is allowed because a
-    // shared interface is a legitimate addition; anything else - a report, a
-    // table, a message class - is not, and would not survive the 702 build.
+    // The union of what the three corpora legitimately hold. samples and
+    // samples-controls are classes and packages only; samples-stack adds the
+    // RAP and on-premise objects. Anything else - a report, a function
+    // group, a message class - is still refused.
     "allowed_object_types": {
-      "allowed": ["CLAS", "DEVC", "INTF"]
+      "allowed": [
+        "CLAS",
+        "DEVC",
+        "INTF",
+        "TABL",
+        "DTEL",
+        "DDLS",
+        "BDEF",
+        "SRVD",
+        "SRVB",
+        "SICF",
+        "SAPC",
+        "SAMC",
+        "SUSH",
+        "SMIM",
+        "G4BA"
+      ]
     },
-    // `keywords` is the one flag that has to stay off: it reads the column
-    // alignment the corpus uses for keyword operands
-    // (`EXPORTING  p_name` over `RECEIVING  p_descr_ref`) as a double space
-    // and would strip it. The three flags that are left catch real
-    // sloppiness - `display(  \`text\`` and `` `text`  )`` - and found three.
+    // Two flags stay off because both read deliberate column alignment as a
+    // double space and would strip it: "keywords" aligns keyword operands
+    // (EXPORTING  p_name over RECEIVING  p_descr_ref), "endParen" aligns the
+    // rows of a literal data table before their closing paren (676 of those
+    // in samples-controls). The two that are left catch real sloppiness.
     "double_space": {
       "keywords": false,
       "startParen": true,
-      "endParen": true,
+      "endParen": false,
       "afterColon": true
     },
-    // Two blank lines separate methods (AGENTS.md 7), so three is already one
-    // too many. Same value as samples-controls and samples-stack.
+    // Two blank lines separate methods, so three is already one too many.
     "sequential_blank": {
       "lines": 3
     },
-    // All eight detectors on. `endselect`, `execSQL`, `kernelCall`,
-    // `communication` and `systemCall` are NOT keys of this rule any more -
-    // they moved to `dangerous_statement` below, which carries them.
+    // Restricted to literal constants on the left, which is the half worth
+    // having ("IF 5 = x"). Unrestricted, the rule also demands
+    // "lines( t ) < i" instead of "i > lines( t )" - 13 of those across the
+    // three corpora, and flipping them reads worse than the code it replaces.
+    "no_yoda_conditions": {
+      "onlyConstants": true
+    },
+    // All eight detectors on. endselect / execSQL / kernelCall /
+    // communication / systemCall are not keys of this rule any more - they
+    // moved to dangerous_statement below, which carries them.
     "avoid_use": {
       "skipQuickFix": false,
       "define": true,
@@ -168,11 +167,9 @@
       "exportToMemory": true,
       "exportToDatabase": true
     },
-    // Every flag is on except dynamicSQL. `SELECT * FROM (mv_table)` is not an
-    // accident in this corpus - it is the subject of the generic table browser
-    // samples in src/00/98 (184, 190, 194, 212, 339, 342, 344), which exist to
-    // show RTTI-built tables filled from a table name the user types. The
-    // samples are in the testing package and never reach the 702 build.
+    // Every flag on except dynamicSQL: "SELECT * FROM (mv_table)" is not an
+    // accident in this corpus, it is the subject of the generic table
+    // browser samples in samples/src/00/98.
     "dangerous_statement": {
       "execSQL": true,
       "kernelCall": true,
@@ -190,17 +187,15 @@
       "dynamicSQL": false,
       "ignoreRAPQueryProvider": true
     },
-    // Every flag is on except the two SELECT ones, and the rule earns its keep
-    // with what is left: it found nine ASSIGN obj->(`NAME`) whose result was
-    // read without checking that the component exists (a dump, not a wrong
-    // value), and three READ TABLE ... INDEX 1 whose work area was used
-    // unconditionally - app 097 inserted a stale row into the target table
-    // whenever the selection was empty. All twelve are fixed.
-    // selectSingle / selectTable are off because in this corpus "no rows" is
-    // never an error: every table SELECT either feeds a binding, where an
-    // empty table is a legitimate view, or is read back through
-    // `VALUE #( lt[ 1 ] OPTIONAL )`, which handles the empty case in the
-    // expression itself. A sy-subrc branch after those would be dead code.
+    // Every flag on except the two SELECT ones. The rule earns its keep with
+    // what is left - it found nine unchecked ASSIGN obj->(`NAME`) (reading
+    // an unassigned field symbol dumps) and four READ TABLE whose work area
+    // was used unconditionally, one of which inserted a stale row whenever
+    // the selection was empty.
+    // selectSingle / selectTable are off because "no rows" is never an error
+    // here: a table SELECT either feeds a binding, where an empty table is a
+    // legitimate view, or is read back through VALUE #( lt[ 1 ] OPTIONAL ),
+    // which handles the empty case in the expression itself.
     "check_subrc": {
       "openDataset": true,
       "authorityCheck": true,
@@ -214,11 +209,156 @@
       "assign": true,
       "find": true
     },
-
-    // ---------------------------------------------------------------------
-    // On, as shipped
-    // ---------------------------------------------------------------------
-    "7bit_ascii": true,
+    // Every block must have code except WHEN: an event whose only job is to
+    // force a round-trip is a legitimate empty branch, and the samples that
+    // have one say so in a comment where the code would be.
+    "empty_structure": {
+      "loop": true,
+      "loopAllowIfSubrc": true,
+      "if": true,
+      "while": true,
+      "case": true,
+      "select": true,
+      "do": true,
+      "at": true,
+      "try": true,
+      "when": false
+    },
+    // The overview app is generated (npm run overview) - its render method is
+    // one long emit, and shortening it means changing the generator's output
+    // shape, not the repository's code.
+    "method_length": {
+      "statements": 100,
+      "errorWhenEmpty": false,
+      "ignoreTestClasses": true,
+      "checkForms": true,
+      "checkFunctionModules": true,
+      "exclude": [
+        "z2ui5_cl_smpc_app_overview\\.clas\\."
+      ]
+    },
+    // On, because non-7-bit source is an abapGit round-trip hazard - and it
+    // caught 22 em-dashes and ellipses in comments, which are now ASCII.
+    // The excluded files are the ones whose DATA is non-ASCII: ports whose
+    // product descriptions, supplier names or i18n strings come from the
+    // original demo kit sample, where scripts/data-fidelity.mjs compares
+    // them against that original. Changing them to ASCII would fail that
+    // gate. app_185 is the non-breaking-space constant the sample is about.
+    "7bit_ascii": {
+      "exclude": [
+        "z2ui5_cl_smpc_app_(012|040|092|103|104|114|134|185|191|194|215|218|254|290|302|303|350|356|357|358|360)\\.clas\\.",
+        "z2ui5_cl_smpc_app_overview\\.clas\\."
+      ]
+    },
+    // --- on, scoped to what the RAP corpus can comply with -------------
+    // Excluded for samples-stack: CDS entities, actions and fields are
+    // CamelCase by definition (Ticket, TravelUuid, Activate) and the rule
+    // reads every one of them as a lower-case violation - 31 findings, all
+    // of them correct ABAP.
+    "keyword_case": {
+      "style": "upper",
+      "ignoreExceptions": true,
+      "ignoreLowerClassImplmentationStatement": true,
+      "exclude": [
+        "z2ui5_cl_smps_"
+      ],
+      "ignoreKeywords": []
+    },
+    // A RAP behavior implementation is called by the runtime, never from
+    // ABAP, so every handler in a bp_ pool reads as unused - and so does a
+    // variable a RAISE ENTITY EVENT consumes, which abaplint has no grammar
+    // for.
+    "unused_methods": {
+      "exclude": [
+        "z2ui5_cl_smps_bp_[a-z]+\\.clas\\.locals_imp\\."
+      ]
+    },
+    "unused_variables": {
+      "exclude": [
+        "z2ui5_cl_smps_bp_[a-z]+\\.clas\\.locals_imp\\."
+      ]
+    },
+    // lhc_<entity> is the name RAP mandates for a handler class; ^LCL_ is
+    // not available there.
+    "local_class_naming": {
+      "exclude": [
+        "z2ui5_cl_smps_bp_[a-z]+\\.clas\\.locals_imp\\."
+      ],
+      "patternKind": "required",
+      "local": "^LCL_.+$",
+      "exception": "^LCX_.+$",
+      "test": "^LTCL_.+$"
+    },
+    // A RAP behavior pool is ABSTRACT FINAL by definition - that is the
+    // required shape, not a mistake.
+    "check_abstract": {
+      "exclude": [
+        "z2ui5_cl_smps_bp_[a-z]+\\.clas\\."
+      ]
+    },
+    // The persistent and draft tables are referenced from the CDS and
+    // behavior definitions, which abaplint does not trace into.
+    "unused_ddic": {
+      "exclude": [
+        "z2ui5_(t|d)_smps_"
+      ]
+    },
+    // Excluded for the two apps that declare TYPE RESPONSE FOR FAILED /
+    // REPORTED EARLY - fully typed RAP syntax abaplint reads as implicit.
+    "fully_type_constants": {
+      "checkData": true,
+      "exclude": [
+        "z2ui5_cl_smps_app_(07|10)\\.clas\\."
+      ]
+    },
+    // Excluded for the RAP handler pools: their SELECT SINGLE is an
+    // aggregate (MAX( travel_id )), which returns exactly one row by
+    // definition - the rule does not model that.
+    "select_single_full_key": {
+      "allowPseudo": true,
+      "exclude": [
+        "z2ui5_cl_smps_bp_[a-z]+\\.clas\\.locals_imp\\."
+      ]
+    },
+    // Excluded for samples-stack app 319: the operator mapping there is a
+    // table written as a CASE, one WHEN per line, and splitting it costs the
+    // shape that makes it readable.
+    "max_one_statement": {
+      "exclude": [
+        "z2ui5_cl_smps_app_319\\.clas\\."
+      ]
+    },
+    // ABAP Push Channels are on-premise only and therefore absent from the
+    // steampunk API dependency, so app 489's superclass cannot be resolved
+    // and every reference to it reports as unknown.
+    "check_syntax": {
+      "exclude": [
+        "z2ui5_cl_smps_app_489(_ws)?\\.clas\\."
+      ]
+    },
+    // See check_syntax above - same class, same missing superclass.
+    "superclass_final": {
+      "exclude": [
+        "z2ui5_cl_smps_app_489_ws\\.clas\\."
+      ]
+    },
+    // Every category set to the namespace the three repositories share. The
+    // per-category SAP prefixes (ZI_, ZC_, ZR_, ...) are not the scheme here:
+    // samples-stack names its root view entities Z2UI5_R_SMPS_<object>.
+    "cds_naming": {
+      "basicInterfaceView": "Z2UI5_",
+      "compositeInterfaceView": "Z2UI5_",
+      "consumptionView": "Z2UI5_",
+      "basicRestrictedReuseView": "Z2UI5_",
+      "compositeRestrictedReuseView": "Z2UI5_",
+      "privateView": "Z2UI5_",
+      "remoteAPIView": "Z2UI5_",
+      "viewExtend": "Z2UI5_",
+      "extensionIncludeView": "Z2UI5_",
+      "derivationFunction": "Z2UI5_",
+      "abstractEntity": "Z2UI5_"
+    },
+    // --- on, as shipped -----------------------------------------------
     "add_test_attributes": true,
     "aff_and_xml": true,
     "align_pseudo_comments": true,
@@ -233,15 +373,12 @@
     "cds_comment_style": true,
     "cds_field_order": true,
     "cds_legacy_view": true,
-    "cds_naming": true,
     "cds_parser_error": true,
     "chain_mainly_declarations": true,
     "change_if_to_case": true,
-    "check_abstract": true,
     "check_comments": true,
     "check_ddic": true,
     "check_include": true,
-    "check_syntax": true,
     "check_text_elements": true,
     "check_transformation_exists": true,
     "classic_exceptions_overlap": true,
@@ -262,7 +399,6 @@
     "easy_to_find_messages": true,
     "empty_event": true,
     "empty_statement": true,
-    "empty_structure": true,
     "exit_or_check": true,
     "expand_macros": true,
     "exporting": true,
@@ -271,7 +407,6 @@
     "forbidden_pseudo_and_pragma": true,
     "forbidden_void_type": true,
     "form_tables_obsolete": true,
-    "fully_type_constants": true,
     "fully_type_itabs": true,
     "function_module_recommendations": true,
     "functional_writing": true,
@@ -288,19 +423,14 @@
     "inline_data_old_versions": true,
     "intf_referencing_clas": true,
     "invalid_table_index": true,
-    "keyword_case": true,
     "line_break_style": true,
-    "line_only_punc": true,
-    "local_class_naming": true,
     "local_testclass_consistency": true,
     "macro_naming": true,
     "main_file_contents": true,
     "many_parentheses": true,
     "max_one_method_parameter_per_line": true,
-    "max_one_statement": true,
     "message_exists": true,
     "method_implemented_twice": true,
-    "method_length": true,
     "method_overwrites_builtin": true,
     "mix_returning": true,
     "modify_only_own_db_tables": true,
@@ -315,7 +445,6 @@
     "no_external_form_calls": true,
     "no_macros": true,
     "no_mandt_in_database_operations": true,
-    "no_yoda_conditions": true,
     "nrob_consistency": true,
     "obsolete_statement": true,
     "omit_parameter_name": true,
@@ -341,13 +470,11 @@
     "rfc_error_handling": true,
     "select_add_order_by": true,
     "select_performance": true,
-    "select_single_full_key": true,
     "selection_screen_naming": true,
     "selection_screen_texts_missing": true,
     "short_case": true,
     "sicf_consistency": true,
     "slow_parameter_passing": true,
-    "smim_consistency": true,
     "space_before_colon": true,
     "space_before_dot": true,
     "sql_escape_host_variables": true,
@@ -355,7 +482,6 @@
     "start_at_tab": true,
     "static_call_via_instance": true,
     "strict_sql": true,
-    "superclass_final": true,
     "superfluous_value": true,
     "sy_modification": true,
     "sy_read_restriction": true,
@@ -370,16 +496,28 @@
     "unnecessary_return": true,
     "unreachable_code": true,
     "unsecure_fae": true,
-    "unused_ddic": true,
     "unused_macros": true,
-    "unused_methods": true,
     "unused_types": true,
-    "unused_variables": true,
     "use_bool_expression": true,
     "use_class_based_exceptions": true,
     "use_line_exists": true,
     "use_new": true,
     "when_others_last": true,
     "whitespace_end": true,
-    "xml_consistency": true  }
+    "xml_consistency": true,
+    // ===================================================================
+    // THE ONE PER-REPOSITORY RULE - everything above this line is identical
+    // in samples, samples-controls and samples-stack.
+    // ===================================================================
+    // Class names are capped at 25 characters by the leading lookahead. ABAP
+    // allows 30, but build_rename (see abap2UI5) replaces the namespace
+    // z2ui5 (5 chars) with up to 9, which costs 4 - so 26 is the hard
+    // ceiling and 25 keeps one character in reserve. A parallel installation
+    // therefore never needs truncation patterns.
+    "object_naming": {
+      "patternKind": "required",
+      "severity": "Error",
+      "clas": "^(?=.{1,25}$)Z2UI5_C(L|X)_SMP_"
+    }
+  }
 }

--- a/src/00/01/z2ui5_cl_smp_context.clas.abap
+++ b/src/00/01/z2ui5_cl_smp_context.clas.abap
@@ -76,15 +76,15 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS msg_get_t
       IMPORTING
-        VALUE(val)    TYPE any
-        VALUE(val2)   TYPE any OPTIONAL
+        val           TYPE any
+        val2          TYPE any OPTIONAL
       RETURNING
         VALUE(result) TYPE ty_t_msg.
 
     CLASS-METHODS msg_get
       IMPORTING
-        VALUE(val)    TYPE any
-        VALUE(val2)   TYPE any OPTIONAL
+        val           TYPE any
+        val2          TYPE any OPTIONAL
       RETURNING
         VALUE(result) TYPE ty_s_msg.
 
@@ -101,7 +101,7 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS rtti_get_t_attri_by_include
       IMPORTING
-        !type         TYPE REF TO cl_abap_datadescr
+        type          TYPE REF TO cl_abap_datadescr
       RETURNING
         VALUE(result) TYPE abap_component_tab.
 
@@ -138,13 +138,13 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS xml_parse
       IMPORTING
-        !xml TYPE clike
+        xml TYPE clike
       EXPORTING
-        !any TYPE any.
+        any TYPE any.
 
     CLASS-METHODS xml_stringify
       IMPORTING
-        !any          TYPE any
+        any           TYPE any
       RETURNING
         VALUE(result) TYPE string
       RAISING
@@ -164,9 +164,9 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS json_parse
       IMPORTING
-        val   TYPE any
+        val  TYPE any
       CHANGING
-        !data TYPE any.
+        data TYPE any.
 
     CLASS-METHODS c_trim_upper
       IMPORTING
@@ -176,7 +176,7 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS xml_srtti_stringify
       IMPORTING
-        !data         TYPE any
+        data          TYPE any
       RETURNING
         VALUE(result) TYPE string.
 
@@ -278,9 +278,9 @@ CLASS z2ui5_cl_smp_context DEFINITION
 
     CLASS-METHODS itab_corresponding
       IMPORTING
-        val  TYPE STANDARD TABLE
+        val TYPE STANDARD TABLE
       CHANGING
-        !tab TYPE STANDARD TABLE.
+        tab TYPE STANDARD TABLE.
 
     CLASS-METHODS itab_filter_by_val
       IMPORTING
@@ -288,7 +288,7 @@ CLASS z2ui5_cl_smp_context DEFINITION
         fields      TYPE string_table OPTIONAL
         ignore_case TYPE abap_bool DEFAULT abap_false
       CHANGING
-        !tab        TYPE STANDARD TABLE.
+        tab         TYPE STANDARD TABLE.
 
     CLASS-METHODS uuid_get_c32
       RETURNING
@@ -370,14 +370,13 @@ CLASS z2ui5_cl_smp_context DEFINITION
         nohistory   TYPE c LENGTH 1,
         ampmformat  TYPE c LENGTH 1,
       END OF ty_s_dfies,
-      ty_t_dfies TYPE STANDARD TABLE OF ty_s_dfies WITH DEFAULT KEY.
+      ty_t_dfies TYPE STANDARD TABLE OF ty_s_dfies WITH EMPTY KEY.
 
     CLASS-METHODS rtti_get_t_dfies_by_table_name
       IMPORTING
         table_name    TYPE string
       RETURNING
         VALUE(result) TYPE ty_t_dfies.
-
 
 
     CLASS-METHODS context_check_abap_cloud
@@ -435,7 +434,6 @@ CLASS z2ui5_cl_smp_context DEFINITION
         tabname       TYPE string
       RETURNING
         VALUE(result) TYPE ty_t_dfies ##NEEDED.
-
 
 
     CLASS-DATA gv_check_cloud TYPE abap_bool.
@@ -695,7 +693,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
           CONTINUE.
         ENDIF.
         IF <field> NOT IN ls_filter-t_range.
-          DELETE val.
+          DELETE val INDEX sy-tabix.
           EXIT.
         ENDIF.
 
@@ -808,8 +806,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
     DATA(lt_tab) = VALUE ty_t_range( ).
 
     itab_corresponding( EXPORTING val = val
-                        CHANGING  tab = lt_tab
-    ).
+                        CHANGING  tab = lt_tab ).
 
     LOOP AT lt_tab REFERENCE INTO DATA(lr_row).
 
@@ -854,7 +851,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
             EXIT.
           ENDIF.
         ELSE.
-          IF lv_index > lines( fields ).
+          IF lines( fields ) < lv_index.
             EXIT.
           ENDIF.
           DATA(lv_name) = fields[ lv_index ].
@@ -872,19 +869,17 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
             lv_check_found = abap_true.
             EXIT.
           ENDIF.
-        ELSE.
-          " Case-sensitive: use find() because CS is always case-insensitive
-          IF find( val = lv_value sub = lv_search ) >= 0.
-            lv_check_found = abap_true.
-            EXIT.
-          ENDIF.
+        " Case-sensitive: use find() because CS is always case-insensitive
+        ELSEIF find( val = lv_value sub = lv_search ) >= 0.
+          lv_check_found = abap_true.
+          EXIT.
         ENDIF.
 
         lv_index = lv_index + 1.
       ENDDO.
 
       IF lv_check_found = abap_false.
-        DELETE tab.
+        DELETE tab INDEX sy-tabix.
       ENDIF.
 
     ENDLOOP.
@@ -896,6 +891,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
     FIELD-SYMBOLS <tab> TYPE table.
     DATA lt_lines TYPE string_table.
     DATA lv_line TYPE string.
+    DATA lr_row TYPE REF TO data.
 
     ASSIGN val TO <tab>.
     DATA(tab) = CAST cl_abap_tabledescr( cl_abap_typedescr=>describe_by_data( <tab> ) ).
@@ -908,7 +904,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
     ENDLOOP.
     INSERT lv_line INTO TABLE lt_lines.
 
-    DATA lr_row TYPE REF TO data.
     LOOP AT <tab> REFERENCE INTO lr_row.
 
       CLEAR lv_line.
@@ -1191,15 +1186,16 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD xml_srtti_parse.
 
-    DATA srtti TYPE REF TO object.
+    DATA srtti        TYPE REF TO object.
+    DATA rtti_type    TYPE REF TO cl_abap_typedescr.
+    DATA lo_datadescr TYPE REF TO cl_abap_datadescr.
+
     CALL TRANSFORMATION id SOURCE XML rtti_data RESULT srtti = srtti.
 
-    DATA rtti_type TYPE REF TO cl_abap_typedescr.
     CALL METHOD srtti->(`GET_RTTI`)
       RECEIVING
         rtti = rtti_type.
 
-    DATA lo_datadescr TYPE REF TO cl_abap_datadescr.
     lo_datadescr ?= rtti_type.
 
     CREATE DATA result TYPE HANDLE lo_datadescr.
@@ -1210,9 +1206,10 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD xml_srtti_stringify.
 
+    DATA srtti TYPE REF TO object.
+
     IF rtti_check_class_exists( `ZCL_SRTTI_TYPEDESCR` ) = abap_true.
 
-      DATA srtti TYPE REF TO object.
       DATA(lv_classname) = `ZCL_SRTTI_TYPEDESCR`.
       CALL METHOD (lv_classname)=>(`CREATE_BY_DATA_OBJECT`)
         EXPORTING
@@ -1264,8 +1261,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
         cl_abap_structdescr=>describe_by_name( EXPORTING  p_name         = table_name
                                                RECEIVING  p_descr_ref    = DATA(lo_obj)
                                                EXCEPTIONS type_not_found = 1
-                                                          OTHERS         = 2
-            ).
+                                                          OTHERS         = 2 ).
 
         IF sy-subrc <> 0.
           RAISE EXCEPTION TYPE z2ui5_cx_smp_error
@@ -1280,8 +1276,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
             cl_abap_structdescr=>describe_by_name( EXPORTING  p_name         = table_name
                                                    RECEIVING  p_descr_ref    = lo_obj
                                                    EXCEPTIONS type_not_found = 1
-                                                              OTHERS         = 2
-            ).
+                                                              OTHERS         = 2 ).
             IF sy-subrc <> 0.
               RAISE EXCEPTION TYPE z2ui5_cx_smp_error
                 EXPORTING
@@ -1528,59 +1523,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
     comps = temp9.
 
-*    TYPES: BEGIN OF ty_s_dfies,
-*             tabname     TYPE c LENGTH 30,
-*             fieldname   TYPE c LENGTH 30,
-*             langu       TYPE c LENGTH 1,
-*             position    TYPE n LENGTH 4,
-*             offset      TYPE n LENGTH 6,
-*             domname     TYPE c LENGTH 30,
-*             rollname    TYPE c LENGTH 30,
-*             checktable  TYPE c LENGTH 30,
-*             leng        TYPE n LENGTH 6,
-*             intlen      TYPE n LENGTH 6,
-*             outputlen   TYPE n LENGTH 6,
-*             decimals    TYPE n LENGTH 6,
-*             datatype    TYPE c LENGTH 4,
-*             inttype     TYPE c LENGTH 1,
-*             reftable    TYPE c LENGTH 30,
-*             reffield    TYPE c LENGTH 30,
-*             precfield   TYPE c LENGTH 30,
-*             authorid    TYPE c LENGTH 3,
-*             memoryid    TYPE c LENGTH 20,
-*             logflag     TYPE c LENGTH 1,
-*             mask        TYPE c LENGTH 20,
-*             masklen     TYPE n LENGTH 4,
-*             convexit    TYPE c LENGTH 5,
-*             headlen     TYPE n LENGTH 2,
-*             scrlen1     TYPE n LENGTH 2,
-*             scrlen2     TYPE n LENGTH 2,
-*             scrlen3     TYPE n LENGTH 2,
-*             fieldtext   TYPE c LENGTH 60,
-*             reptext     TYPE c LENGTH 55,
-*             scrtext_s   TYPE c LENGTH 10,
-*             scrtext_m   TYPE c LENGTH 20,
-*             scrtext_l   TYPE c LENGTH 40,
-*             keyflag     TYPE c LENGTH 1,
-*             lowercase   TYPE c LENGTH 1,
-*             mac         TYPE c LENGTH 1,
-*             genkey      TYPE c LENGTH 1,
-*             noforkey    TYPE c LENGTH 1,
-*             valexi      TYPE c LENGTH 1,
-*             noauthch    TYPE c LENGTH 1,
-*             sign        TYPE c LENGTH 1,
-*             dynpfld     TYPE c LENGTH 1,
-*             f4availabl  TYPE c LENGTH 1,
-*             comptype    TYPE c LENGTH 1,
-*             lfieldname  TYPE c LENGTH 132,
-*             ltrflddis   TYPE c LENGTH 1,
-*             bidictrlc   TYPE c LENGTH 1,
-*             outputstyle TYPE n LENGTH 2,
-*             nohistory   TYPE c LENGTH 1,
-*             ampmformat  TYPE c LENGTH 1,
-*           END OF ty_s_dfies.
-*    temp10 ?= cl_abap_structdescr=>describe_by_name( `TY_S_DFIES` ).
-
     temp10 ?= cl_abap_structdescr=>describe_by_name( `DFIES` ).
 
     lo_struct = temp10.
@@ -1710,159 +1652,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
        ) INTO TABLE result.
 
     ENDLOOP.
-*            structdescr->
-*        <dfies> = structdescr->get_ddic_field_list( ).
-
-*        LOOP AT <dfies> ASSIGNING <line>.
-*
-*          LOOP AT comps INTO comp.
-*
-*            ASSIGN COMPONENT comp-name OF STRUCTURE <line> TO <value>.
-*            IF <value> IS NOT ASSIGNED.
-*              CONTINUE.
-*            ENDIF.
-*
-*            ASSIGN COMPONENT comp-name OF STRUCTURE s_dfies TO <value_dest>.
-*            IF <value_dest> IS NOT ASSIGNED.
-*              CONTINUE.
-*            ENDIF.
-*
-*            <value_dest> = <value>.
-*
-*            UNASSIGN <value>.
-*            UNASSIGN <value_dest>.
-*
-*          ENDLOOP.
-*
-*          APPEND s_dfies TO result.
-*          CLEAR s_dfies.
-*
-*        ENDLOOP.
-
-
-
-*    DATA db        TYPE REF TO object.
-*    DATA fields    TYPE REF TO object.
-*    DATA r_names   TYPE REF TO data.
-*    DATA t_param   TYPE abap_parmbind_tab.
-*    DATA field     TYPE REF TO object.
-*    DATA content   TYPE REF TO object.
-*    DATA r_content TYPE REF TO data.
-*    DATA type      TYPE REF TO object.
-*    DATA element   TYPE REF TO object.
-*    DATA tab       TYPE c LENGTH 16.
-*
-*    FIELD-SYMBOLS <any>   TYPE any.
-*    FIELD-SYMBOLS <names> TYPE STANDARD TABLE.
-*    FIELD-SYMBOLS <name>  TYPE any.
-*    FIELD-SYMBOLS <fiel>  TYPE REF TO object.
-*
-*    tab = tabname.
-*
-*    CALL METHOD (`XCO_CP_ABAP_DICTIONARY`)=>database_table
-*      EXPORTING
-*        iv_name           = tab
-*      RECEIVING
-*        ro_database_table = db.
-*
-*    ASSIGN db->(`IF_XCO_DATABASE_TABLE~FIELDS->IF_XCO_DBT_FIELDS_FACTORY~ALL`) TO <any>.
-*
-*    IF sy-subrc <> 0.
-*      RETURN.
-*    ENDIF.
-*
-*    fields = <any>.
-*
-*    CREATE DATA r_names TYPE (`SXCO_T_AD_FIELD_NAMES`).
-*    ASSIGN r_names->* TO <Names>.
-*    IF <Names> IS NOT ASSIGNED.
-*      RETURN.
-*    ENDIF.
-*
-*    CALL METHOD fields->(`IF_XCO_DBT_FIELDS~GET_NAMES`)
-*      RECEIVING
-*        rt_names = <Names>.
-*
-*    LOOP AT <Names> ASSIGNING <name>.
-*
-*      CLEAR t_param.
-*
-*      INSERT VALUE #( name  = `IV_NAME`
-*                      kind  = cl_abap_objectdescr=>exporting
-*                      value = REF #( <name> ) ) INTO TABLE t_param.
-*      INSERT VALUE #( name  = `RO_FIELD`
-*                      kind  = cl_abap_objectdescr=>receiving
-*                      value = REF #( field ) ) INTO TABLE t_param.
-*
-*      CALL METHOD db->(`IF_XCO_DATABASE_TABLE~FIELD`)
-*        PARAMETER-TABLE t_param.
-*
-*      ASSIGN t_param[ name = `RO_FIELD` ] TO FIELD-SYMBOL(<line>).
-*      IF <line> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*      ASSIGN <line>-value->* TO <fiel>.
-*      IF <fiel> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*
-*      CALL METHOD <fiel>->(`IF_XCO_DBT_FIELD~CONTENT`)
-*        RECEIVING
-*          ro_content = content.
-*
-*      CREATE DATA r_content TYPE (`IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT`).
-*      ASSIGN r_content->* TO FIELD-SYMBOL(<Content>) CASTING TYPE (`IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT`).
-*      IF <content> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*
-*      CALL METHOD content->(`IF_XCO_DBT_FIELD_CONTENT~GET`)
-*        RECEIVING
-*          rs_content = <Content>.
-*
-*      ASSIGN COMPONENT `KEY_INDICATOR` OF STRUCTURE <content> TO FIELD-SYMBOL(<key>).
-*      IF <key> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*      ASSIGN COMPONENT `SHORT_DESCRIPTION` OF STRUCTURE <content> TO FIELD-SYMBOL(<text>).
-*      IF <text> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*      ASSIGN COMPONENT `TYPE` OF STRUCTURE <content> TO FIELD-SYMBOL(<type>).
-*      IF <type> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*
-*      type = <type>.
-*
-*      CALL METHOD type->(`IF_XCO_DBT_FIELD_TYPE~GET_DATA_ELEMENT`)
-*        RECEIVING
-*          ro_data_element = element.
-*
-*      IF <text> IS INITIAL.
-*        <text> = <name>.
-*      ENDIF.
-*
-*      ASSIGN element->(`IF_XCO_AD_OBJECT~NAME`) TO FIELD-SYMBOL(<rname>).
-*      IF <rname> IS NOT ASSIGNED.
-*        CONTINUE.
-*      ENDIF.
-*
-*      IF sy-subrc = 0.
-*        result = VALUE #( BASE result
-*                          ( fieldname = <name> keyflag = <key> tabname = tab scrtext_s = <text> rollname = <rname> ) ).
-*      ELSE.
-*        result = VALUE #( BASE result
-*                          ( fieldname = <name> keyflag = <key> tabname = tab scrtext_s = <text> rollname = <name> ) ).
-*      ENDIF.
-*
-*      UNASSIGN <Content>.
-*      UNASSIGN <key>.
-*      UNASSIGN <Text>.
-*      UNASSIGN <type>.
-*      UNASSIGN <rname>.
-*
-*    ENDLOOP.
 
   ENDMETHOD.
 
@@ -1923,11 +1712,12 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD msg_get_internal.
 
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
     DATA(lv_kind) = rtti_get_type_kind( val ).
     CASE lv_kind.
 
       WHEN cl_abap_datadescr=>typekind_table.
-        FIELD-SYMBOLS <tab> TYPE ANY TABLE.
         ASSIGN val TO <tab>.
         LOOP AT <tab> ASSIGNING FIELD-SYMBOL(<row>).
           DATA(lt_tab) = msg_get_internal( <row> ).
@@ -1986,6 +1776,8 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
   METHOD msg_get_by_oref.
 
     FIELD-SYMBOLS <comp> TYPE any.
+    DATA obj    TYPE REF TO object.
+    DATA lr_tab TYPE REF TO data.
 
     TRY.
         DATA(lx) = CAST cx_root( val ).
@@ -2003,12 +1795,10 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
         INSERT ls_result INTO TABLE result.
       CATCH cx_root.
 
-        DATA obj TYPE REF TO object.
         obj = val.
 
         TRY.
 
-            DATA lr_tab TYPE REF TO data.
             CREATE DATA lr_tab TYPE (`if_bali_log=>ty_item_table`).
             ASSIGN lr_tab->* TO FIELD-SYMBOL(<tab2>).
 
@@ -2115,6 +1905,8 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD msg_get_rap.
 
+    FIELD-SYMBOLS <ftab> TYPE ANY TABLE.
+
     DATA(lv_kind) = rtti_get_type_kind( val ).
     IF lv_kind <> cl_abap_datadescr=>typekind_struct1
        AND lv_kind <> cl_abap_datadescr=>typekind_struct2.
@@ -2135,7 +1927,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
       CHECK sy-subrc = 0.
       CHECK rtti_get_type_kind( <tab> ) = cl_abap_datadescr=>typekind_table.
 
-      FIELD-SYMBOLS <ftab> TYPE ANY TABLE.
       ASSIGN <tab> TO <ftab>.
 
       LOOP AT <ftab> ASSIGNING FIELD-SYMBOL(<row>).
@@ -2156,6 +1947,8 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD msg_get_rap_row.
+
+    DATA lv_cause TYPE i.
 
     CLEAR messages.
     is_row = abap_false.
@@ -2182,7 +1975,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
       is_row = abap_true.
       ASSIGN COMPONENT `CAUSE` OF STRUCTURE <fail> TO FIELD-SYMBOL(<cause>).
       IF sy-subrc = 0.
-        DATA lv_cause TYPE i.
         lv_cause = <cause>.
         DATA(lv_text) = msg_get_rap_fail_text( lv_cause ).
         IF entity_name IS NOT INITIAL.
@@ -2269,6 +2061,8 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD msg_get_rap_flatten.
 
+    DATA lv_str TYPE string.
+
     DATA(lv_kind) = rtti_get_type_kind( val ).
     IF lv_kind <> cl_abap_datadescr=>typekind_struct1
        AND lv_kind <> cl_abap_datadescr=>typekind_struct2.
@@ -2292,7 +2086,6 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
         ENDIF.
       ELSEIF <comp> IS NOT INITIAL.
         TRY.
-            DATA lv_str TYPE string.
             lv_str = <comp>.
             IF result IS NOT INITIAL.
               result = |{ result }, |.

--- a/src/00/01/z2ui5_cx_smp_error.clas.abap
+++ b/src/00/01/z2ui5_cx_smp_error.clas.abap
@@ -14,8 +14,8 @@ CLASS z2ui5_cx_smp_error DEFINITION
 
     METHODS constructor
       IMPORTING
-        val       TYPE any            OPTIONAL
-        !previous TYPE REF TO cx_root OPTIONAL
+        val      TYPE any            OPTIONAL
+        previous TYPE REF TO cx_root OPTIONAL
           PREFERRED PARAMETER val.
 
     METHODS if_message~get_text REDEFINITION.

--- a/src/00/01/z2ui5_cx_smp_error.clas.testclasses.abap
+++ b/src/00/01/z2ui5_cx_smp_error.clas.testclasses.abap
@@ -59,6 +59,7 @@ CLASS ltcl_unit_test IMPLEMENTATION.
 
     TRY.
         DATA(lv_val) = 1 / 0.
+        cl_abap_unit_assert=>fail( |unreachable { lv_val }| ).
       CATCH cx_root INTO DATA(lx_root).
     ENDTRY.
 

--- a/src/00/98/z2ui5_cl_smp_app_094.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_094.clas.abap
@@ -155,6 +155,8 @@ CLASS z2ui5_cl_smp_app_094 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_build( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_117.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_117.clas.abap
@@ -86,6 +86,8 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_117.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_117.clas.abap
@@ -9,7 +9,7 @@ CLASS z2ui5_cl_smp_app_117 DEFINITION PUBLIC.
         count TYPE string,
         class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -22,7 +22,6 @@ CLASS z2ui5_cl_smp_app_117 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -31,26 +30,7 @@ CLASS z2ui5_cl_smp_app_117 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
-
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
 
 
   METHOD on_init.
@@ -81,6 +61,7 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -107,7 +88,6 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.
@@ -124,40 +104,34 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            data = t002->count.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                data = t002->count.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_118.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_118.clas.abap
@@ -9,10 +9,10 @@ CLASS z2ui5_cl_smp_app_118 DEFINITION PUBLIC.
              adate TYPE d,
              atime TYPE t,
            END OF ty_s_row.
-    TYPES t_rows TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+    TYPES ty_t_row TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
 
-    DATA problematic_rows TYPE t_rows.
-    DATA these_are_fine_rows TYPE t_rows.
+    DATA problematic_rows TYPE ty_t_row.
+    DATA these_are_fine_rows TYPE ty_t_row.
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/00/98/z2ui5_cl_smp_app_126.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_126.clas.abap
@@ -172,6 +172,8 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_126.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_126.clas.abap
@@ -99,6 +99,7 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
         ASSIGN mt_table->* TO <table>.
 
         SELECT * FROM z2ui5_t_01
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 3 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_131.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_131.clas.abap
@@ -88,6 +88,8 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_131.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_131.clas.abap
@@ -10,7 +10,7 @@ CLASS z2ui5_cl_smp_app_131 DEFINITION PUBLIC.
         table TYPE string,
         class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_131 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -32,26 +31,7 @@ CLASS z2ui5_cl_smp_app_131 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
-
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
 
 
   METHOD on_init.
@@ -83,6 +63,7 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -109,7 +90,6 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.
@@ -126,41 +106,35 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            count = t002->count
+            table = t002->table.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                count = t002->count
-                table = t002->table.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_132.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_132.clas.abap
@@ -71,6 +71,8 @@ CLASS z2ui5_cl_smp_app_132 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_132.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_132.clas.abap
@@ -11,67 +11,18 @@ CLASS z2ui5_cl_smp_app_132 DEFINITION PUBLIC.
 
     METHODS set_app_data
       IMPORTING
-        count TYPE string
-        table TYPE string.
+        count TYPE string.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
 
     METHODS view_display.
 
-    METHODS get_comp
-      RETURNING
-        VALUE(result) TYPE abap_component_tab.
-
   PRIVATE SECTION.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_132 IMPLEMENTATION.
-
-
-  METHOD get_comp.
-
-    DATA index TYPE int4.
-
-    TRY.
-
-        TRY.
-
-            cl_abap_typedescr=>describe_by_name( EXPORTING  p_name         = `Z2UI5_T_01`
-                                                 RECEIVING p_descr_ref     = DATA(typedesc)
-                                                 EXCEPTIONS type_not_found = 1
-                                                            OTHERS         = 2 ).
-
-            DATA(structdesc) = CAST cl_abap_structdescr( typedesc ).
-
-            DATA(comp) = structdesc->get_components( ).
-
-            LOOP AT comp INTO DATA(com).
-
-              IF com-as_include = abap_false.
-                APPEND com TO result.
-
-              ENDIF.
-
-            ENDLOOP.
-
-          CATCH cx_root.
-
-        ENDTRY.
-
-        DATA(component) = VALUE cl_abap_structdescr=>component_table(
-                                    ( name = `ROW_ID`
-                                      type = CAST #( cl_abap_datadescr=>describe_by_data( index ) ) ) ).
-
-        APPEND LINES OF component TO result.
-
-      CATCH cx_root.
-    ENDTRY.
-
-  ENDMETHOD.
-
 
   METHOD view_display.
 

--- a/src/00/98/z2ui5_cl_smp_app_138.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_138.clas.abap
@@ -29,6 +29,10 @@ CLASS z2ui5_cl_smp_app_138 DEFINITION PUBLIC.
     DATA quantity TYPE string.
 
   PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS view_display.
+
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -37,52 +41,59 @@ CLASS z2ui5_cl_smp_app_138 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    me->client = client.
     IF client->check_on_init( ).
-
       ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val  = `tomato`.
       quantity = `500`.
-
-      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
-          )->ele( n = `View` ns = `mvc`
-              )->a( n = `displayBlock` v = `true`
-              )->a( n = `height`       v = `100%`
-              )->a( n = `xmlns`        v = `sap.m`
-              )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-              )->a( n = `xmlns:core`   v = `sap.ui.core`
-              )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
-
-              )->ele( `Shell`
-                  )->ele( `Page`
-                      )->a( n = `title`          v = `abap2UI5 - First Example`
-                      )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
-                      )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
-
-                      )->ele( n = `SimpleForm` ns = `form`
-                          )->a( n = `title`    v = `Form Title`
-                          )->a( n = `editable` b = abap_true
-
-                          )->ele( n = `content` ns = `form`
-                              )->tag( `Title`
-                                  )->a( n = `text`  v = `Input`
-                              )->tag( `Label`
-                                  )->a( n = `text`  v = `quantity`
-                              )->tag( `Input`
-                                  )->a( n = `value` v = client->_bind( quantity )
-                              )->tag( `Label`
-                                  )->a( n = `text`  v = `product`
-                              )->tag( `Input`
-                                  )->a( n = `value` v = client->_bind( ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val )
-                              )->tag( `Button`
-                                  )->a( n = `press` v = client->_event( `BUTTON_POST` )
-                                  )->a( n = `text`  v = `post` ).
-
-      client->view_display( view->stringify( ) ).
-
+      view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     IF client->get_event( ) = `BUTTON_POST`.
       client->message_toast_display( |{ quantity } - send to the server| ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `displayBlock` v = `true`
+            )->a( n = `height`       v = `100%`
+            )->a( n = `xmlns`        v = `sap.m`
+            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:core`   v = `sap.ui.core`
+            )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title`          v = `abap2UI5 - First Example`
+                    )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+                    )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
+
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `title`    v = `Form Title`
+                        )->a( n = `editable` b = abap_true
+
+                        )->ele( n = `content` ns = `form`
+                            )->tag( `Title`
+                                )->a( n = `text`  v = `Input`
+                            )->tag( `Label`
+                                )->a( n = `text`  v = `quantity`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( quantity )
+                            )->tag( `Label`
+                                )->a( n = `text`  v = `product`
+                            )->tag( `Input`
+                                )->a( n = `value` v = client->_bind( ms_data-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-ms_data2-val )
+                            )->tag( `Button`
+                                )->a( n = `press` v = client->_event( `BUTTON_POST` )
+                                )->a( n = `text`  v = `post` ).
+
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_138.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_138.clas.abap
@@ -80,11 +80,9 @@ CLASS z2ui5_cl_smp_app_138 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get_event( ).
-
-      WHEN `BUTTON_POST`.
-        client->message_toast_display( |{ quantity } - send to the server| ).
-    ENDCASE.
+    IF client->get_event( ) = `BUTTON_POST`.
+      client->message_toast_display( |{ quantity } - send to the server| ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_184.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_184.clas.abap
@@ -15,7 +15,6 @@ CLASS z2ui5_cl_smp_app_184 DEFINITION PUBLIC.
 
     METHODS set_app_data
       IMPORTING
-        count TYPE string
         table TYPE string.
 
   PROTECTED SECTION.
@@ -33,7 +32,6 @@ CLASS z2ui5_cl_smp_app_184 DEFINITION PUBLIC.
 
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
@@ -144,6 +142,7 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 2 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_184.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_184.clas.abap
@@ -107,6 +107,8 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_185.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_185.clas.abap
@@ -143,6 +143,8 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_185.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_185.clas.abap
@@ -10,7 +10,7 @@ CLASS z2ui5_cl_smp_app_185 DEFINITION PUBLIC.
       table TYPE string,
       class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_185 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -32,32 +31,13 @@ CLASS z2ui5_cl_smp_app_185 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
-
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
 
 
   METHOD on_init.
 
-    mt_t002 = VALUE #( ( id = `1` class = `Z2UI5_CL_SMP_APP_184`  count = `10` table = `Z2UI5_T_01`)
-                       ( id = `2` class = `Z2UI5_CL_SMP_APP_184`  count = `12` table = `Z2UI5_T_01`) ).
+    mt_t002 = VALUE #( ( id = `1` class = `Z2UI5_CL_SMP_APP_184`  count = `10` table = `Z2UI5_T_01` )
+                       ( id = `2` class = `Z2UI5_CL_SMP_APP_184`  count = `12` table = `Z2UI5_T_01` ) ).
 
     mv_selectedkey = `1`.
 
@@ -83,6 +63,7 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -111,41 +92,35 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            count = t002->count
+            table = t002->table.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                count = t002->count
-                table = t002->table.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).
@@ -170,7 +145,6 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_190.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_190.clas.abap
@@ -119,6 +119,8 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_190.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_190.clas.abap
@@ -13,14 +13,12 @@ CLASS z2ui5_cl_smp_app_190 DEFINITION PUBLIC.
     DATA mt_comp         TYPE abap_component_tab.
 
     METHODS set_app_data
-      IMPORTING count TYPE string
-                table TYPE string.
+      IMPORTING table TYPE string.
 
   PROTECTED SECTION.
     DATA client            TYPE REF TO z2ui5_if_client.
 
     METHODS on_init.
-    METHODS on_event.
 
     METHODS view_display.
 
@@ -34,13 +32,6 @@ ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
-
-  METHOD on_event.
-
-    FIELD-SYMBOLS <row> TYPE any.
-
-  ENDMETHOD.
-
 
   METHOD on_init.
 
@@ -131,8 +122,6 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
 
     ENDIF.
 
-    on_event( ).
-
   ENDMETHOD.
 
 
@@ -145,8 +134,7 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
 
   METHOD get_data.
 
-    FIELD-SYMBOLS <table>     TYPE STANDARD TABLE.
-    FIELD-SYMBOLS <table_tmp> TYPE STANDARD TABLE.
+    FIELD-SYMBOLS <table> TYPE STANDARD TABLE.
 
     mt_comp = get_comp( ).
 
@@ -164,6 +152,7 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_191.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_191.clas.abap
@@ -10,7 +10,7 @@ CLASS z2ui5_cl_smp_app_191 DEFINITION PUBLIC.
       table TYPE string,
       class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_191 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -33,24 +32,6 @@ ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
-
 
   METHOD on_init.
 
@@ -83,6 +64,7 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -111,41 +93,35 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            count = t002->count
+            table = t002->table.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                count = t002->count
-                table = t002->table.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).
@@ -170,7 +146,6 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_191.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_191.clas.abap
@@ -144,6 +144,8 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_192.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_192.clas.abap
@@ -3,21 +3,6 @@ CLASS z2ui5_cl_smp_app_192 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    TYPES: BEGIN OF ty_s_key_value,
-             fname   TYPE string,
-             value   TYPE string,
-             tabname TYPE string,
-             comp    TYPE abap_componentdescr,
-           END OF ty_s_key_value,
-           ty_t_key_values TYPE STANDARD TABLE OF ty_s_key_value WITH EMPTY KEY.
-
-    TYPES: BEGIN OF ty_s_merged_data,
-             t_kopf  TYPE REF TO data,
-             t_pos   TYPE REF TO data,
-             t_keyva TYPE ty_t_key_values,
-           END OF ty_s_merged_data,
-           ty_t_merged_data TYPE STANDARD TABLE OF ty_s_merged_data WITH EMPTY KEY.
-
     TYPES:
       BEGIN OF ty_s_out,
         aa TYPE string,

--- a/src/00/98/z2ui5_cl_smp_app_193.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_193.clas.abap
@@ -3,18 +3,8 @@ CLASS z2ui5_cl_smp_app_193 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES if_serializable_object.
 
-    TYPES:
-      BEGIN OF ty_s_key_value,
-        fname   TYPE char30,
-        value   TYPE string,
-        tabname TYPE char30,
-        comp    TYPE abap_componentdescr,
-      END OF ty_s_key_value,
-      ty_t_key_values TYPE STANDARD TABLE OF ty_s_key_value WITH EMPTY KEY.
-
-    DATA mt_kopf  TYPE REF TO data.
-    DATA mt_pos   TYPE REF TO data.
-    DATA mt_keyva TYPE ty_t_key_values.
+    DATA mt_kopf TYPE REF TO data.
+    DATA mt_pos  TYPE REF TO data.
 
     DATA mt_kopf_xml  TYPE string.
     DATA mt_pos_xml   TYPE string.

--- a/src/00/98/z2ui5_cl_smp_app_194.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_194.clas.abap
@@ -152,6 +152,8 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_194.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_194.clas.abap
@@ -190,6 +190,7 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 
@@ -215,10 +216,10 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
         ddlanguage TYPE string,
         ddtext     TYPE string,
       END OF ty_s_fixvalue.
-    TYPES fixvalues TYPE STANDARD TABLE OF ty_s_fixvalue WITH DEFAULT KEY.
+    TYPES ty_t_fixvalue TYPE STANDARD TABLE OF ty_s_fixvalue WITH EMPTY KEY.
 
     DATA comp        TYPE cl_abap_structdescr=>component_table.
-    DATA lt_fixval   TYPE fixvalues.
+    DATA lt_fixval   TYPE ty_t_fixvalue.
     DATA structdescr TYPE REF TO cl_abap_structdescr.
 
     LOOP AT mt_comp REFERENCE INTO DATA(dfies).

--- a/src/00/98/z2ui5_cl_smp_app_195.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_195.clas.abap
@@ -143,6 +143,8 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_195.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_195.clas.abap
@@ -10,7 +10,7 @@ CLASS z2ui5_cl_smp_app_195 DEFINITION PUBLIC.
       table TYPE string,
       class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_195 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -34,30 +33,12 @@ ENDCLASS.
 
 CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
-
-
   METHOD on_init.
 
-    mt_t002 = VALUE #( ( id = `1` class = `Z2UI5_CL_SMP_APP_194`  count = `10` table = `Z2UI5_T_11`)
-                       ( id = `2` class = `Z2UI5_CL_SMP_APP_194`  count = `20` table = `Z2UI5_T_12`)
-                       ( id = `3` class = `Z2UI5_CL_SMP_APP_194`  count = `30` table = `Z2UI5_T_11`)
-                       ( id = `4` class = `Z2UI5_CL_SMP_APP_194`  count = `40` table = `Z2UI5_T_12`) ).
+    mt_t002 = VALUE #( ( id = `1` class = `Z2UI5_CL_SMP_APP_194`  count = `10` table = `Z2UI5_T_11` )
+                       ( id = `2` class = `Z2UI5_CL_SMP_APP_194`  count = `20` table = `Z2UI5_T_12` )
+                       ( id = `3` class = `Z2UI5_CL_SMP_APP_194`  count = `30` table = `Z2UI5_T_11` )
+                       ( id = `4` class = `Z2UI5_CL_SMP_APP_194`  count = `40` table = `Z2UI5_T_12` ) ).
 
     mv_selectedkey = `1`.
 
@@ -83,6 +64,7 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -111,40 +93,34 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            table = t002->table.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                table = t002->table.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).
@@ -169,7 +145,6 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_199.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_199.clas.abap
@@ -109,6 +109,8 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     ASSIGN mt_table->* TO <tab>.

--- a/src/00/98/z2ui5_cl_smp_app_199.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_199.clas.abap
@@ -113,7 +113,7 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
 
     ASSIGN mt_table->* TO <tab>.
 
-    IF mv_counter <> lines( <tab> ) AND mv_counter IS NOT INITIAL.
+    IF lines( <tab> ) <> mv_counter AND mv_counter IS NOT INITIAL.
       client->message_box_display( text = `Frontend Lines <> Backend!`
                                    type = `error` ).
     ENDIF.
@@ -134,6 +134,7 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
         mt_comp = z2ui5_cl_smp_context=>rtti_get_t_attri_by_any( <table> ).
 
         SELECT id, id_prev FROM z2ui5_t_01
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 2 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_211.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_211.clas.abap
@@ -101,6 +101,8 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
       on_init( ).
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_211.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_211.clas.abap
@@ -16,7 +16,7 @@ CLASS z2ui5_cl_smp_app_211 DEFINITION PUBLIC.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
-    DATA mt_t002            TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    DATA mt_t002            TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
     DATA mo_app             TYPE REF TO object.
 
   PROTECTED SECTION.
@@ -25,7 +25,6 @@ CLASS z2ui5_cl_smp_app_211 DEFINITION PUBLIC.
     DATA client            TYPE REF TO z2ui5_if_client.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -35,23 +34,6 @@ ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
-
 
   METHOD on_init.
 
@@ -84,6 +66,7 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -121,7 +104,6 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
     ENDIF.
 
-    on_event( ).
 
     render_sub_app( ).
 
@@ -137,39 +119,33 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
 
-      WHEN OTHERS.
+    TRY.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING table = t002->table.
+
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
 
-        TRY.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING client = client.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING table = t002->table.
-
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO FIELD-SYMBOL(<view_display>).
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_212.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_212.clas.abap
@@ -214,6 +214,8 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_212.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_212.clas.abap
@@ -133,7 +133,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
             )->a( n = `editable` b = abap_true
             )->ele( n = `content` ns = `form` ).
 
-    " Walk through all comps — in edit mode the key fields are not editable.
+    " Walk through all comps - in edit mode the key fields are not editable.
     LOOP AT mt_dfies REFERENCE INTO DATA(dfies).
 
       ASSIGN ms_table_row->* TO <row>.
@@ -194,7 +194,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
         )->a( n = `growing` v = `true`
         )->a( n = `width`   v = `auto` ).
 
-    DATA(headder) = table->ele( `headerToolbar`
+    table->ele( `headerToolbar`
         )->ele( `OverflowToolbar`
             )->tag( `ToolbarSpacer` ).
 
@@ -251,6 +251,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_324.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_324.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_324 IMPLEMENTATION.
 
     me->client = client.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/00/98/z2ui5_cl_smp_app_324.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_324.clas.abap
@@ -42,10 +42,9 @@ CLASS z2ui5_cl_smp_app_324 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `PRESS`.
-          call_dynpro( ).
-      ENDCASE.
+      IF client->get_event( ) = `PRESS`.
+        call_dynpro( ).
+      ENDIF.
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_328.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_328.clas.abap
@@ -22,7 +22,7 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     FIELD-SYMBOLS <line> TYPE any.
-    FIELD-SYMBOLS: <tab> TYPE ANY TABLE.
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
 
     IF client->check_on_init( ).
 
@@ -31,48 +31,45 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
       view_display( client ).
     ENDIF.
 
-    CASE client->get_event( ).
-      WHEN `GO`.
+    IF client->get_event( ) = `GO`.
+      ASSIGN mt_table->* TO <tab>.
 
-        ASSIGN mt_table->* TO <tab>.
+      LOOP AT <tab> ASSIGNING <line>.
 
-        LOOP AT <tab> ASSIGNING <line>.
+        ASSIGN COMPONENT `SELKZ` OF STRUCTURE <line> TO FIELD-SYMBOL(<selkz>).
 
-          ASSIGN COMPONENT `SELKZ` OF STRUCTURE <line> TO FIELD-SYMBOL(<selkz>).
-
-          IF sy-subrc <> 0.
-            CONTINUE.
-          ENDIF.
-
-          IF <selkz> = abap_true.
-
-            DATA(okay) = abap_true.
-            EXIT.
-          ENDIF.
-
-        ENDLOOP.
-
-        IF okay = abap_true.
-
-          get_data( ).
-          mo_table_obj = z2ui5_cl_smp_app_329=>factory( mt_table ).
-          view_display( client ).
-
-          ASSIGN mt_table->* TO FIELD-SYMBOL(<table>).
-          ASSIGN mo_table_obj->mr_data->* TO FIELD-SYMBOL(<val>).
-
-          IF <table> <> <val>.
-            client->message_toast_display( `Error - MT_TABLE <> MO_TABLE_OBJ->MR_TABLE_DATA` ).
-
-          ELSE.
-            client->message_toast_display( `Success - MT_TABLE = MO_TABLE_OBJ->MR_TABLE_DATA` ).
-          ENDIF.
-
-        ELSE.
-          client->message_toast_display( `Please select a line` ).
+        IF sy-subrc <> 0.
+          CONTINUE.
         ENDIF.
 
-    ENDCASE.
+        IF <selkz> = abap_true.
+
+          DATA(okay) = abap_true.
+          EXIT.
+        ENDIF.
+
+      ENDLOOP.
+
+      IF okay = abap_true.
+
+        get_data( ).
+        mo_table_obj = z2ui5_cl_smp_app_329=>factory( mt_table ).
+        view_display( client ).
+
+        ASSIGN mt_table->* TO FIELD-SYMBOL(<table>).
+        ASSIGN mo_table_obj->mr_data->* TO FIELD-SYMBOL(<val>).
+
+        IF <table> <> <val>.
+          client->message_toast_display( `Error - MT_TABLE <> MO_TABLE_OBJ->MR_TABLE_DATA` ).
+
+        ELSE.
+          client->message_toast_display( `Success - MT_TABLE = MO_TABLE_OBJ->MR_TABLE_DATA` ).
+        ENDIF.
+
+      ELSE.
+        client->message_toast_display( `Please select a line` ).
+      ENDIF.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -147,6 +144,7 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
         ASSIGN mt_table->* TO <table>.
 
         SELECT id FROM z2ui5_t_01
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 4 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_328.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_328.clas.abap
@@ -29,6 +29,8 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
       get_data( ).
       mo_table_obj = z2ui5_cl_smp_app_329=>factory( mt_table ).
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
     ENDIF.
 
     IF client->get_event( ) = `GO`.

--- a/src/00/98/z2ui5_cl_smp_app_329.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_329.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_smp_app_329 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_329 IMPLEMENTATION.
 
 

--- a/src/00/98/z2ui5_cl_smp_app_331.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_331.clas.abap
@@ -26,6 +26,8 @@ CLASS z2ui5_cl_smp_app_331 IMPLEMENTATION.
       get_data( ).
       mo_table_obj = z2ui5_cl_smp_app_329=>factory( REF #( ms_struc ) ).
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
     ENDIF.
 
     IF ms_struc IS INITIAL.

--- a/src/00/98/z2ui5_cl_smp_app_331.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_331.clas.abap
@@ -84,8 +84,14 @@ CLASS z2ui5_cl_smp_app_331 IMPLEMENTATION.
 
   METHOD get_data.
 
-    SELECT SINGLE * FROM z2ui5_t_01
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+    " any single row will do here, but it has to be the SAME one on every
+    " roundtrip - SELECT SINGLE without a full key leaves that to the database
+    SELECT * FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
+      INTO TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_332.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_332.clas.abap
@@ -75,7 +75,6 @@ CLASS z2ui5_cl_smp_app_332 IMPLEMENTATION.
 
       ASSIGN mo_table_obj->mr_data->* TO FIELD-SYMBOL(<val>).
       ASSIGN COMPONENT layout->name OF STRUCTURE <val> TO FIELD-SYMBOL(<value>).
-      " assign component layout->name of structure ms_struc to field-symbol(<value>).
 
       IF sy-subrc <> 0.
         RETURN.
@@ -100,8 +99,14 @@ CLASS z2ui5_cl_smp_app_332 IMPLEMENTATION.
 
   METHOD get_data.
 
-    SELECT SINGLE * FROM z2ui5_t_01
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+    " any single row will do here, but it has to be the SAME one on every
+    " roundtrip - SELECT SINGLE without a full key leaves that to the database
+    SELECT * FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
+      INTO TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_332.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_332.clas.abap
@@ -29,6 +29,8 @@ CLASS z2ui5_cl_smp_app_332 IMPLEMENTATION.
                                                      vis_cols = 3 ).
 
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_333.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_333.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_smp_app_333 DEFINITION PUBLIC.
           END OF test3,
         END OF test2,
       END OF ty_s_test.
-    TYPES ty_t_test TYPE STANDARD TABLE OF ty_s_test WITH EMPTY KEY.
 
     TYPES:
       BEGIN OF ty_s_layout,
@@ -31,12 +30,9 @@ CLASS z2ui5_cl_smp_app_333 DEFINITION PUBLIC.
              t_layout TYPE ty_t_layout,
              s_test   TYPE ty_s_test,
            END OF ty_s_data.
-    TYPES ty_t_data TYPE STANDARD TABLE OF ty_s_data WITH EMPTY KEY.
 
     DATA ms_data TYPE ty_s_data.
     DATA mr_data TYPE REF TO data.
-
-    CLASS-DATA cv_value TYPE c LENGTH 10 VALUE `STRUCT`.
 
     CLASS-METHODS factory
       IMPORTING
@@ -48,7 +44,6 @@ CLASS z2ui5_cl_smp_app_333 DEFINITION PUBLIC.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_333 IMPLEMENTATION.

--- a/src/00/98/z2ui5_cl_smp_app_334.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_334.clas.abap
@@ -32,6 +32,8 @@ CLASS z2ui5_cl_smp_app_334 IMPLEMENTATION.
                                                         vis_cols = 5 ).
 
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_334.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_334.clas.abap
@@ -91,7 +91,6 @@ CLASS z2ui5_cl_smp_app_334 IMPLEMENTATION.
       ASSIGN mo_layout_obj->mr_data->* TO FIELD-SYMBOL(<val>).
 
       ASSIGN COMPONENT layout->name OF STRUCTURE <val> TO FIELD-SYMBOL(<value>).
-      " assign component layout->name of structure ms_struc to field-symbol(<value>).
 
       IF sy-subrc <> 0.
         RETURN.
@@ -116,8 +115,14 @@ CLASS z2ui5_cl_smp_app_334 IMPLEMENTATION.
 
   METHOD get_data.
 
-    SELECT SINGLE * FROM z2ui5_t_01
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+    " any single row will do here, but it has to be the SAME one on every
+    " roundtrip - SELECT SINGLE without a full key leaves that to the database
+    SELECT * FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
+      INTO TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_335.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_335.clas.abap
@@ -123,7 +123,6 @@ CLASS z2ui5_cl_smp_app_335 IMPLEMENTATION.
 
       ASSIGN mo_layout_obj->mr_data->* TO FIELD-SYMBOL(<val>).
       ASSIGN COMPONENT layout->name OF STRUCTURE <val> TO FIELD-SYMBOL(<value>).
-      " assign component layout->name of structure ms_struc to field-symbol(<value>).
 
       IF sy-subrc <> 0.
         RETURN.
@@ -148,17 +147,27 @@ CLASS z2ui5_cl_smp_app_335 IMPLEMENTATION.
 
   METHOD get_data.
 
-    SELECT SINGLE * FROM z2ui5_t_01
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+    " any single row will do here, but it has to be the SAME one on every
+    " roundtrip - SELECT SINGLE without a full key leaves that to the database
+    SELECT * FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
+      INTO TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 
 
   METHOD get_data_2.
 
-    SELECT SINGLE * FROM z2ui5_t_01
+    SELECT * FROM z2ui5_t_01
       WHERE id <> @ms_struc-id
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+      ORDER BY PRIMARY KEY
+      INTO TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_336.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_336.clas.abap
@@ -32,6 +32,8 @@ CLASS z2ui5_cl_smp_app_336 IMPLEMENTATION.
                                                         vis_cols = 3 ).
 
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_337.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_337.clas.abap
@@ -3,7 +3,7 @@ CLASS z2ui5_cl_smp_app_337 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01.
+    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01 WITH EMPTY KEY.
     DATA ms_data         TYPE z2ui5_t_01.
     DATA mo_layout_obj   TYPE REF TO z2ui5_cl_smp_app_333.
     DATA mo_layout_obj_2 TYPE REF TO z2ui5_cl_smp_app_333.
@@ -48,11 +48,10 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `GO`.
-          DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
-          client->nav_app_call( app ).
-      ENDCASE.
+      IF client->get_event( ) = `GO`.
+        DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
+        client->nav_app_call( app ).
+      ENDIF.
 
     ENDIF.
 
@@ -158,6 +157,7 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
            id_prev_app_stack,
            timestampl
       FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
       INTO CORRESPONDING FIELDS OF TABLE @mt_data
       UP TO 10 ROWS.
 
@@ -181,7 +181,6 @@ CLASS z2ui5_cl_smp_app_337 IMPLEMENTATION.
       index = index + 1.
 
       ASSIGN COMPONENT layout->name OF STRUCTURE ms_data TO FIELD-SYMBOL(<value>).
-      " assign component layout->name of structure ms_struc to field-symbol(<value>).
 
       IF sy-subrc <> 0.
         RETURN.

--- a/src/00/98/z2ui5_cl_smp_app_338.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_338.clas.abap
@@ -88,6 +88,8 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
 
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      render_sub_app( ).
     ENDIF.
 
     render_sub_app( ).

--- a/src/00/98/z2ui5_cl_smp_app_338.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_338.clas.abap
@@ -10,7 +10,7 @@ CLASS z2ui5_cl_smp_app_338 DEFINITION PUBLIC.
         table TYPE string,
         class TYPE string,
       END OF ty_s_t002.
-    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH DEFAULT KEY.
+    TYPES ty_t_t002 TYPE STANDARD TABLE OF ty_s_t002 WITH EMPTY KEY.
 
     DATA mv_selectedkey     TYPE string.
     DATA mv_selectedkey_tmp TYPE string.
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_338 DEFINITION PUBLIC.
     DATA mo_main_page      TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     METHODS on_init.
-    METHODS on_event.
     METHODS view_display.
 
     METHODS render_sub_app.
@@ -33,24 +32,6 @@ ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
-
-  METHOD on_event.
-
-    CASE client->get_event( ).
-
-      WHEN `ONSELECTICONTABBAR`.
-
-        CASE mv_selectedkey.
-
-          WHEN space.
-
-          WHEN OTHERS.
-
-        ENDCASE.
-    ENDCASE.
-
-  ENDMETHOD.
-
 
   METHOD on_init.
 
@@ -82,6 +63,7 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
 
     DATA(lo_items) = page->ele( `IconTabBar`
         )->a( n = `class`       v = `sapUiResponsiveContentPadding`
+        " abap2ui5lint-disable-next-line event-without-handler -- the roundtrip alone is the point: selectedKey is written back by the binding, render_sub_app( ) reads it
         )->a( n = `select`      v = client->_event( `ONSELECTICONTABBAR` )
         )->a( n = `selectedKey` v = client->_bind( mv_selectedkey )
         )->ele( `items` ).
@@ -108,7 +90,6 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    on_event( ).
     render_sub_app( ).
 
   ENDMETHOD.
@@ -125,40 +106,34 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE mv_selectedkey.
+    IF mv_selectedkey <> mv_selectedkey_tmp.
+      CREATE OBJECT mo_app TYPE (t002->class).
+    ENDIF.
+    TRY.
 
-      WHEN OTHERS.
+        CALL METHOD mo_app->(`SET_APP_DATA`)
+          EXPORTING
+            table = t002->table.
 
-        IF mv_selectedkey <> mv_selectedkey_tmp.
-          CREATE OBJECT mo_app TYPE (t002->class).
+        view_display( ).
+
+        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+
+        IF <view> IS ASSIGNED.
+          <view> = mo_main_page.
         ENDIF.
-        TRY.
 
-            CALL METHOD mo_app->(`SET_APP_DATA`)
-              EXPORTING
-                table = t002->table.
+        CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
+          EXPORTING
+            client = client.
 
-            view_display( ).
-
-            ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
-
-            IF <view> IS ASSIGNED.
-              <view> = mo_main_page.
-            ENDIF.
-
-            CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)
-              EXPORTING
-                client = client.
-
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-
-    ENDCASE.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
 
     ASSIGN mo_app->(`MV_VIEW_DISPLAY`) TO <view_display>.
 
-    IF <view_display> = abap_true.
+    IF sy-subrc = 0 AND <view_display> = abap_true.
 
       <view_display> = abap_false.
       client->view_display( mo_main_page->stringify( ) ).

--- a/src/00/98/z2ui5_cl_smp_app_339.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_339.clas.abap
@@ -16,12 +16,12 @@ CLASS z2ui5_cl_smp_app_339 DEFINITION PUBLIC.
 
     METHODS set_app_data
       IMPORTING
-        !table TYPE string.
+        table TYPE string.
 
   PROTECTED SECTION.
 
-    METHODS on_event     IMPORTING !client TYPE REF TO z2ui5_if_client.
-    METHODS view_display IMPORTING !client TYPE REF TO z2ui5_if_client.
+    METHODS on_event     IMPORTING client TYPE REF TO z2ui5_if_client.
+    METHODS view_display IMPORTING client TYPE REF TO z2ui5_if_client.
     METHODS get_data.
 
     METHODS get_comp
@@ -86,7 +86,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
       WHEN `SELECTION_CHANGE`.
 
         client->nav_app_call( z2ui5_cl_smp_app_340=>factory( io_table  = mt_table
-                                                              io_layout = mo_layout  ) ).
+                                                              io_layout = mo_layout ) ).
 
       WHEN `BACK`.
 
@@ -189,7 +189,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
     ASSIGN mt_table->* TO FIELD-SYMBOL(<table>).
 
     IF <data> <> <table>.
-      client->message_toast_display( `ERROR - mo_layout->mr_data->* ne mt_table->*`  ).
+      client->message_toast_display( `ERROR - mo_layout->mr_data->* ne mt_table->*` ).
     ENDIF.
 
     on_event( client ).
@@ -216,6 +216,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 3 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_340.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_340.clas.abap
@@ -66,6 +66,10 @@ CLASS z2ui5_cl_smp_app_340 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    " No check_on_navigated( ) branch: this app shows a POPUP, not a main
+    " view. The framework pushes the model back into the still-standing
+    " popup by itself - only an app that owns the MAIN slot has to
+    " re-display (AGENTS.md 9).
     IF client->check_on_init( ).
       view_display( client ).
 

--- a/src/00/98/z2ui5_cl_smp_app_340.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_340.clas.abap
@@ -45,7 +45,7 @@ CLASS z2ui5_cl_smp_app_340 IMPLEMENTATION.
             )->a( n = `xmlns:core` v = `sap.ui.core`
             )->a( n = `xmlns:form` v = `sap.ui.layout.form` ).
 
-    DATA(simple_form) = popup->ele( `Dialog`
+    popup->ele( `Dialog`
         )->a( n = `title`        v = `Test`
         )->a( n = `contentWidth` v = `60%`
         )->a( n = `afterClose`   v = client->_event( `POPUP_CLOSE` )

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -17,12 +17,12 @@ CLASS z2ui5_cl_smp_app_342 DEFINITION PUBLIC.
 
     METHODS set_app_data
       IMPORTING
-        !table TYPE string.
+        table TYPE string.
 
   PROTECTED SECTION.
-    METHODS on_event    IMPORTING !client TYPE REF TO z2ui5_if_client.
+    METHODS on_event    IMPORTING client TYPE REF TO z2ui5_if_client.
 
-    METHODS render_main IMPORTING !client TYPE REF TO z2ui5_if_client.
+    METHODS render_main IMPORTING client TYPE REF TO z2ui5_if_client.
     METHODS get_data.
 
     METHODS get_comp
@@ -229,6 +229,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
         SELECT *
           FROM (mv_table)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 5 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_343.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_343.clas.abap
@@ -69,6 +69,7 @@ CLASS z2ui5_cl_smp_app_343 IMPLEMENTATION.
         ASSIGN mt_data1->* TO <table1>.
 
         SELECT * FROM z2ui5_t_01
+          ORDER BY PRIMARY KEY
           INTO TABLE @<table1>
           UP TO 5 ROWS.
 
@@ -100,7 +101,7 @@ CLASS z2ui5_cl_smp_app_343 IMPLEMENTATION.
         " to refuse it rather than serialize a reference. If _bind( ) ever
         " stops raising, the first message_box below fires and the test fails.
         " abap2ui5lint-disable-next-line missing-required-aggregation -- the chain never gets as far as `columns`: the line below is expected to raise
-        DATA(table) = page->ele( `Table`
+        page->ele( `Table`
             " abap2ui5lint-disable-next-line binding-to-reference -- this is the assertion, not a mistake
             )->a( n = `items` v = client->_bind( mt_data1 )
             )->a( n = `width` v = `auto` ).

--- a/src/00/98/z2ui5_cl_smp_app_344.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_344.clas.abap
@@ -54,11 +54,10 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `GO`.
-          DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
-          client->nav_app_call( app ).
-      ENDCASE.
+      IF client->get_event( ) = `GO`.
+        DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
+        client->nav_app_call( app ).
+      ENDIF.
 
     ENDIF.
 
@@ -181,6 +180,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
         SELECT *
           FROM (iv_tabname)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 3 ROWS.
 
@@ -211,6 +211,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
         SELECT *
           FROM (iv_tabname)
+          ORDER BY PRIMARY KEY
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 4 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_345.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_345.clas.abap
@@ -78,6 +78,7 @@ CLASS z2ui5_cl_smp_app_345 IMPLEMENTATION.
         ASSIGN mt_data1->* TO <table1>.
 
         SELECT * FROM z2ui5_t_01
+          ORDER BY PRIMARY KEY
           INTO TABLE @<table1>
           UP TO 5 ROWS.
 
@@ -172,11 +173,10 @@ CLASS z2ui5_cl_smp_app_345 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `GO`.
-          DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
-          client->nav_app_call( app ).
-      ENDCASE.
+      IF client->get_event( ) = `GO`.
+        DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
+        client->nav_app_call( app ).
+      ENDIF.
 
     ENDIF.
 

--- a/src/00/98/z2ui5_cl_smp_app_347.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_347.clas.abap
@@ -3,7 +3,7 @@ CLASS z2ui5_cl_smp_app_347 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01.
+    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01 WITH EMPTY KEY.
     DATA mo_layout_obj   TYPE REF TO z2ui5_cl_smp_app_333.
 
     METHODS get_data.
@@ -40,11 +40,10 @@ CLASS z2ui5_cl_smp_app_347 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `GO`.
-          DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
-          client->nav_app_call( app ).
-      ENDCASE.
+      IF client->get_event( ) = `GO`.
+        DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
+        client->nav_app_call( app ).
+      ENDIF.
 
     ENDIF.
 
@@ -141,6 +140,7 @@ CLASS z2ui5_cl_smp_app_347 IMPLEMENTATION.
            id_prev_app_stack,
            timestampl
       FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
       INTO CORRESPONDING FIELDS OF TABLE @mt_data
       UP TO 10 ROWS.
 

--- a/src/00/98/z2ui5_cl_smp_app_348.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_348.clas.abap
@@ -115,27 +115,37 @@ CLASS z2ui5_cl_smp_app_348 IMPLEMENTATION.
 
   METHOD get_data.
 
-    SELECT SINGLE id,
-                  id_prev,
-                  id_prev_app,
-                  id_prev_app_stack,
-                  timestampl
+    " any single row will do here, but it has to be the SAME one on every
+    " roundtrip - SELECT SINGLE without a full key leaves that to the database
+    SELECT id,
+           id_prev,
+           id_prev_app,
+           id_prev_app_stack,
+           timestampl
       FROM z2ui5_t_01
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+      ORDER BY PRIMARY KEY
+      INTO CORRESPONDING FIELDS OF TABLE @DATA(lt_data)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 
 
   METHOD get_data2.
 
-    SELECT SINGLE id,
-                  id_prev,
-                  id_prev_app,
-                  id_prev_app_stack,
-                  timestampl
+    SELECT id,
+           id_prev,
+           id_prev_app,
+           id_prev_app_stack,
+           timestampl
       FROM z2ui5_t_01
       WHERE id <> @ms_struc-id
-      INTO CORRESPONDING FIELDS OF @ms_struc.
+      ORDER BY PRIMARY KEY
+      INTO CORRESPONDING FIELDS OF TABLE @DATA(lt_data2)
+      UP TO 1 ROWS.
+
+    ms_struc = VALUE #( lt_data2[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_349.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_349.clas.abap
@@ -3,7 +3,7 @@ CLASS z2ui5_cl_smp_app_349 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01.
+    DATA mt_data         TYPE STANDARD TABLE OF z2ui5_t_01 WITH EMPTY KEY.
     DATA ms_data         TYPE z2ui5_t_01.
     DATA mo_layout_obj   TYPE REF TO z2ui5_cl_smp_app_333.
     DATA mo_layout_obj_2 TYPE REF TO z2ui5_cl_smp_app_333.
@@ -48,11 +48,10 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( ).
 
-      CASE client->get_event( ).
-        WHEN `GO`.
-          DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
-          client->nav_app_call( app ).
-      ENDCASE.
+      IF client->get_event( ) = `GO`.
+        DATA(app) = z2ui5_cl_smp_app_336=>factory( ).
+        client->nav_app_call( app ).
+      ENDIF.
 
     ENDIF.
 
@@ -166,6 +165,7 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
            id_prev_app_stack,
            timestampl
       FROM z2ui5_t_01
+      ORDER BY PRIMARY KEY
       INTO CORRESPONDING FIELDS OF TABLE @mt_data
       UP TO 10 ROWS.
 
@@ -189,7 +189,6 @@ CLASS z2ui5_cl_smp_app_349 IMPLEMENTATION.
       index = index + 1.
 
       ASSIGN COMPONENT layout->name OF STRUCTURE ms_data TO FIELD-SYMBOL(<value>).
-      " assign component layout->name of structure ms_struc to field-symbol(<value>).
 
       IF sy-subrc <> 0.
         RETURN.

--- a/src/00/98/z2ui5_cl_smp_app_353.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_353.clas.abap
@@ -119,6 +119,8 @@ CLASS z2ui5_cl_smp_app_353 IMPLEMENTATION.
       client->follow_up_action(
           val   = z2ui5_if_client=>cs_event-set_focus
           t_arg = VALUE #( ( `IdOne` ) ) ).
+    ELSEIF client->check_on_navigated( ).
+      render( ).
 
     ELSEIF client->check_on_event( `TIMER_FINISHED` ).
 

--- a/src/00/98/z2ui5_cl_smp_app_443.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_443.clas.abap
@@ -8,6 +8,10 @@ CLASS z2ui5_cl_smp_app_443 DEFINITION PUBLIC CREATE PUBLIC.
     DATA info    TYPE string.
 
   PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS view_display.
+
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -16,51 +20,14 @@ CLASS z2ui5_cl_smp_app_443 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    me->client = client.
     IF client->check_on_init( ).
       enabled = abap_true.
       value   = `86801398`.
       info    = `Step 1: Lock the field. Step 2: Re-enable + SET_CURSOR in the same roundtrip.`.
-
-      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
-          )->ele( n = `View` ns = `mvc`
-              )->a( n = `displayBlock` v = `true`
-              )->a( n = `height`       v = `100%`
-              )->a( n = `xmlns`        v = `sap.m`
-              )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-              )->a( n = `xmlns:core`   v = `sap.ui.core`
-              )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
-              )->ele( `Shell`
-                  )->ele( `Page`
-                      )->a( n = `title` v = `abap2UI5 - SET_CURSOR after enabled binding`
-                      )->ele( n = `SimpleForm` ns = `form`
-                          )->a( n = `editable` b = abap_true
-                          )->ele( n = `content` ns = `form`
-                              )->tag( n = `Title` ns = `core`
-                                  )->a( n = `text` v = client->_bind( info )
-                              )->tag( `Label`
-                                  )->a( n = `text` v = `Document Number`
-                              )->tag( `Input`
-                                  )->a( n = `id`      v = `inpDocNum`
-                                  )->a( n = `enabled` v = client->_bind( enabled )
-                                  )->a( n = `value`   v = client->_bind( value )
-                              )->tag( `Label`
-                                  )->a( n = `text` v = ``
-                              )->tag( `Button`
-                                  )->a( n = `press` v = client->_event( `LOCK` )
-                                  )->a( n = `text`  v = `1 - Lock field (enabled = false)`
-                              )->tag( `Label`
-                                  )->a( n = `text` v = ``
-                              )->tag( `Button`
-                                  )->a( n = `press` v = client->_event( `UNLOCK_AND_SET_CURSOR` )
-                                  )->a( n = `text`  v = `2 - Re-enable field + SET_CURSOR (one roundtrip)`
-                                  )->a( n = `type`  v = `Emphasized`
-                              )->tag( `Label`
-                                  )->a( n = `text` v = ``
-                              )->tag( `Button`
-                                  )->a( n = `press` v = client->_event( `SET_CURSOR_ONLY` )
-                                  )->a( n = `text`  v = `Reference: SET_CURSOR only (no enabled change)` ).
-      client->view_display( view->stringify( ) ).
-
+      view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( `LOCK` ).
       " The field gets locked via binding - just like a real app that
       " blocks input while processing is running.
@@ -86,6 +53,51 @@ CLASS z2ui5_cl_smp_app_443 IMPLEMENTATION.
       client->follow_up_action( val   = client->cs_event-set_focus
                                 t_arg = VALUE #( ( `inpDocNum` ) ( `0` ) ( `4` ) ) ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `displayBlock` v = `true`
+            )->a( n = `height`       v = `100%`
+            )->a( n = `xmlns`        v = `sap.m`
+            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:core`   v = `sap.ui.core`
+            )->a( n = `xmlns:form`   v = `sap.ui.layout.form`
+            )->ele( `Shell`
+                )->ele( `Page`
+                    )->a( n = `title` v = `abap2UI5 - SET_CURSOR after enabled binding`
+                    )->ele( n = `SimpleForm` ns = `form`
+                        )->a( n = `editable` b = abap_true
+                        )->ele( n = `content` ns = `form`
+                            )->tag( n = `Title` ns = `core`
+                                )->a( n = `text` v = client->_bind( info )
+                            )->tag( `Label`
+                                )->a( n = `text` v = `Document Number`
+                            )->tag( `Input`
+                                )->a( n = `id`      v = `inpDocNum`
+                                )->a( n = `enabled` v = client->_bind( enabled )
+                                )->a( n = `value`   v = client->_bind( value )
+                            )->tag( `Label`
+                                )->a( n = `text` v = ``
+                            )->tag( `Button`
+                                )->a( n = `press` v = client->_event( `LOCK` )
+                                )->a( n = `text`  v = `1 - Lock field (enabled = false)`
+                            )->tag( `Label`
+                                )->a( n = `text` v = ``
+                            )->tag( `Button`
+                                )->a( n = `press` v = client->_event( `UNLOCK_AND_SET_CURSOR` )
+                                )->a( n = `text`  v = `2 - Re-enable field + SET_CURSOR (one roundtrip)`
+                                )->a( n = `type`  v = `Emphasized`
+                            )->tag( `Label`
+                                )->a( n = `text` v = ``
+                            )->tag( `Button`
+                                )->a( n = `press` v = client->_event( `SET_CURSOR_ONLY` )
+                                )->a( n = `text`  v = `Reference: SET_CURSOR only (no enabled change)` ).
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 

--- a/src/00/98/z2ui5_cl_smp_app_446.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_446.clas.abap
@@ -20,6 +20,8 @@ CLASS z2ui5_cl_smp_app_446 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/00/98/z2ui5_cl_smp_app_447.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_447.clas.abap
@@ -36,6 +36,8 @@ CLASS z2ui5_cl_smp_app_447 IMPLEMENTATION.
       ENDDO.
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_004.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_004.clas.abap
@@ -56,6 +56,7 @@ CLASS z2ui5_cl_smp_app_004 IMPLEMENTATION.
         ENDCASE.
       WHEN `BUTTON_ERROR`.
         DATA(dummy) = 1 / 0.
+        client->message_box_display( |{ dummy }| ).
     ENDCASE.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_004.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_004.clas.abap
@@ -25,6 +25,16 @@ CLASS z2ui5_cl_smp_app_004 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+
+      " the app has two views and remembers which one is up, so returning
+      " from a sub-app brings back the one the user left, not the first
+      IF view_main = `SECOND`.
+        view_second_display( ).
+      ELSE.
+        view_main_display( ).
+      ENDIF.
+
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_006.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_006.clas.abap
@@ -39,6 +39,8 @@ CLASS z2ui5_cl_smp_app_006 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_006.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_006.clas.abap
@@ -19,9 +19,8 @@ CLASS z2ui5_cl_smp_app_006 DEFINITION PUBLIC.
     DATA t_tab TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
 
   PROTECTED SECTION.
-    DATA client    TYPE REF TO z2ui5_if_client.
-    DATA check_ui5 TYPE abap_bool.
-    DATA key       TYPE string.
+    DATA client TYPE REF TO z2ui5_if_client.
+    DATA key    TYPE string.
 
     METHODS on_init.
     METHODS on_event.
@@ -30,7 +29,6 @@ CLASS z2ui5_cl_smp_app_006 DEFINITION PUBLIC.
 
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_006 IMPLEMENTATION.

--- a/src/01/z2ui5_cl_smp_app_008.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_008.clas.abap
@@ -23,6 +23,8 @@ CLASS z2ui5_cl_smp_app_008 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_008.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_008.clas.abap
@@ -15,7 +15,6 @@ CLASS z2ui5_cl_smp_app_008 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_008 IMPLEMENTATION.
 
 
@@ -48,6 +47,7 @@ CLASS z2ui5_cl_smp_app_008 IMPLEMENTATION.
       WHEN `BUTTON_MESSAGE_BOX_CX_ROOT`.
         TRY.
             DATA(lv_val) = 1 / 0.
+            client->message_box_display( |{ lv_val }| ).
           CATCH cx_root INTO DATA(lx).
             client->message_box_display( lx ).
         ENDTRY.

--- a/src/01/z2ui5_cl_smp_app_009.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_009.clas.abap
@@ -67,6 +67,8 @@ CLASS z2ui5_cl_smp_app_009 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_011.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_011.clas.abap
@@ -144,6 +144,8 @@ CLASS z2ui5_cl_smp_app_011 IMPLEMENTATION.
           ( ) ).
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( `BUTTON_EDIT` ).
       check_editable_active = xsdbool( check_editable_active = abap_false ).

--- a/src/01/z2ui5_cl_smp_app_011.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_011.clas.abap
@@ -28,7 +28,6 @@ CLASS z2ui5_cl_smp_app_011 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_011 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_019.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_019.clas.abap
@@ -153,6 +153,8 @@ CLASS z2ui5_cl_smp_app_019 IMPLEMENTATION.
           ( title = `title_03` value = `value_03` )
           ( title = `title_04` value = `value_04` )
           ( title = `title_05` value = `value_05` ) ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( `BUTTON_SEGMENT_CHANGE` ).
       client->message_toast_display( `Selection Mode changed` ).

--- a/src/01/z2ui5_cl_smp_app_024.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_024.clas.abap
@@ -19,7 +19,6 @@ CLASS z2ui5_cl_smp_app_024 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_024 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_025.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_025.clas.abap
@@ -30,6 +30,8 @@ CLASS z2ui5_cl_smp_app_025 IMPLEMENTATION.
       IF event_backend = `NEW_APP_EVENT`.
         client->message_box_display( `new app called and event NEW_APP_EVENT raised` ).
       ENDIF.
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_026.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_026.clas.abap
@@ -34,6 +34,8 @@ CLASS z2ui5_cl_smp_app_026 IMPLEMENTATION.
       quantity  = `500`.
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( `POPOVER` ).
       popover_display( `TEST` ).

--- a/src/01/z2ui5_cl_smp_app_027.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_027.clas.abap
@@ -35,6 +35,8 @@ CLASS z2ui5_cl_smp_app_027 IMPLEMENTATION.
       product  = `tomato`.
       quantity = `500`.
       input41  = `faasdfdfsaVIp`.
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_027.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_027.clas.abap
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_027 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_027 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_028.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_028.clas.abap
@@ -38,6 +38,8 @@ CLASS z2ui5_cl_smp_app_028 IMPLEMENTATION.
     IF client->check_on_init( ).
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( `TIMER_FINISHED` ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_045.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_045.clas.abap
@@ -25,7 +25,6 @@ CLASS z2ui5_cl_smp_app_045 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_045 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_047.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_047.clas.abap
@@ -29,7 +29,6 @@ CLASS z2ui5_cl_smp_app_047 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_047 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_048.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_048.clas.abap
@@ -22,7 +22,6 @@ CLASS z2ui5_cl_smp_app_048 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_048 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_050.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_050.clas.abap
@@ -23,10 +23,9 @@ CLASS z2ui5_cl_smp_app_050 IMPLEMENTATION.
       quantity = `500`.
     ENDIF.
 
-    CASE client->get_event( ).
-      WHEN `BUTTON_POST`.
-        client->message_toast_display( |{ product } { quantity } - send to the server| ).
-    ENDCASE.
+    IF client->get_event( ) = `BUTTON_POST`.
+      client->message_toast_display( |{ product } { quantity } - send to the server| ).
+    ENDIF.
 
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
         )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_052.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_052.clas.abap
@@ -161,6 +161,8 @@ CLASS z2ui5_cl_smp_app_052 IMPLEMENTATION.
       view_display( ).
       set_data( ).
       RETURN.
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     CASE client->get_event( ).

--- a/src/01/z2ui5_cl_smp_app_053.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_053.clas.abap
@@ -39,6 +39,8 @@ CLASS z2ui5_cl_smp_app_053 IMPLEMENTATION.
     IF client->check_on_init( ).
       set_data( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSE.
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_059.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_059.clas.abap
@@ -40,6 +40,8 @@ CLASS z2ui5_cl_smp_app_059 IMPLEMENTATION.
 
       set_data( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_061.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_061.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_smp_app_061 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_061 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_064.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_064.clas.abap
@@ -32,6 +32,8 @@ CLASS z2ui5_cl_smp_app_064 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      on_init( ).
 
     ELSE.
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_064.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_064.clas.abap
@@ -5,26 +5,6 @@ CLASS z2ui5_cl_smp_app_064 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    TYPES:
-      BEGIN OF ty_s_tab,
-        selkz     TYPE abap_bool,
-        row_id    TYPE string,
-        carrid    TYPE string,
-        connid    TYPE string,
-        fldate    TYPE string,
-        planetype TYPE string,
-      END OF ty_s_tab.
-    TYPES
-      ty_t_table TYPE STANDARD TABLE OF ty_s_tab WITH DEFAULT KEY.
-    TYPES:
-      BEGIN OF ty_s_filter_pop,
-        option TYPE string,
-        low    TYPE string,
-        high   TYPE string,
-        key    TYPE string,
-      END OF ty_s_filter_pop.
-
-    DATA mt_table TYPE ty_t_table.
     DATA mv_check_active TYPE abap_bool.
     DATA:
       BEGIN OF screen,
@@ -41,26 +21,11 @@ CLASS z2ui5_cl_smp_app_064 DEFINITION PUBLIC.
     METHODS on_init.
     METHODS on_event.
 
-    METHODS set_selkz
-      IMPORTING
-        iv_selkz TYPE abap_bool.
-
   PRIVATE SECTION.
 ENDCLASS.
 
 
 CLASS z2ui5_cl_smp_app_064 IMPLEMENTATION.
-
-  METHOD set_selkz.
-
-    FIELD-SYMBOLS <ls_table> TYPE ty_s_tab.
-
-    LOOP AT mt_table ASSIGNING <ls_table>.
-      <ls_table>-selkz = iv_selkz.
-    ENDLOOP.
-
-  ENDMETHOD.
-
 
   METHOD z2ui5_if_app~main.
 
@@ -76,9 +41,6 @@ CLASS z2ui5_cl_smp_app_064 IMPLEMENTATION.
 
 
   METHOD on_event.
-
-    DATA lt_arg TYPE string_table.
-    DATA ls_arg TYPE string.
 
     IF client->check_on_event( `LOAD` ).
 

--- a/src/01/z2ui5_cl_smp_app_067.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_067.clas.abap
@@ -14,7 +14,6 @@ CLASS z2ui5_cl_smp_app_067 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_067 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -63,6 +63,8 @@ CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      on_init( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -22,14 +22,6 @@ CLASS z2ui5_cl_smp_app_070 DEFINITION PUBLIC.
         process_state    TYPE string,
       END OF ty_s_tab.
 
-    TYPES:
-      BEGIN OF ty_s_filter_pop,
-        option TYPE string,
-        low    TYPE string,
-        high   TYPE string,
-        key    TYPE string,
-      END OF ty_s_filter_pop.
-
     DATA mt_mapping TYPE z2ui5_if_types=>ty_t_name_value.
     DATA mv_search_value TYPE string.
     DATA mt_table TYPE STANDARD TABLE OF ty_s_tab WITH EMPTY KEY.
@@ -49,7 +41,6 @@ CLASS z2ui5_cl_smp_app_070 DEFINITION PUBLIC.
 
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
@@ -367,7 +358,7 @@ CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
         ENDDO.
 
         IF lv_row NS mv_search_value.
-          DELETE mt_table.
+          DELETE mt_table INDEX sy-tabix.
         ENDIF.
       ENDLOOP.
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_071.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_071.clas.abap
@@ -35,6 +35,8 @@ CLASS z2ui5_cl_smp_app_071 IMPLEMENTATION.
 
       combo_fill( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( `UPDATE` ).
 

--- a/src/01/z2ui5_cl_smp_app_073.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_073.clas.abap
@@ -59,6 +59,8 @@ CLASS z2ui5_cl_smp_app_073 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     IF client->get_event( ) = `BUTTON_OPEN_NEW_TAB`.

--- a/src/01/z2ui5_cl_smp_app_073.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_073.clas.abap
@@ -61,23 +61,20 @@ CLASS z2ui5_cl_smp_app_073 IMPLEMENTATION.
       view_display( ).
     ENDIF.
 
-    CASE client->get_event( ).
+    IF client->get_event( ) = `BUTTON_OPEN_NEW_TAB`.
+      DATA(ls_config) = client->get( )-s_config.
+      DATA(result) = z2ui5_cl_smp_context=>app_get_url( classname = `z2ui5_cl_smp_app_073`
+                                                        origin    = ls_config-origin
+                                                        pathname  = ls_config-pathname
+                                                        search    = ls_config-search
+                                                        hash      = ls_config-hash ).
 
-      WHEN `BUTTON_OPEN_NEW_TAB`.
-
-        DATA(ls_config) = client->get( )-s_config.
-        DATA(result) = z2ui5_cl_smp_context=>app_get_url( classname = `z2ui5_cl_smp_app_073`
-                                                          origin    = ls_config-origin
-                                                          pathname  = ls_config-pathname
-                                                          search    = ls_config-search
-                                                          hash      = ls_config-hash ).
-
-        client->follow_up_action(
-            val   = z2ui5_if_client=>cs_event-open_new_tab
-            t_arg = VALUE #(
-                ( result )
-                ) ).
-    ENDCASE.
+      client->follow_up_action(
+          val   = z2ui5_if_client=>cs_event-open_new_tab
+          t_arg = VALUE #(
+              ( result )
+              ) ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -19,7 +19,6 @@ CLASS z2ui5_cl_smp_app_074 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
 
 
@@ -73,6 +72,8 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
 
   METHOD view_display.
 
+    FIELD-SYMBOLS <table> TYPE table.
+
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
         )->ele( n = `View` ns = `mvc`
             )->a( n = `displayBlock` v = `true`
@@ -97,7 +98,6 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
 
     IF table IS NOT INITIAL.
 
-      FIELD-SYMBOLS <table> TYPE table.
       ASSIGN table->* TO <table>.
 
       DATA(tab) = page->ele( `Table`

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -28,7 +28,7 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_078 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
 
 
@@ -99,21 +98,18 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get_event( ).
+    IF client->get_event( ) = `UPDATE_BACKEND`.
+      LOOP AT mt_tokens_removed INTO DATA(ls_token).
+        DELETE mt_token WHERE key = ls_token-key.
+      ENDLOOP.
 
-      WHEN `UPDATE_BACKEND`.
+      LOOP AT mt_tokens_added INTO ls_token.
+        INSERT VALUE #( key = ls_token-key text = ls_token-text visible = abap_true editable = abap_true ) INTO TABLE mt_token.
+      ENDLOOP.
 
-        LOOP AT mt_tokens_removed INTO DATA(ls_token).
-          DELETE mt_token WHERE key = ls_token-key.
-        ENDLOOP.
-
-        LOOP AT mt_tokens_added INTO ls_token.
-          INSERT VALUE #( key = ls_token-key text = ls_token-text visible = abap_true editable = abap_true ) INTO TABLE mt_token.
-        ENDLOOP.
-
-        mt_tokens_removed = VALUE #( ).
-        mt_tokens_added   = VALUE #( ).
-    ENDCASE.
+      mt_tokens_removed = VALUE #( ).
+      mt_tokens_added   = VALUE #( ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_081.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_081.clas.abap
@@ -173,6 +173,8 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
     IF client->check_on_init( ).
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSE.
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -28,6 +28,8 @@ CLASS z2ui5_cl_smp_app_088 IMPLEMENTATION.
     IF client->check_on_init( ).
       mv_page = `page1`.
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSE.
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_088.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_088.clas.abap
@@ -38,25 +38,14 @@ CLASS z2ui5_cl_smp_app_088 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-      WHEN OTHERS.
-        mv_page = client->get_event( ).
-        view_display( ).
-
-    ENDCASE.
+    mv_page = client->get_event( ).
+    view_display( ).
 
   ENDMETHOD.
 
 
   METHOD view_display.
 
-    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
-        )->ele( n = `View` ns = `mvc`
-            )->a( n = `displayBlock` v = `true`
-            )->a( n = `height`       v = `100%`
-            )->a( n = `xmlns`        v = `sap.m`
-            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-            )->a( n = `xmlns:core`   v = `sap.ui.core` ).
     DATA(page) = z2ui5_cl_ui5_view_builder=>factory(
         )->ele( n = `View` ns = `mvc`
             )->a( n = `displayBlock` v = `true`

--- a/src/01/z2ui5_cl_smp_app_097.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_097.clas.abap
@@ -186,8 +186,11 @@ CLASS z2ui5_cl_smp_app_097 IMPLEMENTATION.
         DELETE lt_sel WHERE selected = abap_false.
 
         READ TABLE lt_sel INTO DATA(ls_sel) INDEX 1.
-        ls_sel-uuid = z2ui5_cl_smp_context=>uuid_get_c32( ).
-        INSERT ls_sel INTO TABLE t_tab2.
+
+        IF sy-subrc = 0.
+          ls_sel-uuid = z2ui5_cl_smp_context=>uuid_get_c32( ).
+          INSERT ls_sel INTO TABLE t_tab2.
+        ENDIF.
 
         mv_layout = `TwoColumnsMidExpanded`.
 

--- a/src/01/z2ui5_cl_smp_app_097.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_097.clas.abap
@@ -172,6 +172,8 @@ CLASS z2ui5_cl_smp_app_097 IMPLEMENTATION.
 
       view_display_master( ).
       view_display_detail( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display_master( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_098.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_098.clas.abap
@@ -208,6 +208,8 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
 
       view_display_master( ).
       view_display_detail( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display_master( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_098.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_098.clas.abap
@@ -98,7 +98,7 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
         )->ele( n = `rowActionTemplate` ns = `table`
             )->ele( n = `RowAction` ns = `table`
                 )->ele( n = `RowActionItem` ns = `table`
-                    )->a( n = `type`  v = `Navigation` "icon = `sap-icon://navigation-right-arrow`
+                    )->a( n = `type`  v = `Navigation`
                     )->a( n = `press` v = client->_event( val = `ROW_NAVIGATE` t_arg = VALUE #( ( `${TITLE}` ) ) ) ).
 
     client->nest_view_display(
@@ -156,7 +156,7 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
                     )->a( n = `title`          v = `abap2UI5 - Nested View - Three Columns with FlexibleColumnLayout`
                     )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
                     )->a( n = `navButtonPress` v = client->_event_nav_app_leave( )
-                    )->a( n = `showHeader`     b = xsdbool( abap_false = client->get( )-check_launchpad_active ) ).
+                    )->a( n = `showHeader`     b = xsdbool( client->get( )-check_launchpad_active = abap_false ) ).
 
     page->tag( `MessageStrip`
         )->a( n = `text`     v = `A three-column FlexibleColumnLayout: select a row to open the detail column, then ` &&
@@ -214,7 +214,7 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
     CASE client->get_event( ).
 
       WHEN 'NN_VIEW'.
-        client->message_box_display(  `Event in nested nested view raised` ).
+        client->message_box_display( `Event in nested nested view raised` ).
 
       WHEN `ROW_NAVIGATE`.
 
@@ -230,7 +230,8 @@ CLASS z2ui5_cl_smp_app_098 IMPLEMENTATION.
         DELETE lt_sel WHERE selected = abap_false.
 
         READ TABLE lt_sel INTO DATA(ls_sel) INDEX 1.
-        IF NOT line_exists( t_tab2[ title = ls_sel-title ] ).
+
+        IF sy-subrc = 0 AND NOT line_exists( t_tab2[ title = ls_sel-title ] ).
           INSERT ls_sel INTO TABLE t_tab2.
         ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_104.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_104.clas.abap
@@ -164,6 +164,8 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
       layout = `OneColumn`.
       view_display_master( ).
       view_display_detail( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display_master( ).
 
     ELSEIF client->check_on_event( `SELCHANGE` ).
 

--- a/src/01/z2ui5_cl_smp_app_104.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_104.clas.abap
@@ -44,6 +44,11 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
     IF app_sub IS BOUND.
 
       ASSIGN app_sub->(`VIEW_PARENT`) TO FIELD-SYMBOL(<fs>).
+
+      IF sy-subrc <> 0.
+        RETURN.
+      ENDIF.
+
       <fs> = grid_sub.
       CALL METHOD app_sub->(`Z2UI5_IF_APP~MAIN`) EXPORTING client = client.
 
@@ -58,6 +63,11 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
     CREATE OBJECT app_sub TYPE (classname).
 
     ASSIGN app_sub->(`VIEW_PARENT`) TO FIELD-SYMBOL(<fs>).
+
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
     <fs> = grid_sub.
     CALL METHOD app_sub->(`Z2UI5_IF_APP~MAIN`) EXPORTING client = client.
 
@@ -160,6 +170,10 @@ CLASS z2ui5_cl_smp_app_104 IMPLEMENTATION.
       DATA(t_sel) = t_tab.
       DELETE t_sel WHERE selected = abap_false.
       READ TABLE t_sel INTO DATA(s_sel) INDEX 1.
+
+      IF sy-subrc <> 0.
+        RETURN.
+      ENDIF.
 
       IF classname IS NOT INITIAL.
         view_display_master( ).

--- a/src/01/z2ui5_cl_smp_app_105.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_105.clas.abap
@@ -69,6 +69,9 @@ CLASS z2ui5_cl_smp_app_105 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    " No check_on_navigated( ) branch: this is a SUB-APP. It never calls
+    " client->view_display( ) - it renders into the parent's view reference
+    " (view_parent), and the parent app owns the screen and re-displays it.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).

--- a/src/01/z2ui5_cl_smp_app_105.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_105.clas.abap
@@ -5,12 +5,9 @@ CLASS z2ui5_cl_smp_app_105 DEFINITION PUBLIC.
 
     DATA view_parent TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_class_1 TYPE string.
-    DATA mr_data TYPE REF TO data.
 
     METHODS on_event.
-    METHODS view_display
-      CHANGING
-        xml TYPE REF TO z2ui5_cl_ui5_view_builder OPTIONAL.
+    METHODS view_display.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/01/z2ui5_cl_smp_app_109.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_109.clas.abap
@@ -151,6 +151,8 @@ CLASS z2ui5_cl_smp_app_109 IMPLEMENTATION.
     IF client->check_on_init( ).
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_112.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_112.clas.abap
@@ -72,6 +72,9 @@ CLASS z2ui5_cl_smp_app_112 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    " No check_on_navigated( ) branch: this is a SUB-APP. It never calls
+    " client->view_display( ) - it renders into the parent's view reference
+    " (view_parent), and the parent app owns the screen and re-displays it.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).

--- a/src/01/z2ui5_cl_smp_app_112.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_112.clas.abap
@@ -11,13 +11,10 @@ CLASS z2ui5_cl_smp_app_112 DEFINITION PUBLIC.
 
     DATA view_parent TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA mv_class_2 TYPE string.
-    DATA mr_data TYPE REF TO data.
     DATA t_items TYPE STANDARD TABLE OF ty_s_item WITH EMPTY KEY.
 
     METHODS on_event.
-    METHODS view_display
-      CHANGING
-        xml TYPE REF TO z2ui5_cl_ui5_view_builder OPTIONAL.
+    METHODS view_display.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -5,17 +5,6 @@ CLASS z2ui5_cl_smp_app_120 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    TYPES:
-      BEGIN OF ty_s_spot,
-        tooltip       TYPE string,
-        type          TYPE string,
-        pos           TYPE string,
-        scale         TYPE string,
-        contentoffset TYPE string,
-        key           TYPE string,
-        icon          TYPE string,
-      END OF ty_s_spot.
-
     DATA longitude TYPE string.
     DATA latitude TYPE string.
     DATA altitude TYPE string.
@@ -44,18 +33,14 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CASE client->get_event( ).
-
-      WHEN `GEOLOCATION_ERROR`.
-
-        " the Geolocation control fires `error` when the position cannot be
-        " read; the code (1 = permission denied, 2 = position unavailable,
-        " 3 = timeout) and message are passed as event arguments.
-        client->message_box_display(
-            text = |Location unavailable ({ client->get_event_arg( 1 ) }): { client->get_event_arg( 2 ) }|
-            type = `error` ).
-
-    ENDCASE.
+    IF client->get_event( ) = `GEOLOCATION_ERROR`.
+      " the Geolocation control fires `error` when the position cannot be
+      " read; the code (1 = permission denied, 2 = position unavailable,
+      " 3 = timeout) and message are passed as event arguments.
+      client->message_box_display(
+          text = |Location unavailable ({ client->get_event_arg( 1 ) }): { client->get_event_arg( 2 ) }|
+          type = `error` ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_120.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_120.clas.abap
@@ -31,6 +31,8 @@ CLASS z2ui5_cl_smp_app_120 IMPLEMENTATION.
     IF client->check_on_init( ).
       view_display( ).
       RETURN.
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     IF client->get_event( ) = `GEOLOCATION_ERROR`.

--- a/src/01/z2ui5_cl_smp_app_122.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_122.clas.abap
@@ -200,6 +200,8 @@ CLASS z2ui5_cl_smp_app_122 IMPLEMENTATION.
 
       read_frontend_info( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_122.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_122.clas.abap
@@ -35,7 +35,6 @@ CLASS z2ui5_cl_smp_app_122 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_122 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_125.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_125.clas.abap
@@ -17,7 +17,7 @@ CLASS z2ui5_cl_smp_app_125 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_125.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_125.clas.abap
@@ -12,7 +12,6 @@ CLASS z2ui5_cl_smp_app_125 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_125 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_133.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_133.clas.abap
@@ -95,6 +95,8 @@ CLASS z2ui5_cl_smp_app_133 IMPLEMENTATION.
 
       view_display( ).
       RETURN.
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_133.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_133.clas.abap
@@ -19,7 +19,6 @@ CLASS z2ui5_cl_smp_app_133 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_133 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_143.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_143.clas.abap
@@ -160,6 +160,8 @@ CLASS z2ui5_cl_smp_app_143 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     view_display( ).

--- a/src/01/z2ui5_cl_smp_app_144.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_144.clas.abap
@@ -105,6 +105,8 @@ CLASS z2ui5_cl_smp_app_144 IMPLEMENTATION.
             ( title = `entry 02`  value = `blue` ) ).
       ENDDO.
       set_view( ).
+    ELSEIF client->check_on_navigated( ).
+      set_view( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_144.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_144.clas.abap
@@ -53,7 +53,7 @@ CLASS z2ui5_cl_smp_app_144 IMPLEMENTATION.
           )->a( n = `value` v = client->_bind( val = lr_row->value tab = t_tab tab_index = lv_tabix ) ).
     ENDLOOP.
 
-    DATA(tab) = page->ele( `Table`
+    page->ele( `Table`
         )->a( n = `items` v = client->_bind( t_tab )
         )->ele( `headerToolbar`
             )->ele( `OverflowToolbar`

--- a/src/01/z2ui5_cl_smp_app_160.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_160.clas.abap
@@ -36,7 +36,7 @@ CLASS z2ui5_cl_smp_app_160 DEFINITION PUBLIC.
         pl_q04         TYPE i,
         per_cent_q04   TYPE p LENGTH 2 DECIMALS 1,
       END OF ty_s_output.
-    DATA mt_output TYPE STANDARD TABLE OF ty_s_output.
+    DATA mt_output TYPE STANDARD TABLE OF ty_s_output WITH EMPTY KEY.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
@@ -47,7 +47,6 @@ CLASS z2ui5_cl_smp_app_160 DEFINITION PUBLIC.
 
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_160 IMPLEMENTATION.
@@ -88,12 +87,11 @@ CLASS z2ui5_cl_smp_app_160 IMPLEMENTATION.
 
     IF client->check_on_event( `PL_TOTAL_CHANGE` ).
       client->message_box_display(
-        `Id of Input via source object: ` &&  client->get_event_arg( ) && z2ui5_cl_smp_context=>cv_char_util_newline  &&
-        `Id of Input via event.oSource.sId: ` &&  client->get_event_arg( 2 ) && z2ui5_cl_smp_context=>cv_char_util_newline &&
-        `Value of same row, index: ` &&  client->get_event_arg( 3 ) && z2ui5_cl_smp_context=>cv_char_util_newline  &&
-        `Id of parent (row) via event.oSource.oParent.sId: ` &&  client->get_event_arg( 4 ) && z2ui5_cl_smp_context=>cv_char_util_newline  &&
-        `Attribute of parameters.value: ` &&  client->get_event_arg( 5 )
-        ).
+        `Id of Input via source object: ` && client->get_event_arg( ) && z2ui5_cl_smp_context=>cv_char_util_newline &&
+        `Id of Input via event.oSource.sId: ` && client->get_event_arg( 2 ) && z2ui5_cl_smp_context=>cv_char_util_newline &&
+        `Value of same row, index: ` && client->get_event_arg( 3 ) && z2ui5_cl_smp_context=>cv_char_util_newline &&
+        `Id of parent (row) via event.oSource.oParent.sId: ` && client->get_event_arg( 4 ) && z2ui5_cl_smp_context=>cv_char_util_newline &&
+        `Attribute of parameters.value: ` && client->get_event_arg( 5 ) ).
     ENDIF.
 
 

--- a/src/01/z2ui5_cl_smp_app_160.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_160.clas.abap
@@ -57,6 +57,8 @@ CLASS z2ui5_cl_smp_app_160 IMPLEMENTATION.
     IF client->check_on_init( ).
       model_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_161.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_161.clas.abap
@@ -30,7 +30,7 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
         )->a( n = `afterClose` v = client->_event( `BTN_OK_1ND` )
         )->ele( `content` ).
 
-    DATA(content) = dialog->tag( `Button`
+    dialog->tag( `Button`
         )->a( n = `press` v = client->_event( `GOTO_2ND` )
         )->a( n = `text`  v = `Open 2nd popup` ).
 
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_smp_app_161 IMPLEMENTATION.
         )->a( n = `afterClose` v = client->_event( `BTN_OK_2ND` )
         )->ele( `content` ).
 
-    DATA(content) = dialog->tag( `Label`
+    dialog->tag( `Label`
         )->a( n = `text` v = `this is a second popup` ).
 
     dialog->end(

--- a/src/01/z2ui5_cl_smp_app_163.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_163.clas.abap
@@ -115,6 +115,8 @@ CLASS z2ui5_cl_smp_app_163 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_166.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_166.clas.abap
@@ -103,6 +103,8 @@ CLASS z2ui5_cl_smp_app_166 IMPLEMENTATION.
       ms_struc2-incl_value2 = `val02_incl`.
 
       set_view( ).
+    ELSEIF client->check_on_navigated( ).
+      set_view( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_167.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_167.clas.abap
@@ -85,6 +85,8 @@ CLASS z2ui5_cl_smp_app_167 IMPLEMENTATION.
     IF client->check_on_init( ).
       mv_value = `my value`.
       set_view( ).
+    ELSEIF client->check_on_navigated( ).
+      set_view( ).
     ENDIF.
 
     CASE client->get_event( ).

--- a/src/01/z2ui5_cl_smp_app_167.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_167.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_smp_app_167 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_167 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_170.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_170.clas.abap
@@ -33,7 +33,7 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
         )->a( n = `afterClose` v = client->_event( `BTN_OK_1ND` )
         )->ele( `content` ).
 
-    DATA(content) = dialog->ele( `IconTabBar`
+    dialog->ele( `IconTabBar`
         )->a( n = `select`      v = client->follow_up_action( val   = client->cs_event-control_by_id
                                                                                          view  = client->cs_view-popup
                                                                                          t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
@@ -99,7 +99,7 @@ CLASS z2ui5_cl_smp_app_170 IMPLEMENTATION.
         )->a( n = `afterClose` v = client->_event( `BTN_OK_2ND` )
         )->ele( `content` ).
 
-    DATA(content) = dialog->tag( `Label`
+    dialog->tag( `Label`
         )->a( n = `text` v = `this is a second popup` ).
 
     dialog->end(

--- a/src/01/z2ui5_cl_smp_app_173.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_173.clas.abap
@@ -126,6 +126,8 @@ CLASS z2ui5_cl_smp_app_173 IMPLEMENTATION.
                            ( fname = `AGE`  merge = `false` visible = `false` ) ).
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_173.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_173.clas.abap
@@ -21,7 +21,7 @@ CLASS z2ui5_cl_smp_app_173 DEFINITION PUBLIC.
       END OF ty_s_layout,
       ty_t_layout TYPE STANDARD TABLE OF ty_s_layout WITH EMPTY KEY.
 
-    DATA mv_flag TYPE abap_bool. " VALUE abap_true.
+    DATA mv_flag TYPE abap_bool.
     DATA mt_layout TYPE ty_t_layout.
     DATA mt_data   TYPE ty_t_data.
 
@@ -32,7 +32,6 @@ CLASS z2ui5_cl_smp_app_173 DEFINITION PUBLIC.
 
   PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_smp_app_173 IMPLEMENTATION.
@@ -130,10 +129,9 @@ CLASS z2ui5_cl_smp_app_173 IMPLEMENTATION.
 
     ENDIF.
 
-    CASE client->get_event( ).
-      WHEN `CHANGE_FLAG`.
-        view_display( ).
-    ENDCASE.
+    IF client->get_event( ) = `CHANGE_FLAG`.
+      view_display( ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_186.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_186.clas.abap
@@ -115,6 +115,8 @@ CLASS z2ui5_cl_smp_app_186 IMPLEMENTATION.
 
       initialize( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_189.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_189.clas.abap
@@ -19,7 +19,6 @@ CLASS z2ui5_cl_smp_app_189 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_189 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_189.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_189.clas.abap
@@ -95,6 +95,8 @@ CLASS z2ui5_cl_smp_app_189 IMPLEMENTATION.
       client->follow_up_action(
           val   = z2ui5_if_client=>cs_event-set_focus
           t_arg = VALUE #( ( `IdOne` ) ) ).
+    ELSEIF client->check_on_navigated( ).
+      render( ).
     ENDIF.
 
     dispatch( ).

--- a/src/01/z2ui5_cl_smp_app_202.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_202.clas.abap
@@ -15,7 +15,6 @@ CLASS z2ui5_cl_smp_app_202 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_202 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_202.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_202.clas.abap
@@ -103,6 +103,8 @@ CLASS z2ui5_cl_smp_app_202 IMPLEMENTATION.
 
       view_display( client ).
       RETURN.
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
     ENDIF.
 
     CASE client->get_event( ).

--- a/src/01/z2ui5_cl_smp_app_255.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_255.clas.abap
@@ -106,7 +106,7 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
             )->a( n = `target` v = `_blank`
             )->a( n = `href`   v = `https://sdk.openui5.org/entity/sap.m.FlexBox/sample/sap.m.sample.FlexBoxNav` ).
 
-    DATA(layout) = page->ele( `VBox`
+    page->ele( `VBox`
         )->a( n = `class` v = `navigationExamples`
         )->ele( `Panel`
             )->a( n = `headerText` v = `Variable width`

--- a/src/01/z2ui5_cl_smp_app_255.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_255.clas.abap
@@ -198,6 +198,8 @@ CLASS z2ui5_cl_smp_app_255 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
     ENDIF.
 
     on_event( client ).

--- a/src/01/z2ui5_cl_smp_app_279.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_279.clas.abap
@@ -27,6 +27,8 @@ CLASS z2ui5_cl_smp_app_279 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_305.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_305.clas.abap
@@ -128,6 +128,8 @@ CLASS z2ui5_cl_smp_app_305 IMPLEMENTATION.
           ( title = `entry 06`  value = `grey` ) ).
 
       set_view( ).
+    ELSEIF client->check_on_navigated( ).
+      set_view( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -61,6 +61,8 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
                                      ( key = `right` text = `right` ) ).
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_306.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_306.clas.abap
@@ -10,8 +10,10 @@ CLASS z2ui5_cl_smp_app_306 DEFINITION PUBLIC.
         time      TYPE string,
         id        TYPE string,
         name      TYPE string,
-        data      TYPE string,    " full resolution - backend only
-        thumbnail TYPE string,    " small preview - used in model
+        " data is the full resolution, backend only; thumbnail is the small
+        " preview that goes into the model
+        data      TYPE string,
+        thumbnail TYPE string,
         selected  TYPE abap_bool,
       END OF ty_s_picture.
 
@@ -20,7 +22,7 @@ CLASS z2ui5_cl_smp_app_306 DEFINITION PUBLIC.
         key  TYPE string,
         text TYPE string,
       END OF ty_s_combo,
-      tt_combo TYPE STANDARD TABLE OF ty_s_combo WITH EMPTY KEY.
+      ty_t_combo TYPE STANDARD TABLE OF ty_s_combo WITH EMPTY KEY.
 
     DATA mt_picture       TYPE STANDARD TABLE OF ty_s_picture WITH EMPTY KEY.
     DATA mt_picture_out   TYPE STANDARD TABLE OF ty_s_picture WITH EMPTY KEY.
@@ -28,9 +30,9 @@ CLASS z2ui5_cl_smp_app_306 DEFINITION PUBLIC.
     DATA mv_picture_base  TYPE string.
     DATA mv_picture_thumb TYPE string.
     DATA facing_mode      TYPE string.
-    DATA facing_modes     TYPE tt_combo.
+    DATA facing_modes     TYPE ty_t_combo.
     DATA device           TYPE string.
-    DATA devices          TYPE tt_combo.
+    DATA devices          TYPE ty_t_combo.
 
   PROTECTED SECTION.
     DATA selected_picture TYPE ty_s_picture.
@@ -52,7 +54,7 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
 
-      facing_modes = VALUE tt_combo( ( key = `` text = `` )
+      facing_modes = VALUE ty_t_combo( ( key = `` text = `` )
                                      ( key = `environment` text = `environment` )
                                      ( key = `user` text = `user` )
                                      ( key = `left` text = `left` )
@@ -186,8 +188,7 @@ CLASS z2ui5_cl_smp_app_306 IMPLEMENTATION.
       INSERT VALUE #( name      = |picture { sy-tabix }|
                       id        = sy-tabix
                       thumbnail = ls_pic-thumbnail
-                      selected  = COND #( WHEN sy-tabix = selected_picture-id
-                                          THEN abap_true ) )
+                      selected  = xsdbool( sy-tabix = selected_picture-id ) )
              INTO TABLE mt_picture_out.
     ENDLOOP.
 

--- a/src/01/z2ui5_cl_smp_app_316.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_316.clas.abap
@@ -183,6 +183,8 @@ CLASS z2ui5_cl_smp_app_316 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       view_display( client ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( client ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -13,7 +13,6 @@ CLASS z2ui5_cl_smp_app_325 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_325 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_smp_app_325 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_352.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_352.clas.abap
@@ -32,6 +32,8 @@ CLASS z2ui5_cl_smp_app_352 IMPLEMENTATION.
       client->follow_up_action(
           val   = z2ui5_if_client=>cs_event-keyboard_set_mode
           t_arg = VALUE #( ( `ZINPUT` ) ( `numeric` ) ) ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
     on_event( ).

--- a/src/01/z2ui5_cl_smp_app_352.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_352.clas.abap
@@ -17,7 +17,6 @@ CLASS z2ui5_cl_smp_app_352 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_352 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_361.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_361.clas.abap
@@ -13,7 +13,7 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_362.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_362.clas.abap
@@ -34,6 +34,8 @@ CLASS z2ui5_cl_smp_app_362 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_362.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_362.clas.abap
@@ -26,7 +26,6 @@ CLASS z2ui5_cl_smp_app_362 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_362 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_363.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_363.clas.abap
@@ -26,6 +26,8 @@ CLASS z2ui5_cl_smp_app_363 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_381.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_381.clas.abap
@@ -38,6 +38,8 @@ CLASS z2ui5_cl_smp_app_381 IMPLEMENTATION.
     IF client->check_on_init( ).
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( `SHOW` ).
       show_toast( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_382.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_382.clas.abap
@@ -28,6 +28,8 @@ CLASS z2ui5_cl_smp_app_382 IMPLEMENTATION.
     IF client->check_on_init( ).
       on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_445.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_445.clas.abap
@@ -26,7 +26,6 @@ CLASS z2ui5_cl_smp_app_445 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.

--- a/src/01/z2ui5_cl_smp_app_445.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_445.clas.abap
@@ -33,6 +33,8 @@ CLASS z2ui5_cl_smp_app_445 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_448.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_448.clas.abap
@@ -24,6 +24,8 @@ CLASS z2ui5_cl_smp_app_448 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_448.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_448.clas.abap
@@ -33,24 +33,21 @@ CLASS z2ui5_cl_smp_app_448 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `TOGGLE`.
-        " invert the mirrored state and call the whitelisted setExpanded on
-        " the panel - client-side, after the response renders, no rebuild.
-        " t_arg is positional: id, method, params (the view defaults to
-        " cs_view-main and can be omitted for a main-view control)
-        expanded = xsdbool( expanded = abap_false ).
-        " Driving a property through control_by_id IS this sample; the two-way
-        " binding the rule recommends is what app 449 shows instead.
-        " abap2ui5lint-disable settable-property-via-action
-        client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
-                                  t_arg = VALUE #( ( `demoPanel` )
-                                                   ( `setExpanded` )
-                                                   ( CONV string( expanded ) ) ) ).
-        " abap2ui5lint-enable settable-property-via-action
-
-    ENDCASE.
+    IF client->get_event( ) = `TOGGLE`.
+      " invert the mirrored state and call the whitelisted setExpanded on
+      " the panel - client-side, after the response renders, no rebuild.
+      " t_arg is positional: id, method, params (the view defaults to
+      " cs_view-main and can be omitted for a main-view control)
+      expanded = xsdbool( expanded = abap_false ).
+      " Driving a property through control_by_id IS this sample; the two-way
+      " binding the rule recommends is what app 449 shows instead.
+      " abap2ui5lint-disable settable-property-via-action
+      client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
+                                t_arg = VALUE #( ( `demoPanel` )
+                                                 ( `setExpanded` )
+                                                 ( CONV string( expanded ) ) ) ).
+      " abap2ui5lint-enable settable-property-via-action
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_449.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_449.clas.abap
@@ -31,18 +31,15 @@ CLASS z2ui5_cl_smp_app_449 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `OPEN`.
-        " open the popup-mode PDFViewer via the whitelisted open method -
-        " the viewer brings its own dialog and close button.
-        " t_arg is positional: id, method (the view defaults to cs_view-main
-        " and can be omitted for a main-view control)
-        client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
-                                  t_arg = VALUE #( ( `demoPdf` )
-                                                   ( `open` ) ) ).
-
-    ENDCASE.
+    IF client->get_event( ) = `OPEN`.
+      " open the popup-mode PDFViewer via the whitelisted open method -
+      " the viewer brings its own dialog and close button.
+      " t_arg is positional: id, method (the view defaults to cs_view-main
+      " and can be omitted for a main-view control)
+      client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
+                                t_arg = VALUE #( ( `demoPdf` )
+                                                 ( `open` ) ) ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_449.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_449.clas.abap
@@ -22,6 +22,8 @@ CLASS z2ui5_cl_smp_app_449 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_450.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_450.clas.abap
@@ -32,6 +32,8 @@ CLASS z2ui5_cl_smp_app_450 IMPLEMENTATION.
       tims         = `134501`.
       dats_initial = `00000000`.
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_452.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_452.clas.abap
@@ -37,6 +37,8 @@ CLASS z2ui5_cl_smp_app_452 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_453.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_453.clas.abap
@@ -56,6 +56,8 @@ CLASS z2ui5_cl_smp_app_453 IMPLEMENTATION.
             status = `Discontinued` delivery = `Pending` ) ).
       products_prepare( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_454.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_454.clas.abap
@@ -21,7 +21,6 @@ CLASS z2ui5_cl_smp_app_454 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_454 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_454.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_454.clas.abap
@@ -36,6 +36,8 @@ CLASS z2ui5_cl_smp_app_454 IMPLEMENTATION.
           ( name = `Comfort Easy`       category = `PDAs` )
           ( name = `ITelO Vault`        category = `PDAs` ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_455.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_455.clas.abap
@@ -35,6 +35,8 @@ CLASS z2ui5_cl_smp_app_455 IMPLEMENTATION.
           ( name = `Comfort Easy`       category = `PDAs` )
           ( name = `ITelO Vault`        category = `PDAs` ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_455.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_455.clas.abap
@@ -20,7 +20,6 @@ CLASS z2ui5_cl_smp_app_455 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_455 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_456.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_456.clas.abap
@@ -48,6 +48,8 @@ CLASS z2ui5_cl_smp_app_456 IMPLEMENTATION.
                 ( start_at = `2026-07-20T09:30:00` end_at = `2026-07-20T10:30:00`
                   title = `Code review` type = `Type06` ) ) ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_457.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_457.clas.abap
@@ -24,6 +24,8 @@ CLASS z2ui5_cl_smp_app_457 IMPLEMENTATION.
     IF client->check_on_init( ).
       date_iso = `2026-07-20`.
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -45,35 +45,32 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `REORDER`.
-        " the three event args arrive resolved client-side from the drop
-        " event: dragged row index, drop target index (both 0-based) and
-        " the drop position (Before/After)
-        TRY.
-            DATA(lv_from) = CONV i( client->get_event_arg( ) ) + 1.
-            DATA(lv_to)   = CONV i( client->get_event_arg( 2 ) ) + 1.
-            DATA(lv_pos)  = client->get_event_arg( 3 ).
-            DATA(ls_row)  = t_products[ lv_from ].
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-        " dropping a row onto itself is a no-op
-        IF lv_from = lv_to.
+    IF client->get_event( ) = `REORDER`.
+      " the three event args arrive resolved client-side from the drop
+      " event: dragged row index, drop target index (both 0-based) and
+      " the drop position (Before/After)
+      TRY.
+          DATA(lv_from) = CONV i( client->get_event_arg( ) ) + 1.
+          DATA(lv_to)   = CONV i( client->get_event_arg( 2 ) ) + 1.
+          DATA(lv_pos)  = client->get_event_arg( 3 ).
+          DATA(ls_row)  = t_products[ lv_from ].
+        CATCH cx_root.
           RETURN.
-        ENDIF.
-        DELETE t_products INDEX lv_from.
-        IF lv_from < lv_to.
-          lv_to = lv_to - 1.
-        ENDIF.
-        IF lv_pos = `Before`.
-          INSERT ls_row INTO t_products INDEX lv_to.
-        ELSE.
-          INSERT ls_row INTO t_products INDEX lv_to + 1.
-        ENDIF.
-
-    ENDCASE.
+      ENDTRY.
+      " dropping a row onto itself is a no-op
+      IF lv_from = lv_to.
+        RETURN.
+      ENDIF.
+      DELETE t_products INDEX lv_from.
+      IF lv_from < lv_to.
+        lv_to = lv_to - 1.
+      ENDIF.
+      IF lv_pos = `Before`.
+        INSERT ls_row INTO t_products INDEX lv_to.
+      ELSE.
+        INSERT ls_row INTO t_products INDEX lv_to + 1.
+      ENDIF.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_459.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_459.clas.abap
@@ -36,6 +36,8 @@ CLASS z2ui5_cl_smp_app_459 IMPLEMENTATION.
           ( name = `Comfort Easy`       category = `PDAs` )
           ( name = `ITelO Vault`        category = `PDAs` ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_460.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_460.clas.abap
@@ -49,6 +49,8 @@ CLASS z2ui5_cl_smp_app_460 IMPLEMENTATION.
                   ( text = `Beach.jpg` ) ) ) ) )
           ( text = `Music` ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -26,7 +26,6 @@ CLASS z2ui5_cl_smp_app_461 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
 
 
@@ -51,53 +50,50 @@ CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `MOVE_NODE`.
-        " both event args arrive resolved client-side: the binding context
-        " paths of the dragged and the drop target item, e.g.
-        " /T_NODES/0/NODES/1 (a file) and /T_NODES/2 (a folder) - so parse
-        " from the END of the path
-        SPLIT client->get_event_arg( ) AT `/` INTO TABLE DATA(lt_drag).
-        SPLIT client->get_event_arg( 2 ) AT `/` INTO TABLE DATA(lt_drop).
-        DATA(lv_drag_lines) = lines( lt_drag ).
-        DATA(lv_drop_lines) = lines( lt_drop ).
-        IF lv_drag_lines < 4 OR lv_drop_lines < 2
-            OR VALUE #( lt_drag[ lv_drag_lines - 1 ] OPTIONAL ) <> `NODES`
-            OR VALUE #( lt_drag[ lv_drag_lines - 3 ] OPTIONAL ) <> `T_NODES`
-            OR VALUE #( lt_drop[ lv_drop_lines - 1 ] OPTIONAL ) <> `T_NODES`.
-          client->message_toast_display( `drop a file onto a folder` ).
+    IF client->get_event( ) = `MOVE_NODE`.
+      " both event args arrive resolved client-side: the binding context
+      " paths of the dragged and the drop target item, e.g.
+      " /T_NODES/0/NODES/1 (a file) and /T_NODES/2 (a folder) - so parse
+      " from the END of the path
+      SPLIT client->get_event_arg( ) AT `/` INTO TABLE DATA(lt_drag).
+      SPLIT client->get_event_arg( 2 ) AT `/` INTO TABLE DATA(lt_drop).
+      DATA(lv_drag_lines) = lines( lt_drag ).
+      DATA(lv_drop_lines) = lines( lt_drop ).
+      IF lv_drag_lines < 4 OR lv_drop_lines < 2
+          OR VALUE #( lt_drag[ lv_drag_lines - 1 ] OPTIONAL ) <> `NODES`
+          OR VALUE #( lt_drag[ lv_drag_lines - 3 ] OPTIONAL ) <> `T_NODES`
+          OR VALUE #( lt_drop[ lv_drop_lines - 1 ] OPTIONAL ) <> `T_NODES`.
+        client->message_toast_display( `drop a file onto a folder` ).
+        RETURN.
+      ENDIF.
+      TRY.
+          DATA(lv_from_root)  = CONV i( lt_drag[ lv_drag_lines - 2 ] ) + 1.
+          DATA(lv_from_child) = CONV i( lt_drag[ lv_drag_lines ] ) + 1.
+          DATA(lv_to_root)    = CONV i( lt_drop[ lv_drop_lines ] ) + 1.
+          DATA(ls_child)      = t_nodes[ lv_from_root ]-nodes[ lv_from_child ].
+        CATCH cx_root.
           RETURN.
-        ENDIF.
-        TRY.
-            DATA(lv_from_root)  = CONV i( lt_drag[ lv_drag_lines - 2 ] ) + 1.
-            DATA(lv_from_child) = CONV i( lt_drag[ lv_drag_lines ] ) + 1.
-            DATA(lv_to_root)    = CONV i( lt_drop[ lv_drop_lines ] ) + 1.
-            DATA(ls_child)      = t_nodes[ lv_from_root ]-nodes[ lv_from_child ].
-          CATCH cx_root.
-            RETURN.
-        ENDTRY.
-        " dropping a file onto its own parent folder is a no-op
-        IF lv_from_root = lv_to_root.
-          RETURN.
-        ENDIF.
-        ASSIGN t_nodes[ lv_from_root ] TO FIELD-SYMBOL(<from>).
-        IF sy-subrc <> 0.
-          RETURN.
-        ENDIF.
-        ASSIGN t_nodes[ lv_to_root ] TO FIELD-SYMBOL(<to>).
-        IF sy-subrc <> 0.
-          RETURN.
-        ENDIF.
-        DELETE <from>-nodes INDEX lv_from_child.
-        APPEND ls_child TO <to>-nodes.
-        " full view rebuild instead of relying on the automatic model push:
-        " the z2ui5.cc.Tree companion re-applies the expand state (snapshotted
-        " before this roundtrip) only when it renders - a pure model refresh
-        " would leave the rebuilt tree binding collapsed
-        view_display( ).
-
-    ENDCASE.
+      ENDTRY.
+      " dropping a file onto its own parent folder is a no-op
+      IF lv_from_root = lv_to_root.
+        RETURN.
+      ENDIF.
+      ASSIGN t_nodes[ lv_from_root ] TO FIELD-SYMBOL(<from>).
+      IF sy-subrc <> 0.
+        RETURN.
+      ENDIF.
+      ASSIGN t_nodes[ lv_to_root ] TO FIELD-SYMBOL(<to>).
+      IF sy-subrc <> 0.
+        RETURN.
+      ENDIF.
+      DELETE <from>-nodes INDEX lv_from_child.
+      APPEND ls_child TO <to>-nodes.
+      " full view rebuild instead of relying on the automatic model push:
+      " the z2ui5.cc.Tree companion re-applies the expand state (snapshotted
+      " before this roundtrip) only when it renders - a pure model refresh
+      " would leave the rebuilt tree binding collapsed
+      view_display( ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_461.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_461.clas.abap
@@ -41,6 +41,8 @@ CLASS z2ui5_cl_smp_app_461 IMPLEMENTATION.
               ( text = `Old_Report.pdf` ) ) )
           ( text = `Trash` ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -32,7 +32,6 @@ CLASS z2ui5_cl_smp_app_462 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_462.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_462.clas.abap
@@ -50,6 +50,8 @@ CLASS z2ui5_cl_smp_app_462 IMPLEMENTATION.
               ( text = `Suppliers` nodes = VALUE #(
                   ( text = `Very Best Screens` ) ) ) ) ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -57,19 +57,16 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `SHOW_MODEL`.
-        " the bound inputs have already written the edits back into
-        " t_nodes before on_event runs - read the (possibly renamed) roots
-        " back and echo them, proving the round-trip
-        DATA(lv_roots) = ``.
-        LOOP AT t_nodes INTO DATA(ls_node).
-          lv_roots = |{ lv_roots }{ COND #( WHEN sy-tabix > 1 THEN `, ` ) }{ ls_node-text }|.
-        ENDLOOP.
-        client->message_toast_display( |Root nodes now: { lv_roots }| ).
-
-    ENDCASE.
+    IF client->get_event( ) = `SHOW_MODEL`.
+      " the bound inputs have already written the edits back into
+      " t_nodes before on_event runs - read the (possibly renamed) roots
+      " back and echo them, proving the round-trip
+      DATA(lv_roots) = ``.
+      LOOP AT t_nodes INTO DATA(ls_node).
+        lv_roots = |{ lv_roots }{ COND #( WHEN sy-tabix > 1 THEN `, ` ) }{ ls_node-text }|.
+      ENDLOOP.
+      client->message_toast_display( |Root nodes now: { lv_roots }| ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_463.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_463.clas.abap
@@ -48,6 +48,8 @@ CLASS z2ui5_cl_smp_app_463 IMPLEMENTATION.
               ( text = `Vacation` nodes = VALUE #(
                   ( text = `Beach.jpg` ) ) ) ) ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_464.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_464.clas.abap
@@ -22,6 +22,8 @@ CLASS z2ui5_cl_smp_app_464 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_464.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_464.clas.abap
@@ -41,6 +41,7 @@ CLASS z2ui5_cl_smp_app_464 IMPLEMENTATION.
       WHEN `DIVIDE_BY_ZERO`.
         DATA(lv_zero) = 0.
         DATA(lv_result) = 1 / lv_zero.
+        client->message_box_display( |{ lv_result }| ).
 
       WHEN `ASSERT`.
         ASSERT 1 = 0.

--- a/src/01/z2ui5_cl_smp_app_465.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_465.clas.abap
@@ -22,6 +22,8 @@ CLASS z2ui5_cl_smp_app_465 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSE.
       on_event( ).
     ENDIF.

--- a/src/01/z2ui5_cl_smp_app_465.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_465.clas.abap
@@ -31,20 +31,17 @@ CLASS z2ui5_cl_smp_app_465 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-
-      WHEN `TOGGLE`.
-        " toggle the popover open/closed, anchored to the pressed button's DOM
-        " ref - the whitelisted toggleBy opens it if closed, closes it if open
-        " (the controller pattern oPopover.openBy(oButton) / oPopover.close()).
-        " t_arg is positional: id, method, anchor id (the view defaults to
-        " cs_view-main and can be omitted for a main-view control)
-        client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
-                                  t_arg = VALUE #( ( `demoPopover` )
-                                                   ( `toggleBy` )
-                                                   ( client->get_event_arg( ) ) ) ).
-
-    ENDCASE.
+    IF client->get_event( ) = `TOGGLE`.
+      " toggle the popover open/closed, anchored to the pressed button's DOM
+      " ref - the whitelisted toggleBy opens it if closed, closes it if open
+      " (the controller pattern oPopover.openBy(oButton) / oPopover.close()).
+      " t_arg is positional: id, method, anchor id (the view defaults to
+      " cs_view-main and can be omitted for a main-view control)
+      client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
+                                t_arg = VALUE #( ( `demoPopover` )
+                                                 ( `toggleBy` )
+                                                 ( client->get_event_arg( ) ) ) ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_466.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_466.clas.abap
@@ -28,6 +28,8 @@ CLASS z2ui5_cl_smp_app_466 IMPLEMENTATION.
                     `%%icon:sap-icon://stethoscope%%`.
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_467.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_467.clas.abap
@@ -50,6 +50,8 @@ CLASS z2ui5_cl_smp_app_467 IMPLEMENTATION.
             additionaltext = `Autosave` ) ).
 
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_469.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_469.clas.abap
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_smp_app_469 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_469 IMPLEMENTATION.
 
 

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -61,6 +61,8 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
                             ( name = `Cable 1 m` qty = 1 unit = `pc` )
                             ( name = `Quick Guide` qty = 1 unit = `pc` ) ) ) ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( ).
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_470.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_470.clas.abap
@@ -41,7 +41,6 @@ CLASS z2ui5_cl_smp_app_470 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-
 CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
 
 
@@ -72,10 +71,9 @@ CLASS z2ui5_cl_smp_app_470 IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get_event( ).
-      WHEN `SHOW`.
-        popup_components( client->get_event_arg( ) ).
-    ENDCASE.
+    IF client->get_event( ) = `SHOW`.
+      popup_components( client->get_event_arg( ) ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/z2ui5_cl_smp_app_473.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_473.clas.abap
@@ -20,6 +20,8 @@ CLASS z2ui5_cl_smp_app_473 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/01/z2ui5_cl_smp_app_488.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_488.clas.abap
@@ -48,26 +48,28 @@ CLASS z2ui5_cl_smp_app_488 IMPLEMENTATION.
     DATA(ls_get) = client->get( ).
     returned_event = ls_get-event.
 
-    IF returned_event = `DATA_CONFIRMED`.
+    CASE returned_event.
 
-      " the payload handed over by nav_app_leave( r_data = ... ) arrives as a
-      " generic data reference - the receiver decides the type
-      ASSIGN ls_get-r_event_data->* TO FIELD-SYMBOL(<s_result>).
+      WHEN `DATA_CONFIRMED`.
 
-      IF <s_result> IS ASSIGNED.
+        " the payload handed over by nav_app_leave( r_data = ... ) arrives as a
+        " generic data reference - the receiver decides the type
+        ASSIGN ls_get-r_event_data->* TO FIELD-SYMBOL(<s_result>).
 
-        s_result = <s_result>.
-        client->message_toast_display( |Returned event { returned_event }, | &&
-                                       |product { s_result-product }, quantity { s_result-quantity }| ).
+        IF <s_result> IS ASSIGNED.
 
-      ENDIF.
+          s_result = <s_result>.
+          client->message_toast_display( |Returned event { returned_event }, | &&
+                                         |product { s_result-product }, quantity { s_result-quantity }| ).
 
-    ELSEIF returned_event = `DATA_CANCELLED`.
+        ENDIF.
 
-      s_result = VALUE #( ).
-      client->message_toast_display( `Returned event DATA_CANCELLED, no data passed` ).
+      WHEN `DATA_CANCELLED`.
 
-    ENDIF.
+        s_result = VALUE #( ).
+        client->message_toast_display( `Returned event DATA_CANCELLED, no data passed` ).
+
+    ENDCASE.
 
     view_display( ).
 

--- a/src/01/z2ui5_cl_smp_app_490.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_490.clas.abap
@@ -34,6 +34,8 @@ CLASS z2ui5_cl_smp_app_490 IMPLEMENTATION.
       " popover anchored to a control of that very view
       view_display( ).
       popover_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( `REBUILD_AND_OPEN` ).
       " same pair on an event roundtrip: the view is REPLACED and the
       " popover opens on the freshly built anchor

--- a/src/01/z2ui5_cl_smp_app_491.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_491.clas.abap
@@ -16,7 +16,7 @@ CLASS z2ui5_cl_smp_app_491 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_492.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_492.clas.abap
@@ -17,7 +17,7 @@ CLASS z2ui5_cl_smp_app_492 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(s_config) = client->get( )-s_config.
       url = s_config-pathname && s_config-search.

--- a/src/01/z2ui5_cl_smp_app_493.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_493.clas.abap
@@ -14,7 +14,7 @@ CLASS z2ui5_cl_smp_app_493 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_494.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_494.clas.abap
@@ -9,6 +9,10 @@ CLASS z2ui5_cl_smp_app_494 DEFINITION PUBLIC.
     DATA greeting TYPE string.
 
   PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS view_display.
+
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -17,58 +21,65 @@ CLASS z2ui5_cl_smp_app_494 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
+    me->client = client.
     IF client->check_on_init( ).
-
       name = `World`.
-
-      DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
-          )->ele( n = `View` ns = `mvc`
-              )->a( n = `displayBlock` v = `true`
-              )->a( n = `height`       v = `100%`
-              )->a( n = `xmlns`        v = `sap.m`
-              )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
-              )->a( n = `xmlns:core`   v = `sap.ui.core`
-              )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
-      DATA(page) = view->ele( `Shell`
-          )->ele( `Page`
-              )->a( n = `title`          v = `abap2UI5 - Basics II - Data Binding: Input and Button`
-              )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
-              )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
-
-      page->tag( `MessageStrip`
-          )->a( n = `text`     v = `client->_bind( name ) connects the public attribute NAME with the input ` &&
-                     `below. Type a name and leave the field: the text ` &&
-                     `next to it changes without any ABAP code, because both are bound to the ` &&
-                     `same attribute. Press Greet and the backend reads NAME - already filled ` &&
-                     `in, no event argument needed - and writes GREETING back into the view.`
-          )->a( n = `type`     v = `Information`
-          )->a( n = `showIcon` b = abap_true
-          )->a( n = `class`    v = `sapUiSmallMargin` ).
-
-      page->ele( n = `SimpleForm` ns = `form`
-          )->a( n = `title`    v = `Data Binding`
-          )->a( n = `editable` b = abap_true
-          )->ele( n = `content` ns = `form`
-              )->tag( `Label`
-                  )->a( n = `text` v = `your name`
-              )->tag( `Input`
-                  )->a( n = `value` v = client->_bind( name )
-              )->tag( `Label`
-                  )->a( n = `text` v = `bound to the same attribute`
-              )->tag( `Text`
-                  )->a( n = `text` v = client->_bind( name )
-              )->tag( `Label`
-                  )->a( n = `text` v = `written by the backend`
-              )->tag( `Text`
-                  )->a( n = `text` v = client->_bind( greeting )
-              )->tag( `Button`
-                  )->a( n = `press` v = client->_event( `GREET` )
-                  )->a( n = `text`  v = `Greet` ).
-      client->view_display( view->stringify( ) ).
-
+      view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
     ELSEIF client->check_on_event( `GREET` ).
       greeting = |Hello { name }!|.
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `displayBlock` v = `true`
+            )->a( n = `height`       v = `100%`
+            )->a( n = `xmlns`        v = `sap.m`
+            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:core`   v = `sap.ui.core`
+            )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+    DATA(page) = view->ele( `Shell`
+        )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics II - Data Binding: Input and Button`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
+
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `client->_bind( name ) connects the public attribute NAME with the input ` &&
+                   `below. Type a name and leave the field: the text ` &&
+                   `next to it changes without any ABAP code, because both are bound to the ` &&
+                   `same attribute. Press Greet and the backend reads NAME - already filled ` &&
+                   `in, no event argument needed - and writes GREETING back into the view.`
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
+
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Data Binding`
+        )->a( n = `editable` b = abap_true
+        )->ele( n = `content` ns = `form`
+            )->tag( `Label`
+                )->a( n = `text` v = `your name`
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( name )
+            )->tag( `Label`
+                )->a( n = `text` v = `bound to the same attribute`
+            )->tag( `Text`
+                )->a( n = `text` v = client->_bind( name )
+            )->tag( `Label`
+                )->a( n = `text` v = `written by the backend`
+            )->tag( `Text`
+                )->a( n = `text` v = client->_bind( greeting )
+            )->tag( `Button`
+                )->a( n = `press` v = client->_event( `GREET` )
+                )->a( n = `text`  v = `Greet` ).
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_495.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_495.clas.abap
@@ -10,12 +10,12 @@ CLASS z2ui5_cl_smp_app_495 DEFINITION PUBLIC.
         no    TYPE string,
         check TYPE string,
       END OF ty_s_step.
-    DATA t_log TYPE STANDARD TABLE OF ty_s_step WITH DEFAULT KEY.
+    DATA t_log TYPE STANDARD TABLE OF ty_s_step WITH EMPTY KEY.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
 
-    METHODS log
+    METHODS log_step
       IMPORTING
         val TYPE string.
     METHODS view_display.
@@ -31,20 +31,20 @@ CLASS z2ui5_cl_smp_app_495 IMPLEMENTATION.
     me->client = client.
     IF client->check_on_init( ).
 
-      log( `check_on_init( ) - the very first call, nothing exists yet` ).
+      log_step( `check_on_init( ) - the very first call, nothing exists yet` ).
       view_display( ).
 
     ELSEIF client->check_on_navigated( ).
 
-      log( `check_on_navigated( ) - the sub-app returned, re-display the view` ).
+      log_step( `check_on_navigated( ) - the sub-app returned, re-display the view` ).
       view_display( ).
 
     ELSEIF client->check_on_event( `LOG` ).
-      log( `check_on_event( ) - a button was pressed, the view stays as it is` ).
+      log_step( `check_on_event( ) - a button was pressed, the view stays as it is` ).
 
     ELSEIF client->check_on_event( `CALL` ).
 
-      log( `check_on_event( ) - calling Basics I as a sub-app` ).
+      log_step( `check_on_event( ) - calling Basics I as a sub-app` ).
       client->nav_app_call( NEW z2ui5_cl_smp_app_493( ) ).
 
     ENDIF.
@@ -52,7 +52,7 @@ CLASS z2ui5_cl_smp_app_495 IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD log.
+  METHOD log_step.
 
     INSERT VALUE #(
         no    = |{ lines( t_log ) + 1 }|

--- a/src/01/z2ui5_cl_smp_app_496.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_496.clas.abap
@@ -13,7 +13,7 @@ CLASS z2ui5_cl_smp_app_496 DEFINITION PUBLIC.
 
     " a public attribute is serialized between the roundtrips - so everything
     " on this page is part of what the View Model tab of the tools shows
-    DATA t_tab      TYPE STANDARD TABLE OF ty_s_tab WITH DEFAULT KEY.
+    DATA t_tab      TYPE STANDARD TABLE OF ty_s_tab WITH EMPTY KEY.
     DATA text       TYPE string.
     DATA roundtrips TYPE i.
 

--- a/src/01/z2ui5_cl_smp_app_496.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_496.clas.abap
@@ -44,6 +44,8 @@ CLASS z2ui5_cl_smp_app_496 IMPLEMENTATION.
       text = `change me and press Send`.
       tabs_init( ).
       view_display( ).
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
 
     ELSEIF client->check_on_event( cs_event-ping ).
 

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
         path     TYPE string,
         app      TYPE string,
       END OF ty_s_tile.
-    TYPES ty_t_tile TYPE STANDARD TABLE OF ty_s_tile WITH DEFAULT KEY.
+    TYPES ty_t_tile TYPE STANDARD TABLE OF ty_s_tile WITH EMPTY KEY.
 
   PROTECTED SECTION.
     TYPES:
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
         base  TYPE string,
         width TYPE i,
       END OF ty_s_block.
-    TYPES ty_t_block TYPE STANDARD TABLE OF ty_s_block WITH DEFAULT KEY.
+    TYPES ty_t_block TYPE STANDARD TABLE OF ty_s_block WITH EMPTY KEY.
 
     " sap.ui.core.IconColor knows no blue - Positive, Critical, Negative and
     " Neutral are the semantic four - so the interactive icons of the header
@@ -251,10 +251,11 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
   METHOD app_call.
 
+    DATA li_app TYPE REF TO z2ui5_if_app.
+
     DATA(name) = to_upper( classname ).
 
     TRY.
-        DATA li_app TYPE REF TO z2ui5_if_app.
         CREATE OBJECT li_app TYPE (name).
         s_scroll = CORRESPONDING #( client->get( )-s_scroll-main ).
         client->nav_app_call( li_app ).
@@ -833,7 +834,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
 
     " estimated render width in 1/100 em, weighted per character class
     DATA(off) = 0.
-    WHILE off < strlen( header ).
+    WHILE strlen( header ) > off.
 
       DATA(char) = substring( val = header
                               off = off


### PR DESCRIPTION
Two changes to the same corpus, both about checks that were not running.

## 1. All 188 abaplint rules, and the same block in all three repositories

The repository ran **17 of abaplint's 188 rules**. The other 171 were not
decided against — they were never listed, so they defaulted to off and nobody
had to say why.

`abaplint.jsonc` now names all 188. **171 are on**, and the rule block is
**byte-identical** in this repository, `samples-controls` and `samples-stack`
— the same arrangement `scripts/chain-format.mjs` already lives under. abaplint
has no `extends`, so the copy is the mechanism and the block carries a header
saying so. Only `global`, `dependencies` and `syntax` stay per repository, plus
exactly **one** rule: `object_naming`, which encodes the token (SMP / SMPC /
SMPS) and sits last behind a marker.

The 17 that are off each carry their reason: four want Hungarian notation and
`no_public_attributes` wants the model hidden (both against §7 and §9);
`abapdoc` treats demos as a published API; seven read a view builder chain or a
`VALUE #( )` data table as a malformed parameter list, and that layout has its
own gate; `prefer_inline` / `no_inline_in_optional_branches` move declarations
the samples place deliberately; `prefer_corresponding` proposes a rewrite that
does not activate on a generic field symbol; `smim_consistency` cannot resolve
a MIME folder that lives on the system.

**What turning the rest on found — 270 findings.** The ones that were bugs:

- **app 097** read a selection with `READ TABLE ... INDEX 1` and used the work
  area without checking `sy-subrc`, so an empty selection inserted a stale row
  into the target table. Nine `ASSIGN obj->(`NAME`)` had the same hole. All
  twelve now check.
- **Seven `SELECT SINGLE` without a full key**, two of which then read "the
  other row" via `WHERE id <>` the first — which row you got was up to the
  database. Now deterministic. Sixteen more SELECTs got the missing `ORDER BY`.

And the dead weight: commented-out code in five apps and two ~150-line blocks
in the shared context class; 28 variables, 9 types and 2 methods nobody read;
seven no-op `on_event` dispatchers whose entire body was an empty `CASE`. Plus
21 single-branch `CASE` → `IF`, 13 `DEFAULT KEY` → `EMPTY KEY`, 41 runs of
three blank lines → two.

## 2. Every app gets the `check_on_navigated( )` branch

`check_on_init( )` means "this app instance never ran", not "the app starts".
abap2UI5 flips `mv_check_initialized` after the first roundtrip, so it is
**false** when a called app leaves, when a `z2ui5_cl_pop_*` value help returns,
and when a bookmarked draft is restored. Those roundtrips raise
`check_on_navigated( )` alone — and with no branch, `main( )` does nothing: the
model lands in a MAIN slot still holding the other app's view. The screen stays
wrong **with no error anywhere**.

AGENTS.md §11 has shown the canonical dispatcher — init, navigated, event — for
a long time. **113 of 141 apps did not have it.** They do now.

91 took the mechanical form. The rest were looked at one by one, because a
branch is not always the answer:

- **7 apps display outside the lifecycle `IF`** and already re-display on every
  roundtrip. Untouched.
- **8 apps** build the view inline in `main( )` with nothing to seed → the
  condition widens to `IF check_on_init( ) OR check_on_navigated( )`, the shape
  `app_074` already used here and what §11 asks for in a simple app.
- **3 apps** (138, 443, 494) also seed bound data there. Widening would reset
  the user's input on the way back, so these got §11's structure instead.
- **app_004** has two views and remembers which is up, so its branch restores
  the one the user left.
- **app_340** shows a popup; **app_105 / 112** are sub-apps rendering into the
  parent's view. All three now say so in a comment — "no branch here" is
  otherwise indistinguishable from the defect.

The linter's new `missing-on-navigated-branch` (0.2.0, pinned on `main` by
#769) was the oracle: it reported 85 before and **none** after.

## Verification

All green on the merged `main`: `abaplint` (0 issues, 317 files), `abap-cloud`,
`abap-702` (`npm run downport` → 0 issues, 217 files), `check-rename`,
`check-abap2UI5` (148 classes, 0 failing), `chain-format`, `check-agents`,
`check-strip`.

Companion PRs: abap2UI5/samples-controls#105, abap2UI5/samples-stack#35,
abap2UI5/abap2UI5#2612, abap2UI5/linter#46 (merged).