### PR TITLE
Answer to npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "Learn how to code with abap2UI5.",
   "scripts": {
+    "test": "npm run check",
     "launchpad": "node scripts/generate-launchpad.mjs && node scripts/generate-samples-md.mjs",
     "lint": "abaplint ./abaplint.jsonc",
     "check:cloud": "abaplint .github/abaplint/abap_cloud.jsonc",


### PR DESCRIPTION
# Description

`CONVENTIONS.md` section 3 asks every repository in the ecosystem for **both** `npm run check` and `npm test` — the two commands somebody types before they have read anything. This repository had `check` and not `test`.

There is no separate suite to point `test` at (a corpus is checked, not unit-tested), so `test` is `npm run check` — which is exactly what section 3 asks for in that case. One line in `package.json`.

abap2UI5#2640 adds a `check:scripts` gate that holds all ten repositories to this; that pull request stays red until this one and its three siblings land.

Siblings: samples-stack, samples-controls, web-abap2UI5.

## How to test

```
npm ci && npm test     # same 12 steps as npm run check
```

Verified here: exit 0, `abaplint: 0 issue(s) found, 216 file(s) analyzed`, tree left clean.

## Checklist

- [x] Verified locally
- [ ] Unit tests added/updated — not applicable; one `package.json` line, no behaviour
- [x] No ABAP source touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_