### PR TITLE
Ask Dependabot monthly, and keep majors out of the routine bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Weekly dependency updates, opened as pull requests so the abaplint and
+# Monthly dependency updates, opened as pull requests so the abaplint and
 # abap2UI5-linter gates decide whether they are safe.
 #
 # The interesting one is @abap2ui5/linter: `npm ci` reads package-lock.json,
@@ -12,21 +12,27 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       time: "06:30"
     open-pull-requests-limit: 5
     groups:
       gates:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      gates-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       time: "06:30"
     open-pull-requests-limit: 5
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]


### PR DESCRIPTION
# Description

Part of an ecosystem-wide change — the same edit lands in all ten repositories that carry a `dependabot.yml`.

Grouping was already at its limit here (one group per ecosystem, `patterns: ["*"]`), so the volume was not coming from ungrouped updates but from **multiplication**: two to three ecosystems × ten repositories × every Tuesday ≈ **21 pull requests a week** for build-time tools. Nobody reads the twenty-first.

**Monthly:** the same updates, a quarter as often.

**Majors travel alone:** each group is split by `update-types`, so a routine month produces one pull request per ecosystem with only minor and patch bumps, and a major arrives separately — visible as a major, and reviewable as one. `actions/download-artifact` 7 → 8 was merged in abap2UI5 today inside a group; it was clean, but it carried an ESM migration and a digest check that now fails a run instead of warning.

`@abap2ui5/linter` stays in the `ignore` list, unchanged — its version here is moved by the bump workflow, not by Dependabot.

## How to test

```
npm ci && npm run check
```

Config validated as YAML: every group carries `update-types`, and no `day:` is left over (it is only honoured for `interval: weekly`).

## Checklist

- [x] YAML validated
- [ ] Unit tests added/updated — not applicable; configuration
- [x] No ABAP source touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_