### PR TITLE
Point AGENTS.md at samples-controls, and check a class name in prose against the repo that owns it

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -50,3 +50,39 @@ jobs:
       with:
         node-version: '22'
     - run: node scripts/chain-format.mjs
+
+  # Class names written in prose, against the repositories that own them.
+  #
+  # The three READMEs carry the same learning-path table naming each other's
+  # overview apps. When samples-controls renamed its overview, two of the three
+  # copies went on telling readers to run a class that no longer exists - which
+  # nothing here could notice, because nothing here reads that repository.
+  #
+  # Foreign sample names resolve through the owning repository's generated
+  # SAMPLES.md over raw.githubusercontent.com; framework names need the sources,
+  # so abap2UI5/src is sparse-checked-out next to this one. Without it the run
+  # SAYS which names it could not check rather than passing them silently - and
+  # the stale name that prompted this gate was a framework-shaped one, so the
+  # checkout is what makes the check real.
+  prose_names:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: abap2UI5/abap2UI5
+        ref: main
+        path: .abap2UI5
+        fetch-depth: 1
+        sparse-checkout: src
+        sparse-checkout-cone-mode: false
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: '22'
+    # A runner cannot check a repository out above the workspace, so the
+    # framework lands inside it and the variable says where - the same
+    # env-over-sibling resolution abap2UI5/ai-mcp uses.
+    - run: node scripts/check-prose-names.mjs
+      env:
+        A2UI5_HOME: ${{ github.workspace }}/.abap2UI5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,11 @@ ship — has **no home in this repository today**, and neither has a superseded
 one. Do not park it in `src/01`: every sample there must survive the 702
 downport (§2). Either it belongs in
 [samples-stack](https://github.com/abap2UI5/samples-stack) or
-[ai-demokit](https://github.com/abap2UI5/ai-demokit) (§2), or the category has
-to come back. Re-creating one is a deliberate, self-contained change: add the
-package, put it back into the tree above, into the §2 build table, and into the
-`downport` strip list in `package.json` — all three in the same commit, or the
-two checks below fail.
+[samples-controls](https://github.com/abap2UI5/samples-controls) (§2), or the
+category has to come back. Re-creating one is a deliberate, self-contained
+change: add the package, put it back into the tree above, into the §2 build
+table, and into the `downport` strip list in `package.json` — all three in the
+same commit, or the two checks below fail.
 
 There is **no on-premise-only package**: `main` is installed on ABAP Cloud
 systems as it is, so every sample in the repository must be ABAP Cloud ready.
@@ -90,23 +90,27 @@ keep the two identical** (see §4).
 
 **`01/03` "Control Library" is gone (2026-08-12), with all 32 of its samples.**
 1:1 rebuilds of UI5 demo kit samples are collected in
-[abap2UI5/ai-demokit](https://github.com/abap2UI5/ai-demokit) — which rebuilds
-every official sample against its original view and gates each port on that
-comparison — and keeping the same original rebuilt in both repositories was
+[abap2UI5/samples-controls](https://github.com/abap2UI5/samples-controls) —
+which rebuilds every official sample against its original view and gates each
+port on that comparison — and keeping the same original rebuilt in both was
 pure redundancy: 14 of the 32 were already ported there under the same demo kit
 sample id, and 12 of the rest carried no sample id at all, only an entity URL,
 so there was no original to be faithful to. The whole set was imported into
-ai-demokit's `todo/` for triage before the packages were removed here, so
-nothing is lost — see `todo/README.md` there for the per-sample verdict.
+samples-controls' `todo/` for triage before the packages were removed here and
+every imported class got its verdict the same day; that staging folder was
+deleted with the closed triage, so the per-sample verdicts are in
+samples-controls' **git history** (`todo/README.md` at commit `37e77b6`), not in
+its tree.
 
 **Do not re-create a Control Library package, and do not add a demo kit rebuild
 to `src/01`.** A sample that rebuilds one specific demo kit original belongs in
-ai-demokit, full stop. What legitimately stays here is what cannot live there,
-and it goes into the basic package (`src/01`) as an ordinary sample:
+samples-controls, full stop. What legitimately stays here is what cannot live
+there, and it goes into the basic package (`src/01`) as an ordinary sample:
 
-- a **1.71-safe** variant of a sample whose ai-demokit port keeps post-1.71
-  members for 1:1 fidelity (declared `POST_171` there) — this repository is
-  downported to 702, so the restriction matters here and does not there;
+- a **1.71-safe** variant of a sample whose samples-controls port keeps
+  post-1.71 members for 1:1 fidelity (declared `POST_171` there) — this
+  repository is downported to 702, so the restriction matters here and does
+  not there;
 - a sample in samples-controls' **hold-out set** (`ui5/holdout.json`), which is
   deliberately never ported there because it measures its generator;
 - a **free-style control demo** with no single demo kit original.
@@ -430,10 +434,10 @@ the only overview app, and it is generated.
 ### `SAMPLES.md` — the same catalogue, readable on GitHub
 
 Reaching the overview app costs an installed framework, an abapGit pull and an
-HTTP handler. Before that, the repository is a flat folder of 150 classes whose
+HTTP handler. Before that, the repository is a flat folder of classes whose
 names encode nothing, and the question a visitor arrives with — *is there a
 sample for X?* — has no answer here. `src/00` is worse off: it has no overview
-app at all, so its 49 apps are reachable by class name only and nothing lists
+app at all, so its apps are reachable by class name only and nothing lists
 the names.
 
 [`SAMPLES.md`](SAMPLES.md) answers it. Every app, its description, its
@@ -450,7 +454,7 @@ Four things it shows that the app does not, on purpose:
 
 | | Why |
 |---|---|
-| the `src/00` packages | they have no overview app (§3); listing them nowhere is how 49 apps became invisible |
+| the `src/00` packages | they have no overview app (§3); listing them nowhere is how its 49 apps became invisible |
 | the `ZZZ` helper apps | they must not get a tile — but a catalogue claiming to account for the tree has to say they exist |
 | the `@keywords` | never rendered in the app (§4); here they are what `Ctrl+F` finds |
 | the `@docs` link | the chapter that explains the pattern the sample demonstrates (§4) — the app has no room for it, and a page does |
@@ -752,6 +756,11 @@ which is all five, in the order they fail fastest:
   `package.devc.xml` CTEXTs.
 - `npm run check:strip` — no drift in the strip list (§2).
 
+**Not in `npm run check`, because it needs the network:**
+`npm run check:app-rules` — the abaplint rule block still matches its source
+in abap2UI5 (§6). CI runs it on every pull request; run it yourself after
+touching `abaplint.jsonc`.
+
 By hand, because no script covers them:
 - abapGit file format for all file types: UTF-8, LF only, final newline,
   2-space indent (§6).
@@ -769,26 +778,46 @@ By hand, because no script covers them:
 - Configuration: `abaplint.jsonc`
 - Install: `npm install -g @abaplint/cli`
 - Run: `abaplint`
-- **The rule block is byte-identical in three repositories** — this one,
-  [samples-controls](https://github.com/abap2UI5/samples-controls) and
-  [samples-stack](https://github.com/abap2UI5/samples-stack) — the same way
-  `scripts/chain-format.mjs` already is. **Change it in one and copy it to
-  the other two**, then re-run that repository's gates: what is checked is a
-  joint decision of the three corpora, not a local preference.
+- **The rule block below the marker is a CHECKED COPY of the shared app rule
+  set, and its source is
+  [abap2UI5/abap2UI5](https://github.com/abap2UI5/abap2UI5)
+  `.github/abaplint/app-rules.json`** — the repository where the rest of "how
+  to write an abap2UI5 app" already lives (the `build-an-app` and
+  `view-chain-layout` skills, `docs/agents/building-apps.md`, `abap-check`,
+  `ui5-check`), because a shared thing needs one owner. **Change it THERE
+  first, then copy it here**; this repository, samples-controls and
+  samples-stack are consumers of that file, not peers of each other.
+  - This replaced a three-way peer comparison, deliberately: three peers have
+    no answer to which of them is right, a repository without its own copy of
+    the checker turned the *other* repositories' CI red when it drifted, and
+    the peer checker compared rule NAMES only — so switching a rule to
+    `false` to get a pull request through, precisely the drift it existed to
+    catch, read to it as no change at all.
+  - **The gate is `scripts/check-app-rules.mjs`** (`npm run check:app-rules`,
+    and the `check-app-rules` workflow on every pull request and push to
+    `main`). It compares PARSED SETTINGS against the source, preferring an
+    `abap2UI5` checkout next to this one and falling back to
+    `raw.githubusercontent.com`. It is the one gate here that needs the
+    network: when the source is unreachable it says so and **passes**, rather
+    than going red because github.com is. abap2UI5 checks the same thing from
+    its side (`shared-file-gate.mjs`) — that is the source noticing, this is
+    the consumer noticing.
   - abaplint has no `extends`, so there is no shared file to include — the
-    copy is the mechanism, and the block carries a header saying so.
+    checked copy is the mechanism, and the block carries a header saying so.
   - Only `global`, `dependencies` and `syntax` are per repository (release
     floor, dependency set, suppressions) — plus exactly **one** rule:
     `object_naming`, which encodes the repository's token (SMP / SMPC /
-    SMPS). It sits last in the file behind a marker that says so. Everything
-    above that marker must be identical.
+    SMPS) and is the only rule `check-app-rules` excludes from the
+    comparison. It sits last in the file behind a marker that says so.
+    Everything above that marker must match the source.
 - **Every rule abaplint ships is listed in the config — all 188 of them**
   (2026-08-16; it was 17 here, 44 in samples-controls and 41 in
   samples-stack, the rest defaulting to off unnoticed). 171 are on. **A rule
-  is never left out of the file.** When an abaplint upgrade adds one, add
-  the key in all three: on if all three corpora pass, off with the reason in
-  a comment above it if they do not. An unlisted rule reads as "nobody
-  decided" rather than "decided against".
+  is never left out of the file.** When an abaplint upgrade adds one, add the
+  key to `app-rules.json` in abap2UI5 and copy the block into all three
+  consumers: on if all three corpora pass, off with the reason in a comment
+  above it if they do not. An unlisted rule reads as "nobody decided" rather
+  than "decided against".
 - The 17 that are off carry their reason in the file. In short: four rules
   want Hungarian notation and `no_public_attributes` wants the model hidden,
   both against §7 and §9; `abapdoc` treats demos as a published API; seven
@@ -852,9 +881,9 @@ By hand, because no script covers them:
   ```
   sources    148 app classes
   views      172 documents reconstructed, nested 11 deep, 7 classes produced none
-  judged     2,176 controls of 106 types, 548 bindings, 69 icons, 4,164 attributes
+  judged     2,176 controls of 106 types, 547 bindings, 69 icons, 4,164 attributes
   gates      properties 148 files, render 172 documents
-  baselined  133 findings suppressed by abap2ui5lint-baseline.json (…)
+  baselined  1 finding suppressed by abap2ui5lint-baseline.json (commercial-ui5-host 1)
   ```
 
   A `judged` line of zeroes, or `148 classes produced none`, is the earlier
@@ -863,7 +892,7 @@ By hand, because no script covers them:
 - **The two README badges** (`.github/badges/abap2ui5.json` and
   `.github/badges/check-abap2ui5.json`, shields.io endpoint files) carry the
   same statement, split along what they mean: *abap2UI5 | 148 apps · 172 views
-  · 2,176 controls* is what is here, blue, a fact; *check-abap2UI5 | 84 rules
+  · 2,176 controls* is what is here, blue, a fact; *check-abap2UI5 | 86 rules
   passed* is what the gate made of it, green (or *3 problems*, *7 errors*,
   red). A run that finds nothing checkable turns both grey and says so. Every
   run rewrites them, `check-abap2UI5` commits them onto the pull request
@@ -1519,8 +1548,8 @@ new/edited samples stay consistent:
   far-right float looks disconnected on wide screens (fixed in `454`/`455`).
 
 - **The page title carries the `<DESCRIPT>` text**, in the form
-  `` `abap2UI5 - <DESCRIPT without the (A)/(C) marker>` `` — all 93 samples in
-  `src/01` follow it since 2026-08-13. A user clicks a tile in the overview
+  `` `abap2UI5 - <DESCRIPT without the (A)/(C) marker>` `` — every sample in
+  `src/01` follows it since 2026-08-13. A user clicks a tile in the overview
   (which shows the DESCRIPT) and the opened sample must name the same thing, so
   it is recognisably the right sample. Change the two together: renaming a
   DESCRIPT without the page title puts them out of sync again (they had drifted
@@ -1532,51 +1561,6 @@ new/edited samples stay consistent:
 - **Give a `search_field` an explicit `placeholder`.** Without one UI5 shows its
   locale default (German "Suchen" on a DE system), which clashes with the
   otherwise-English samples.
-
-## Metadata: what goes on the class, and what goes beside it
-
-Shared across `abap2UI5/samples`, `abap2UI5/samples-controls` and
-`abap2UI5/samples-stack`. Decided once, so nobody has to decide it again per
-repository.
-
-**A class says what it IS. A sidecar records what HAPPENED to it.**
-
-| | where | why |
-|---|---|---|
-| `DESCRIPT` — `Titel - Kurzbeschreibung` | `.clas.xml` | 60 characters, hard. What ADT's object list shows |
-| `" @summary` — one sentence | first lines of `.clas.abap` | no limit. The line a catalogue puts under the title |
-| `" @keywords` — search terms | first lines of `.clas.abap` | what somebody would type who does not know the sample exists |
-| upstream sample, port batch, audit findings, verification date, deviations | a sidecar (`meta/<class>.json`) | not properties of the class; written by machinery; long-form; changes on a different schedule |
-
-### Why the first three are not in a sidecar
-
-**A sidecar does not travel.** abapGit pulls `src/`; a `meta/` folder never
-reaches the SAP system. Three places that costs:
-
-1. **In the system it is simply absent** — which is why an overview app that
-   needs the data has to have it *baked in* by a generator.
-2. **A search engine drops somebody into the `.clas.abap` on GitHub** and the
-   code is all they get. This is the same argument `@docs` is a full URL for.
-3. **An AI reading the class file gets no metadata** unless its tooling happens
-   to know about `meta/`.
-
-A `"` comment costs the ABAP nothing — it is not `"!`, so SLIN/ATC does not
-report an unknown tag — and it cannot desync from the class, because it is in
-the class.
-
-### Why the rest is not on the class
-
-A deviation note with three paragraphs and a verification date is not a
-property of the class; it is a log entry about a process, usually written by a
-test run rather than by an author. Putting it in a `"` comment would bloat the
-source and would still be worse structured than JSON. That belongs beside the
-class, and the sidecar is right for it.
-
-### The test, when a new field turns up
-
-Ask: *would this still be true if nobody ever ran a check again?* If yes it
-describes the sample and belongs on the class. If it only became true because
-somebody did something, it belongs in the sidecar.
 
 ## Metadata: what goes on the class, and what goes beside it
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ start page (`z2ui5_cl_app_startup`) — dropped from all three overviews on
 |------|--------|------------|
 | `sap-icon://lightbulb` | `z2ui5_cl_smp_app_000` | abap2UI5/samples — *Samples* |
 | `sap-icon://palette` | `z2ui5_cl_smpc_app_000` | abap2UI5/samples-controls — *Control Samples* |
-| `sap-icon://database` | `z2ui5_cl_smpe_app_00` | abap2UI5/samples-stack — *Stack Samples* |
+| `sap-icon://database` | `z2ui5_cl_smps_app_000` | abap2UI5/samples-stack — *Stack Samples* |
 | `sap-icon://learning-assistant` | — | <https://abap2UI5.org> |
 | `sap-icon://globe` | — | the repository the app itself lives in |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 _This project is open source and developed alongside other projects or during free time. Contributions are greatly appreciated!_
 
-Check out the contribution guidelines [here.](https://github.com/abap2UI5/abap2UI5-documentation/blob/main/CONTRIBUTING.md)
+Check out the contribution guidelines [here.](https://abap2ui5.github.io/docs/resources/contribution.html)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sample repositories take you further:
 |      | Repository | What you learn | Where to start |
 |------|------------|----------------|----------------|
 | 1️⃣ | **samples** — 📍 *you are here* | **the abap2UI5 basics** — bindings, events, popups, navigation, complete apps | run `Z2UI5_CL_SMP_APP_000`, or read [SAMPLES.md](SAMPLES.md) |
-| 2️⃣ | [**samples-controls**](https://github.com/abap2UI5/samples-controls) | **how to use every UI5 control** — the UI5 Demo Kit rebuilt with abap2UI5 | run `z2ui5_cl_dmo_app_overview` |
+| 2️⃣ | [**samples-controls**](https://github.com/abap2UI5/samples-controls) | **how to use every UI5 control** — the UI5 Demo Kit rebuilt with abap2UI5 | run `z2ui5_cl_smpc_app_000` |
 | 3️⃣ | [**samples-stack**](https://github.com/abap2UI5/samples-stack) | **how abap2UI5 plays with your stack** — OData, RAP, WebSockets, the Fiori Launchpad and more | pick your technology in its package table |
 
 #### What's inside

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "check:strip": "node scripts/check-strip-lists.js",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "downport": "rm -rf src/00/97 src/00/98 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && node scripts/generate-samples-md.js",
-    "check": "npm run lint && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip",
-    "check:app-rules": "node scripts/check-app-rules.mjs"
+    "check": "npm run lint && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip && npm run check:prose",
+    "check:app-rules": "node scripts/check-app-rules.mjs",
+    "check:prose": "node scripts/check-prose-names.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-prose-names.mjs
+++ b/scripts/check-prose-names.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/*
+ * check-prose-names — an app class named in prose here is an app class that
+ * exists, including when it lives in a sibling repository.
+ *
+ * The three sample READMEs carry the same learning-path table, and two of its
+ * three rows name the OTHER repositories' overview apps. When samples-controls
+ * renamed its overview to z2ui5_cl_smpc_app_000, its own README followed and
+ * the two copies did not: `samples` and `samples-stack` went on telling every
+ * reader to run `z2ui5_cl_dmo_app_overview`, a class that no longer exists
+ * anywhere. Nothing failed, because nothing here reads the other repository.
+ *
+ * abap2UI5's prose-name-gate is the same idea one repository over, and it
+ * stops exactly where this has to keep going: a name it does not own goes on
+ * an EXTERNAL allowlist, which exempts it rather than checking it. The names
+ * that go stale are precisely the foreign ones — a local rename breaks a local
+ * gate, a foreign rename breaks nothing.
+ *
+ * So a foreign name is resolved against the repository that owns it, through
+ * its generated SAMPLES.md — the catalogue that lists every class it ships,
+ * and the same page a reader would look the name up in.
+ *
+ * Resolution, in order (shared-file-gate's, including the part that matters):
+ *   a sibling CHECKOUT next to this one   (offline, and what a local run sees)
+ *   raw.githubusercontent.com/<repo>/main (CI, and what is actually published)
+ * When neither is reachable the run SAYS SO and passes: a gate must not go red
+ * because github.com is unreachable, and must not claim to have verified
+ * something it did not.
+ *
+ *   node scripts/check-prose-names.mjs
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/* Which repository owns which class prefix. The prefix IS the owner here —
+ * that is what the namespace tokens were chosen for. */
+const OWNER = [
+  { re: /^z2ui5_cl_smpc_/i, repo: 'samples-controls' },
+  { re: /^z2ui5_cl_smps_/i, repo: 'samples-stack' },
+  { re: /^z2ui5_cl_smp_/i, repo: 'samples' },
+  /* Everything else in the namespace is the framework's. Resolved by file,
+   * since abap2UI5 ships no catalogue - and only from a checkout, because a
+   * raw URL cannot list a directory. Unreachable is a note, not a failure. */
+  { re: /^z2ui5_/i, repo: 'abap2UI5', byFile: true },
+];
+
+/* Prose only. src/ is ABAP and belongs to abaplint; the generated catalogue is
+ * written FROM the classes, so checking it would only ever confirm itself. */
+const PROSE = ['README.md', 'CONTRIBUTING.md', 'AGENTS.md', 'CLAUDE.md', 'TRAINING.md', 'STATUS.md'];
+
+/* A journal records what a class was called when the entry was written; that
+ * is history, not drift. Same reasoning as abap2UI5's changelog cut-off. */
+const HISTORY = /STATUS-history\.md$/;
+
+/* Names that are meant to be absent, from `scripts/prose-absent.json` — one
+ * per repository, because what a repository deliberately names in the past
+ * tense is its own business. Each needs its reason, so an entry cannot become
+ * a silent hole; a blank reason fails the run. abap2UI5's prose-name-gate
+ * carries the same rule, for the same reason: an allowlist without a why is a
+ * way to make a gate stop asking.
+ *
+ * The SCRIPT is byte-identical in samples, samples-controls and samples-stack
+ * (as check-app-rules.mjs is) - only this file differs. */
+const ABSENT = (() => {
+  const at = path.join(ROOT, 'scripts', 'prose-absent.json');
+  if (!fs.existsSync(at)) return new Map();
+  const raw = JSON.parse(fs.readFileSync(at, 'utf8'));
+  const bad = Object.entries(raw).filter(([, why]) => !String(why).trim());
+  if (bad.length) {
+    console.error(`prose-absent.json: ${bad.map(([n]) => n).join(', ')} carry no reason`);
+    process.exit(1);
+  }
+  return new Map(Object.entries(raw).map(([n, why]) => [n.toLowerCase(), why]));
+})();
+
+const here = (() => {
+  const names = new Set();
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const f = path.join(dir, e.name);
+      if (e.isDirectory()) walk(f);
+      else if (e.name.endsWith('.clas.abap')) names.add(e.name.replace('.clas.abap', '').toLowerCase());
+    }
+  };
+  walk(path.join(ROOT, 'src'));
+  return names;
+})();
+
+/* Where a sibling repository is, if it is here at all. The environment wins,
+ * the way it does for abap2UI5/ai-mcp's resolvers - and it has to: a CI runner
+ * cannot check a repository out ABOVE the workspace, so `../<repo>` is a local
+ * convenience and the variable is what CI uses. */
+const HOMES = {
+  samples: 'SAMPLES_HOME',
+  'samples-controls': 'SAMPLES_CONTROLS_HOME',
+  'samples-stack': 'SAMPLES_STACK_HOME',
+  abap2UI5: 'A2UI5_HOME',
+};
+
+function checkoutOf(repo) {
+  const fromEnv = process.env[HOMES[repo]];
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv;
+  const sibling = path.join(ROOT, '..', repo);
+  return fs.existsSync(sibling) ? sibling : null;
+}
+
+const raw = (repo) => `https://raw.githubusercontent.com/abap2UI5/${repo}/main/SAMPLES.md`;
+
+/* Every class a checkout ships, by file name. Read once. */
+let frameworkCache = null;
+function frameworkClasses(root) {
+  if (frameworkCache) return frameworkCache;
+  const names = new Set();
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const f = path.join(dir, e.name);
+      if (e.isDirectory()) walk(f);
+      else if (e.name.endsWith('.clas.abap')) names.add(e.name.replace('.clas.abap', '').toLowerCase());
+    }
+  };
+  walk(path.join(root, 'src'));
+  frameworkCache = names;
+  return names;
+}
+const notes = [];
+const catalogues = new Map();
+
+async function catalogueOf(repo) {
+  if (catalogues.has(repo)) return catalogues.get(repo);
+  const at = checkoutOf(repo);
+  const local = at && path.join(at, 'SAMPLES.md');
+  let text = null;
+  if (local && fs.existsSync(local)) text = fs.readFileSync(local, 'utf8');
+  else {
+    try {
+      const res = await fetch(raw(repo), { signal: AbortSignal.timeout(15000) });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      text = await res.text();
+    } catch (err) {
+      notes.push(`${repo}: not reachable (${err.message}) — names it owns were not checked`);
+    }
+  }
+  const set = text ? new Set([...text.matchAll(/\b(z2ui5_cl_[a-z0-9_]+)\b/gi)].map((m) => m[1].toLowerCase())) : null;
+  catalogues.set(repo, set);
+  return set;
+}
+
+const problems = [];
+let checked = 0;
+
+for (const file of PROSE) {
+  const at = path.join(ROOT, file);
+  if (!fs.existsSync(at) || HISTORY.test(at)) continue;
+  const text = fs.readFileSync(at, 'utf8');
+  const seen = new Set();
+
+  /* Two shapes look like a name and are not one; both are a PREFIX standing for
+   * a family: `z2ui5_cl_smps_bp_*` (a glob) and `z2ui5_cl_smpc_app_<n>` (a
+   * placeholder). An ABAP class name never ends in an underscore, so requiring
+   * the last character to be a letter or digit rules out every one of them and
+   * nothing real. */
+  for (const m of text.matchAll(/\b(z2ui5_cl_[a-z0-9_]*[a-z0-9])\b(?!\*|_|<)/gi)) {
+    const name = m[1].toLowerCase();
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    if (ABSENT.has(name)) continue;
+    if (here.has(name)) { checked += 1; continue; }
+
+    const owner = OWNER.find((o) => o.re.test(name));
+    /* No owner at all means the name carries a token no repository here uses -
+     * which is what a name left behind by a rename looks like. That was the
+     * hole this gate shipped with: `z2ui5_cl_dmo_app_overview` matched no
+     * prefix, so it was skipped silently, which is the one outcome a gate
+     * against stale names must not have. */
+    if (!owner) {
+      problems.push(`${file}: names \`${name}\`, whose prefix belongs to no repository here\n`
+        + '    a leftover from a rename, or a name to add to ABSENT with its reason');
+      continue;
+    }
+    if (owner.repo === path.basename(ROOT)) {
+      problems.push(`${file}: names \`${name}\`, which this repository does not have`);
+      continue;
+    }
+    if (owner.byFile) {
+      const at = checkoutOf(owner.repo);
+      if (!at) {
+        if (!notes.some((n) => n.startsWith(owner.repo))) {
+          notes.push(`${owner.repo}: no checkout next to this one — framework names were not checked`);
+        }
+        continue;
+      }
+      checked += 1;
+      const found = frameworkClasses(at).has(name);
+      if (!found) {
+        problems.push(`${file}: names \`${name}\`, which ${owner.repo} does not ship`);
+      }
+      continue;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const cat = await catalogueOf(owner.repo);
+    if (!cat) continue;                          // unreachable, already noted
+    checked += 1;
+    if (!cat.has(name)) {
+      problems.push(
+        `${file}: names \`${name}\`, which is not in ${owner.repo}'s SAMPLES.md\n`
+        + `    renamed or removed over there — look it up and correct the sentence`,
+      );
+    }
+  }
+}
+
+console.log(`prose-names: ${checked} class name(s) checked in ${PROSE.length} prose file(s)`);
+for (const n of notes) console.log(`  ${n}`);
+
+if (problems.length) {
+  console.error(`\n${problems.length} problem(s):`);
+  for (const p of problems) console.error(`  ${p}`);
+  process.exit(1);
+}
+console.log(checked ? 'every class name in prose exists - OK' : 'nothing reachable to check against');

--- a/scripts/prose-absent.json
+++ b/scripts/prose-absent.json
@@ -1,0 +1,9 @@
+{
+  "z2ui5_cl_smpc_app_overview": "the PREVIOUS name of samples-controls' overview app, kept on purpose: header_button( )'s class_old falls back to it for systems that still carry it",
+  "z2ui5_cl_demo_app_g00": "the same, for this repository's own earlier overview app",
+  "z2ui5_cl_smp_app_000_0": "the retired \"classic\" overview app - the passage says it is gone and that it must not come back",
+  "z2ui5_cl_sample_app_g01": "the extended overview app, removed when the extended samples were reorganised - the passage is about its absence",
+  "z2ui5_cl_app_startup": "the framework start page under its PRE-RENAME name (z2ui5_cl_ui5_app_start today); the sentence records that it was dropped from the overviews",
+  "z2ui5_cl_app_parent": "a placeholder in an example CAST - the calling app, whatever it is called",
+  "z2ui5_cl_app_xxx": "the placeholder class name in the app template snippet"
+}


### PR DESCRIPTION
Part of an ecosystem-wide pass over the two goals: make it maximally easy for AI agents, and for people, to build abap2UI5 apps.

## A rename in another repository left stale names here

The three sample READMEs carry the same learning-path table, and two of its rows name the *other* repositories' overview apps. When samples-controls renamed its overview to `z2ui5_cl_smpc_app_000`, its own README followed and both copies did not: this repository went on telling every reader to run `z2ui5_cl_dmo_app_overview`, a class that exists nowhere.

Nothing failed, and nothing could — a local rename breaks a local gate, a **foreign** rename breaks nothing. `abap2UI5`'s `prose-name-gate` is the same idea one repository over and stops exactly where this has to keep going: a name it does not own goes on an EXTERNAL allowlist, which *exempts* it rather than checking it. The names that go stale are precisely the exempted ones.

`scripts/check-prose-names.mjs` resolves a foreign name against the repository that owns it — sample names through that repository's generated `SAMPLES.md`, the same page a reader would look the name up in, and framework names through the abap2UI5 sources. Checkout first, then `raw.githubusercontent.com`, then say so and pass.

Found **by** the gate on its first run: §7's table of the three overview apps named samples-stack's as `z2ui5_cl_smpe_app_00` — a token this ecosystem stopped using and a class that does not exist. The ABAP has had `z2ui5_cl_smps_app_000` with `z2ui5_cl_smps_app_00` as its documented `class_old` the whole time, so only the table was wrong.

## Also fixed

- Five references to `ai-demokit`, a repository name that has been `samples-controls` for some time — including the hard rule "belongs in ai-demokit, full stop".
- The "Metadata: what goes on the class" section appeared **twice**, back to back, 45 identical lines.
- §6 described the abaplint rule set as "byte-identical in three repositories, change it here and copy it to the other two", while the shipped `check-app-rules.mjs` says the single source is `app-rules.json` in `abap2UI5/abap2UI5` and that peer comparison was abandoned because "three peers have no answer to which of them is right". No document in any of the three named that file.
- `CONTRIBUTING.md` linked to `abap2UI5-documentation/blob/main/CONTRIBUTING.md` — a repository now called `docs`, which has no `CONTRIBUTING.md`. Wrong twice over, in the file whose only job is pointing a first-time contributor somewhere.

Names meant to be absent live in `scripts/prose-absent.json`, each with its reason — a blank reason fails the run. Four are real and worth keeping: two previous overview-app names that `header_button( )`'s `class_old` still falls back to, and two placeholders in example snippets.

The script is byte-identical in samples, samples-controls and samples-stack, as `check-app-rules.mjs` is; only the JSON differs.

## How to test

```sh
npm run check   # lint, abap2ui5, chains, agents, strip, prose — all green
```

Proven to fail on the stale name that prompted it, here and in samples-stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY3AoWMiCC52cuQjbce4SU)_