### PR TITLE
Three more tables deleted out from under their own loop

### DIFF
--- a/src/00/01/z2ui5_cl_smp_context.clas.abap
+++ b/src/00/01/z2ui5_cl_smp_context.clas.abap
@@ -682,10 +682,25 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
 
   METHOD filter_itab.
 
-    DATA ref TYPE REF TO data.
+    DATA ref  TYPE REF TO data.
+    DATA keep TYPE abap_bool.
 
-    LOOP AT val REFERENCE INTO ref.
+    " Collected rather than deleted in place, and the old shape was wrong
+    " twice over: DELETE ... INDEX sy-tabix inside a LOOP shifts the rows
+    " under the loop's own cursor (a system silently SKIPS the row after each
+    " deletion; the transpiled backend raises TABLE_INVALID_INDEX), and
+    " sy-tabix here belonged to the INNER loop over `filter`, so the index
+    " deleted was the FILTER's, not the row's. Found 2026-08-17 by the same
+    " pattern search that turned up four ports in abap2UI5/samples-controls.
+    DATA rows TYPE REF TO data.
+    CREATE DATA rows LIKE val.
+    ASSIGN rows->* TO FIELD-SYMBOL(<rows>).
+    <rows> = val.
+    CLEAR val.
 
+    LOOP AT <rows> REFERENCE INTO ref.
+
+      keep = abap_true.
       LOOP AT filter INTO DATA(ls_filter).
 
         ASSIGN ref->(ls_filter-name) TO FIELD-SYMBOL(<field>).
@@ -693,11 +708,16 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
           CONTINUE.
         ENDIF.
         IF <field> NOT IN ls_filter-t_range.
-          DELETE val INDEX sy-tabix.
+          keep = abap_false.
           EXIT.
         ENDIF.
 
       ENDLOOP.
+
+      IF keep = abap_true.
+        ASSIGN ref->* TO FIELD-SYMBOL(<row>).
+        INSERT <row> INTO TABLE val.
+      ENDIF.
 
     ENDLOOP.
 
@@ -829,6 +849,7 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
     " JS equivalent: always use toLowerCase().includes(toLowerCase()).
     FIELD-SYMBOLS <row>   TYPE any.
     FIELD-SYMBOLS <field> TYPE any.
+    DATA rows TYPE REF TO data.
 
     " an empty search matches everything (and find( sub = `` ) would dump
     " with CX_SY_STRG_PAR_VAL), so leave the table untouched
@@ -840,7 +861,20 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
                                    THEN to_upper( val )
                                    ELSE val ).
 
-    LOOP AT tab ASSIGNING <row>.
+    " Collected rather than deleted in place: DELETE ... INDEX sy-tabix inside
+    " a LOOP over the same table shifts the rows under the loop's own cursor -
+    " a system silently SKIPS the row after each deletion (so the search
+    " returns wrong rows) and the transpiled backend raises
+    " TABLE_INVALID_INDEX. Worse here than elsewhere: the DO loop above the
+    " DELETE can leave sy-tabix pointing at something else entirely.
+    " Found 2026-08-17 with the same pattern search that turned up four ports
+    " in abap2UI5/samples-controls.
+    CREATE DATA rows LIKE tab.
+    ASSIGN rows->* TO FIELD-SYMBOL(<rows>).
+    <rows> = tab.
+    CLEAR tab.
+
+    LOOP AT <rows> ASSIGNING <row>.
 
       DATA(lv_check_found) = abap_false.
       DATA(lv_index) = 1.
@@ -878,8 +912,8 @@ CLASS z2ui5_cl_smp_context IMPLEMENTATION.
         lv_index = lv_index + 1.
       ENDDO.
 
-      IF lv_check_found = abap_false.
-        DELETE tab INDEX sy-tabix.
+      IF lv_check_found = abap_true.
+        INSERT <row> INTO TABLE tab.
       ENDIF.
 
     ENDLOOP.

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -347,7 +347,16 @@ CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
 
     IF mv_search_value IS NOT INITIAL.
 
-      LOOP AT mt_table REFERENCE INTO DATA(lr_row).
+      " Collected rather than deleted in place: DELETE ... INDEX sy-tabix
+      " inside a LOOP over the same table shifts the rows under the loop's own
+      " cursor - a system silently SKIPS the row after each deletion (so the
+      " search returns wrong rows) and the transpiled backend raises
+      " TABLE_INVALID_INDEX. The DO loop above the DELETE can leave sy-tabix
+      " pointing elsewhere as well. Found 2026-08-17.
+      DATA(lt_all) = mt_table.
+      CLEAR mt_table.
+
+      LOOP AT lt_all REFERENCE INTO DATA(lr_row).
         DATA(lv_row) = ``.
         DATA(lv_index) = 1.
         DO.
@@ -360,8 +369,8 @@ CLASS z2ui5_cl_smp_app_070 IMPLEMENTATION.
           lv_index = lv_index + 1.
         ENDDO.
 
-        IF lv_row NS mv_search_value.
-          DELETE mt_table INDEX sy-tabix.
+        IF lv_row CS mv_search_value.
+          APPEND lr_row->* TO mt_table.
         ENDIF.
       ENDLOOP.
     ENDIF.


### PR DESCRIPTION
The defect a running app found in `abap2UI5/samples-controls` today sits here three times, and one of them is worse.

```abap
LOOP AT tab ...
  IF … .
    DELETE tab INDEX sy-tabix.
  ENDIF.
ENDLOOP.
```

Deleting the current row shifts every row after it while the loop's own cursor walks on.

- On a **system** this does not dump — it silently **skips the row after each deletion**, so a filter or a search simply returns wrong rows.
- On the **transpiled Node backend** it raises `TABLE_INVALID_INDEX` and the round-trip 500s.

| where | |
|---|---|
| `z2ui5_cl_smp_context=>filter_itab` | **wrong twice over**: `sy-tabix` there belonged to the *inner* loop over `filter`, so the index deleted was the **filter's**, not the row's |
| `z2ui5_cl_smp_context=>itab_filter_by_val` | a `DO` loop sits between `LOOP` and `DELETE` and can leave `sy-tabix` pointing at something else again |
| `z2ui5_cl_smp_app_070` | the same shape in the grid table's search |

All three now build the result instead of deleting in place. The two context methods copy the table through a `REF TO data` — the parameter is a generic `STANDARD TABLE`, so a plain `DATA(rows) = tab` cannot be typed — and re-insert the rows that match.

### How it was found

Not by a report. The e2e interaction written for `samples-controls`' app 352 answered its `LIVE_TEST` with an HTTP 500, and a pattern search across the ecosystem turned up seven more sites — four ports there, three here. (The one in `abap2UI5`'s `ajson` is *correct*: it follows a `READ TABLE`, not a loop.)

**Nothing offline sees either half.** `abaplint` is happy with the shape, and the silent-skip behaviour on a real system produces a plausible-looking, wrong result rather than an error.

`abaplint` 0 issues over 317 files, `abap2ui5lint` 148 files 0 failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_