### PR TITLE
Take the shorter dispatcher, now that the linter can read it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.2.0",
+        "@abap2ui5/linter": "^0.2.1",
         "@abap2ui5/render-runtime": "^0.1.1",
         "@abaplint/cli": "^2.119.66"
       },
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.0.tgz",
-      "integrity": "sha512-wZQ3MkVz+IiHBzuudizx7rQsYNoAMxM8cBsyDz0Oxrc7zaWb+cRKdx3h/+RqRUpPozGIOxnR2AD9SO0PZe4f/g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.1.tgz",
+      "integrity": "sha512-48uMFctR78nogNai1w6kE7Ho4IXLuEnGPq5BJkstpWL69ToL1G+OJ1t4fDOBmOcJ36uFejDn2ofnoBqEkt+9sA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.2.0",
+    "@abap2ui5/linter": "^0.2.1",
     "@abap2ui5/render-runtime": "^0.1.1",
     "@abaplint/cli": "^2.119.66"
   },

--- a/src/00/98/z2ui5_cl_smp_app_324.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_324.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_324 IMPLEMENTATION.
 
     me->client = client.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_074.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_074.clas.abap
@@ -26,7 +26,7 @@ CLASS z2ui5_cl_smp_app_074 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
       view_display( ).
     ELSE.
       on_event( ).

--- a/src/01/z2ui5_cl_smp_app_078.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_078.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_smp_app_078 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_125.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_125.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_smp_app_125 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_325.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_325.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_smp_app_325 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_361.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_361.clas.abap
@@ -14,7 +14,7 @@ CLASS z2ui5_cl_smp_app_361 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_491.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_491.clas.abap
@@ -17,7 +17,7 @@ CLASS z2ui5_cl_smp_app_491 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/z2ui5_cl_smp_app_492.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_492.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_smp_app_492 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(s_config) = client->get( )-s_config.
       url = s_config-pathname && s_config-search.

--- a/src/01/z2ui5_cl_smp_app_493.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_493.clas.abap
@@ -15,7 +15,7 @@ CLASS z2ui5_cl_smp_app_493 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`


### PR DESCRIPTION
```abap
IF client->check_on_init( ) OR client->check_on_navigated( ).   " before
IF client->check_on_navigated( ).                               " after
```

One condition too many. `check_on_init( )` is only ever true on a roundtrip where `check_on_navigated( )` is true as well — the framework raises both for a fresh `CREATE OBJECT` and for a bookmark-draft restore (`z2ui5_cl_ui5_action=>factory_first_start`, and `z2ui5_if_client` says so in ABAP Doc since abap2UI5 #2614). The `OR` reads as if there were a case the second half does not cover.

**Nine classes here carried it.** The `IF … ELSEIF` shape that 133 other apps use is untouched: there `init` and `navigated` have *different* bodies (`model_init` + a display, versus a display), and the branch order is what makes that work.

### Why this is the second attempt

It was written and reverted once already, in the same breath as the docs change: the linter's `missing-view-display-on-navigated` read the `ELSE` of a `COND #( … )` as the end of the branch and reported apps whose display sat after one. Fixed in **`@abap2ui5/linter` 0.2.1**, which this bumps to — so the corpus and the rule agree again.

| | |
|---|---|
| `abap2ui5lint` | 148 files, 0 failing (0.2.1) |
| `abaplint` | 0 issues over 317 files |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_