### PR TITLE
Follow samples-stack's overview app to z2ui5_cl_smps_app_000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,7 +337,7 @@ GitHub) still open their site directly through `open_url( )`.
 five icons with their separator on the right, the two colour states and the
 install popover. samples-controls builds it in
 `scripts/generate-overview.mjs` (its overview class is generated — never edit
-the class), samples-stack in `z2ui5_cl_smps_app_00`. All three build it with
+the class), samples-stack in `z2ui5_cl_smps_app_000`. All three build it with
 `z2ui5_cl_ui5_view_builder`, which renders an empty attribute rather than
 skipping it (`color=""` is no valid `IconColor`), so the optional ones are
 added under an `IF`. What stays local to a repository is

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -315,7 +315,7 @@
     "fully_type_constants": {
       "checkData": true,
       "exclude": [
-        "z2ui5_cl_smps_app_(07|10)\\.clas\\."
+        "z2ui5_cl_smps_app_(007|010)\\.clas\\."
       ]
     },
     // Excluded for the RAP handler pools: their SELECT SINGLE is an

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -60,10 +60,11 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
         " the overview app of samples-controls before its 2026-08 rename - an
         " installation that predates it still answers to this name
         controls_old TYPE string VALUE `z2ui5_cl_dmo_app_overview`,
-        stack        TYPE string VALUE `z2ui5_cl_smps_app_00`,
-        " samples-stack moved every object from the SMPE token to SMPS in
-        " 2026-08; an installation that predates it still answers to this name
-        stack_old    TYPE string VALUE `z2ui5_cl_smpe_app_00`,
+        stack        TYPE string VALUE `z2ui5_cl_smps_app_000`,
+        " the overview app of samples-stack before its 2026-08 rename to
+        " three-digit app numbers - an installation that predates it still
+        " answers to this name
+        stack_old    TYPE string VALUE `z2ui5_cl_smps_app_00`,
       END OF cs_class.
 
     CONSTANTS:


### PR DESCRIPTION
samples-stack renamed its app classes to three-digit numbers; its overview app is `z2ui5_cl_smps_app_000` now. The shared header follows: the *Stack* entry links the new name, with the previous one as the `stack_old` fallback an installation from before the rename still answers to (one old name each — the smpe-era name is older still and no longer tried). The shared abaplint rule block's `fully_type_constants` exclude moves to `(007|010)`, in lockstep with the other three repositories (same branch name everywhere; merge the abap2UI5 PR first — `check:app-rules` compares against it).

`npm run check` is fully green (abaplint, abap2ui5-linter, chains, agents, strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP)_