### PR TITLE
Carry samples-stack's release-floor exclude into the shared block

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -457,7 +457,14 @@
     "pragma_style": true,
     "prefer_is_not": true,
     "prefer_pragmas": true,
-    "prefer_raise_exception_new": true,
+    // Excluded for samples-stack package 06, which ships at 7.40 SP08 (see
+    // .github/packages.json): RAISE EXCEPTION NEW is 7.52 syntax. The root
+    // abaplint.jsonc lints the whole tree at v757 and cannot see a per-package
+    // release floor - the one-package branch build is the gate that can, and
+    // it is the one that caught this.
+    "prefer_raise_exception_new": {
+      "exclude": ["z2ui5_cl_smps_app_485\\.clas\\."]
+    },
     "prefer_returning_to_exporting": true,
     "prefer_xsdbool": true,
     "preferred_compare_operator": true,


### PR DESCRIPTION
Follow-up to #768, which established that the abaplint rule block is
**byte-identical** in this repository, `samples-controls` and `samples-stack`.
This keeps it that way.

`prefer_raise_exception_new` rewrote two statements in `samples-stack`'s
package 06 to `RAISE EXCEPTION NEW` — 7.52 syntax, where that package ships at
**7.40 SP08** (`.github/packages.json`: *"Standard only, ≥ 7.40 SP08"*). The
rule is excluded for that class there, so the exclude belongs here too.

It matches nothing under this `src/`. That is the point of the arrangement, and
why AGENTS.md §6 says an exclude naming another repository's files is not dead
weight here — **removing it would break `samples-stack` on the next copy.**

## How it was caught

`samples-stack`'s one-package branch build is the only gate in the family that
knows a per-package release floor. Its root `abaplint.jsonc` lints the whole
tree at `v757`, where the rewrite is perfectly valid, so the main lint was
green and the `06-stateful-locks` branch job was the one that said no.

Every `samples-stack` package was then re-linted at its own floor — 01, 02, 06
and 09 at `v740sp08`, 07 and 08 at `v750`, the RAP ones at `v754` — and no
other statement in that change outruns its package.

`abaplint` → 0 issues, 317 files. The block is 492 lines and identical in the
three again (verified with `diff`).

Companion PRs: abap2UI5/samples-controls#105, abap2UI5/samples-stack#35.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgqpUJXaehPpuWg5nWnQ7a)_