### PR TITLE
Follow samples-controls' overview app to z2ui5_cl_smpc_app_000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ start page (`z2ui5_cl_app_startup`) — dropped from all three overviews on
 | Icon | Target | Repository |
 |------|--------|------------|
 | `sap-icon://lightbulb` | `z2ui5_cl_smp_app_000` | abap2UI5/samples — *Samples* |
-| `sap-icon://palette` | `z2ui5_cl_smpc_app_overview` | abap2UI5/samples-controls — *Control Samples* |
+| `sap-icon://palette` | `z2ui5_cl_smpc_app_000` | abap2UI5/samples-controls — *Control Samples* |
 | `sap-icon://database` | `z2ui5_cl_smpe_app_00` | abap2UI5/samples-stack — *Stack Samples* |
 | `sap-icon://learning-assistant` | — | <https://abap2UI5.org> |
 | `sap-icon://globe` | — | the repository the app itself lives in |
@@ -365,7 +365,7 @@ Each repository is installed on its own, so every button decides for itself:
 A repository that **renames** its overview app is installed under both names in
 the wild for a while, so `header_button( )` takes an optional `class_old` and
 falls back to it when the current name is not on the system —
-`z2ui5_cl_dmo_app_overview` for samples-controls (renamed 2026-08),
+`z2ui5_cl_smpc_app_overview` for samples-controls (renamed again 2026-08),
 `z2ui5_cl_demo_app_g00` for this repository. Add the old name there when an
 overview app is renamed; drop it again once the rename is old enough.
 

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -241,7 +241,7 @@
       "checkForms": true,
       "checkFunctionModules": true,
       "exclude": [
-        "z2ui5_cl_smpc_app_overview\\.clas\\."
+        "z2ui5_cl_smpc_app_000\\.clas\\."
       ]
     },
     // On, because non-7-bit source is an abapGit round-trip hazard - and it
@@ -254,7 +254,7 @@
     "7bit_ascii": {
       "exclude": [
         "z2ui5_cl_smpc_app_(012|040|092|103|104|114|134|185|191|194|215|218|254|290|302|303|350|356|357|358|360)\\.clas\\.",
-        "z2ui5_cl_smpc_app_overview\\.clas\\."
+        "z2ui5_cl_smpc_app_000\\.clas\\."
       ]
     },
     // --- on, scoped to what the RAP corpus can comply with -------------

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -56,10 +56,12 @@ CLASS z2ui5_cl_smp_app_000 DEFINITION PUBLIC.
     CONSTANTS:
       BEGIN OF cs_class,
         samples      TYPE string VALUE `z2ui5_cl_smp_app_000`,
-        controls     TYPE string VALUE `z2ui5_cl_smpc_app_overview`,
-        " the overview app of samples-controls before its 2026-08 rename - an
-        " installation that predates it still answers to this name
-        controls_old TYPE string VALUE `z2ui5_cl_dmo_app_overview`,
+        controls     TYPE string VALUE `z2ui5_cl_smpc_app_000`,
+        " the overview app of samples-controls before its 2026-08 rename to
+        " the three-digit number scheme - an installation that predates it
+        " still answers to this name (the dmo-era name is older still and no
+        " longer tried)
+        controls_old TYPE string VALUE `z2ui5_cl_smpc_app_overview`,
         stack        TYPE string VALUE `z2ui5_cl_smps_app_000`,
         " the overview app of samples-stack before its 2026-08 rename to
         " three-digit app numbers - an installation that predates it still


### PR DESCRIPTION
samples-controls renamed its overview app onto the three-digit number scheme; all three overview apps of the family end in `000` now. The shared header's *Controls* entry links the new name and carries the previous one as the `controls_old` fallback an installation from before the rename still answers to — one old name each, the dmo-era name is no longer tried. The shared abaplint rule block's excludes follow, in lockstep with the other three repositories (merge the abap2UI5 PR first).

`npm run check` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP)_