### PR TITLE
Pin the actions by SHA

### DIFF
--- a/.github/workflows/abap-702.yaml
+++ b/.github/workflows/abap-702.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/abap-cloud.yaml
+++ b/.github/workflows/abap-cloud.yaml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/abap-standard.yaml
+++ b/.github/workflows/abap-standard.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/check-abap2UI5.yaml
+++ b/.github/workflows/check-abap2UI5.yaml
@@ -47,12 +47,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # check out the branch, not the merge commit, so the badge can go back
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-    - uses: actions/setup-node@v7
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
     - run: node scripts/check-agents-structure.js
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
     - run: node scripts/check-strip-lists.js
@@ -45,8 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
     - run: node scripts/chain-format.mjs

--- a/.github/workflows/check-rename.yaml
+++ b/.github/workflows/check-rename.yaml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
         cache: 'npm'


### PR DESCRIPTION
Four of this repository's twenty action references were pinned to a commit and sixteen were on moving major tags — the state that reads as "pinned" from a distance. Three of the workflows carry `contents: write`: they push the generated overview app, the 702 downport and the check results back into this repository.

All twenty are pinned now, tag kept as a comment. The SHAs match what abap2UI5, samples-controls and docs pin, so an action resolves to one commit across the organisation. Dependabot's `github-actions` ecosystem is configured here and updates SHA pins in place.

Workflow changes only — no ABAP, no generated file, nothing that touches the R-5/R-6 work in flight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_