### PR TITLE
Follow the MCP server's rename to mcp-server

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -82,7 +82,7 @@ jobs:
         node-version: '22'
     # A runner cannot check a repository out above the workspace, so the
     # framework lands inside it and the variable says where - the same
-    # env-over-sibling resolution abap2UI5/ai-mcp uses.
+    # env-over-sibling resolution abap2UI5/mcp-server uses.
     - run: node scripts/check-prose-names.mjs
       env:
         A2UI5_HOME: ${{ github.workspace }}/.abap2UI5

--- a/.github/workflows/check-keywords.yaml
+++ b/.github/workflows/check-keywords.yaml
@@ -5,7 +5,7 @@ name: check-keywords
 # without them is broken - it compiles, it runs, it is listed in the overview -
 # which is exactly why the omission survives: the only symptom is that nobody
 # looking for it ever arrives, in the overview's search box, in Ctrl+F over
-# SAMPLES.md and in abap2UI5/ai-mcp's `examples` tool alike.
+# SAMPLES.md and in abap2UI5/mcp-server's `examples` tool alike.
 #
 # 104 classes carry the lines and nothing checked them. The generator refuses a
 # TILE without them, but it rewrites the tree while it does so, which is why it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,7 +506,7 @@ them today:
 
 | | |
 |---|---|
-| [ai-mcp](https://github.com/abap2UI5/ai-mcp) `lib/examples.mjs` | the `examples` MCP tool — an agent asking "has somebody already built X" |
+| [mcp-server](https://github.com/abap2UI5/mcp-server) `lib/examples.mjs` | the `examples` MCP tool — an agent asking "has somebody already built X" |
 | [docs](https://github.com/abap2UI5/docs) `scripts/link-samples.mjs` | the *Working Samples* block under a cookbook page |
 
 Both read this file live rather than a generated index, so what they see is

--- a/scripts/check-keywords.mjs
+++ b/scripts/check-keywords.mjs
@@ -37,7 +37,7 @@
  * runs, and is listed. The only symptom is that nobody looking for it arrives,
  * and it is the same silent symptom in all three readers - the overview app's
  * search box, `Ctrl+F` over SAMPLES.md, and an agent asking through
- * abap2UI5/ai-mcp whether a sample for X already exists.
+ * abap2UI5/mcp-server whether a sample for X already exists.
  *
  * The convention is shared with abap2UI5/samples-stack, deliberately
  * unchanged, so one reader can read both repositories.

--- a/scripts/check-prose-names.mjs
+++ b/scripts/check-prose-names.mjs
@@ -104,7 +104,7 @@ const here = (() => {
 })();
 
 /* Where a sibling repository is, if it is here at all. The environment wins,
- * the way it does for abap2UI5/ai-mcp's resolvers - and it has to: a CI runner
+ * the way it does for abap2UI5/mcp-server's resolvers - and it has to: a CI runner
  * cannot check a repository out ABOVE the workspace, so `../<repo>` is a local
  * convenience and the variable is what CI uses. */
 const HOMES = {

--- a/scripts/generate-launchpad.mjs
+++ b/scripts/generate-launchpad.mjs
@@ -160,7 +160,7 @@ for (const [area, list] of Object.entries(tiles)) {
  * whether it is the one they want, and until it existed the answer was a
  * 60-character short text ("Popup - change a popup control from the backend")
  * that names the thing and stops. The same three readers are affected - the
- * overview app, SAMPLES.md, an agent through abap2UI5/ai-mcp - and here the
+ * overview app, SAMPLES.md, an agent through abap2UI5/mcp-server - and here the
  * degradation is not silence but a wrong guess, which costs more.
  *
  * Written, not generated. abap2UI5/samples-controls fetches the sentence from


### PR DESCRIPTION
`abap2UI5/ai-mcp` is now `abap2UI5/mcp-server`. Every reference here still worked — through GitHub's rename redirect — while showing readers a name that no longer exists.

Six files: `AGENTS.md`, `scripts/check-keywords.mjs`, `scripts/generate-launchpad.mjs`, the two workflows that name it, and `scripts/check-prose-names.mjs`.

That last one is **shared byte-identically** with samples-controls, samples-stack and its source in abap2UI5, so it changes in the same batch everywhere; abap2UI5's `check:shared` is what holds them together. **Merge before abap2UI5#2637**, which compares against this branch's `main`.

`npm run check`: green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_