### PR TITLE
Publish the learning path as a page on GitHub Pages

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -86,3 +86,17 @@ jobs:
     - run: node scripts/check-prose-names.mjs
       env:
         A2UI5_HOME: ${{ github.workspace }}/.abap2UI5
+
+  # The learning path of the page in web/ covers every category of src/01. A
+  # category with no stage is a section that is simply not on the page, and
+  # nothing else notices - the samples stay listed in the app and in
+  # SAMPLES.md. Plain node, no dependencies.
+  overview_page:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: '22'
+    - run: node scripts/generate-overview-index.mjs --check

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -1,0 +1,65 @@
+name: deploy-web
+
+# Publishes the overview page in web/ to this repository's GitHub Pages.
+#
+# The page is the learning path of `src/01` - the same samples the overview app
+# lists, in the order somebody learns them - for a reader who has not installed
+# anything yet. It is static: three files plus `web/apps.json`, which this
+# workflow generates from the tree on every deploy, so the page is never staler
+# than the samples it describes and a sample pull request carries no diff of
+# derived data.
+#
+# This is the only way the page is published: Settings -> Pages -> Source must
+# be "GitHub Actions". No dependencies are installed - the generator reads the
+# tree with plain node, the same scan the overview app and SAMPLES.md are built
+# from.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'web/**'
+      - 'scripts/generate-overview-index.mjs'
+      - 'scripts/lib/scan-samples.mjs'
+      - 'scripts/lib/learning-path.json'
+      - '.github/workflows/deploy-web.yaml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# one Pages deployment at a time; let a newer run supersede an in-flight one
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: The catalogue behind the page
+        run: node scripts/generate-overview-index.mjs
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: web
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 downport
 node_modules
 output
+
+# derived: the catalogue behind the overview page in web/, written by
+# scripts/generate-overview-index.mjs on every deploy (AGENTS.md, "The overview
+# page")
+web/apps.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1690,6 +1690,60 @@ new/edited samples stay consistent:
   locale default (German "Suchen" on a DE system), which clashes with the
   otherwise-English samples.
 
+---
+
+## The overview page — `web/`, on GitHub Pages
+
+**https://abap2ui5.github.io/samples/** — the learning path as a page, for
+somebody who has not installed anything yet. Published by the `deploy-web`
+workflow on every push to `main` that touches `src/`, `web/` or the generator
+(*Settings → Pages → Source = GitHub Actions*).
+
+It is the **third view of one catalogue**, and the reason the three cannot
+disagree is that all three are rendered from the same scan
+(`scripts/lib/scan-samples.mjs`, §4): the overview app for a reader who has the
+repository in a system, `SAMPLES.md` for a reader on GitHub, this page for a
+reader who is still deciding whether to install it. **Do not give the page its
+own facts about a sample.** Its title, its one sentence, its search terms and
+its documentation chapters are the `DESCRIPT`, the `@summary`, the `@keywords`
+and the `@docs` of the class — change them on the class, as always, and all
+three follow.
+
+**Only `src/01` is on it.** `src/00/97` is unfinished and `src/00/98` exists to
+be run by a check rather than learned from (§2), and both are stripped from
+`702` — a page that teaches must not lead anybody into either. The ZZZ helpers
+are out for the reason they carry no tile (§4); they come back only as the
+extra files a playground link needs to actually run.
+
+### The one thing that is not derived: the order
+
+The categories are the header of a `DESCRIPT` and therefore sort
+alphabetically, which puts `Browser` between `Binding` and `CSS` — an order
+nobody learns in. So the page groups the 23 categories into **stages**, and
+that grouping is a teaching decision written in
+**`scripts/lib/learning-path.json`** and nowhere else:
+
+```json
+{ "id": "rows", "title": "Show many rows", "blurb": "…", "categories": ["Table", "Grid Table", "List", "Tree"] }
+```
+
+**Every category belongs to exactly one stage.** `npm run check:overview`
+(`scripts/generate-overview-index.mjs --check`, part of `npm run check`) fails
+when a category has no stage, when two stages claim one, or when a stage names
+a category no sample carries. A new category is therefore a decision somebody
+has to make — where in the path does this belong — rather than a section that
+silently is not on the page. Adding a sample to an existing category needs
+nothing: the page picks it up on the next deploy.
+
+### The files
+
+`web/index.html`, `web/overview.css`, `web/overview.js` — no framework, no
+build step — plus `web/apps.json`, which is **generated and not committed**
+(`node scripts/generate-overview-index.mjs`, or `npm run overview`). It is a
+build output like any bundle: the workflow writes it on every deploy, so it is
+never staler than the tree, and a sample pull request carries no diff of
+derived data. See `web/README.md` for how to run the page locally.
+
 <!-- The section below is SHARED. Its source is
      abap2UI5/abap2UI5 .github/shared/agents-metadata.md - change it THERE
      first, or the change is drift. abap2UI5's `npm run check:shared`

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ World below, while `Z2UI5_CL_SMPS_APP_493` in
 [samples-stack](https://github.com/abap2UI5/samples-stack) is a FilterBar with
 variant management. So the catalogue always gives you the class, not a number.
 
-No system at hand? **[SAMPLES.md](SAMPLES.md) is the same catalogue as a
-page** — every app, what it shows, and a link to its source. It is generated
-from the tree, so it is what is actually here.
+No system at hand? **[The sample path](https://abap2ui5.github.io/samples/) is
+this catalogue as a page** — the samples in the order they are meant to be read
+in, six stages from the smallest app that runs to files, devices and custom
+CSS. Every card opens the source, or starts the class in the
+[playground](https://abap2ui5.github.io/playground/) with nothing installed at
+all. [SAMPLES.md](SAMPLES.md) is the same catalogue to scroll and `Ctrl+F`.
+Both are generated from the tree, so both are what is actually here.
 
 #### The learning path
 
@@ -78,7 +82,7 @@ sample repositories take you further:
 
 |      | Repository | What you learn | Where to start |
 |------|------------|----------------|----------------|
-| 1️⃣ | **samples** — 📍 *you are here* | **the abap2UI5 basics** — bindings, events, popups, navigation, complete apps | run `Z2UI5_CL_SMP_APP_000`, or read [SAMPLES.md](SAMPLES.md) |
+| 1️⃣ | **samples** — 📍 *you are here* | **the abap2UI5 basics** — bindings, events, popups, navigation, complete apps | run `Z2UI5_CL_SMP_APP_000`, or follow [the sample path](https://abap2ui5.github.io/samples/) |
 | 2️⃣ | [**samples-controls**](https://github.com/abap2UI5/samples-controls) | **how to use every UI5 control** — the UI5 Demo Kit rebuilt with abap2UI5 | run `z2ui5_cl_smpc_app_000` |
 | 3️⃣ | [**samples-stack**](https://github.com/abap2UI5/samples-stack) | **how abap2UI5 plays with your stack** — OData, RAP, WebSockets, the Fiori Launchpad and more | pick your technology in its package table |
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npm run check",
     "launchpad": "node scripts/generate-launchpad.mjs && node scripts/generate-samples-md.mjs",
+    "overview": "node scripts/generate-overview-index.mjs",
     "lint": "abaplint ./abaplint.jsonc",
     "check:cloud": "abaplint .github/abaplint/abap_cloud.jsonc",
     "check:abap2ui5": "abap2ui5lint",
@@ -15,13 +16,14 @@
     "check:strip": "node scripts/check-strip-lists.mjs",
     "check:keywords": "node scripts/check-keywords.mjs",
     "check:launchpad": "node scripts/generate-launchpad.mjs --check && node scripts/generate-samples-md.mjs --check",
+    "check:overview": "node scripts/generate-overview-index.mjs --check",
     "check:prose": "node scripts/check-prose-names.mjs",
     "check:docs-links": "node scripts/check-docs-links.mjs",
     "check:app-rules": "node scripts/check-app-rules.mjs",
     "rename": "abaplint .github/abaplint/rename_test.jsonc --rename",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "downport": "rm -rf src/00/97 src/00/98 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && node scripts/generate-samples-md.mjs",
-    "check": "npm run lint && npm run check:cloud && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip && npm run check:keywords && npm run check:launchpad && npm run check:prose && npm run check:docs-links && npm run check:app-rules && npm run rename"
+    "check": "npm run lint && npm run check:cloud && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip && npm run check:keywords && npm run check:launchpad && npm run check:overview && npm run check:prose && npm run check:docs-links && npm run check:app-rules && npm run rename"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-overview-index.mjs
+++ b/scripts/generate-overview-index.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/*
+ * generate-overview-index - the data behind the overview page in web/.
+ *
+ * SAMPLES.md answers "what is in this repository" for somebody who scrolls a
+ * 97-row table, and the overview app answers it inside a running system. The
+ * page in web/ answers the question a newcomer actually arrives with, which is
+ * neither: "I have never written an abap2UI5 app - where do I start, and what
+ * comes after that". So it is not a search box over a corpus (that is what the
+ * sibling repository samples-controls has, and its corpus is a control
+ * reference where search IS the question). It is the learning path this
+ * repository already is, laid out in the order somebody walks it.
+ *
+ * Only `src/01` is on it. src/00/97 is unfinished and src/00/98 is run by a
+ * check rather than learned from (AGENTS.md section 2), and both are stripped
+ * from the 702 branch - a page that teaches must not lead anybody into them.
+ * The ZZZ helpers are out for the same reason they carry no tile: a helper is
+ * reached BY a sample, never started on its own. They do come back as the
+ * extra `?src=` files a playground link needs (see `deps` below).
+ *
+ * Everything the page shows about a sample comes from the same scan the
+ * overview app and SAMPLES.md are generated from (scripts/lib/scan-samples.mjs)
+ * - title, summary, keywords, documentation chapters - so the three cannot
+ * disagree about what this repository contains. The one thing the scan cannot
+ * know is the teaching order, which is in scripts/lib/learning-path.json.
+ *
+ *   node scripts/generate-overview-index.mjs           write web/apps.json
+ *   node scripts/generate-overview-index.mjs --check   validate, write nothing
+ *   node scripts/generate-overview-index.mjs --out X   write it elsewhere
+ *
+ * NOT committed - web/apps.json is a build output like any bundle: the deploy
+ * workflow regenerates it on every push, so it is never staler than the tree it
+ * describes, and a sample PR does not carry a diff of derived data. `--check`
+ * is what CI runs: it holds the two rules that CAN go wrong in a pull request
+ * (a category with no stage, a stage naming a category nobody uses) without
+ * needing the output.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { ROOT, SRC, scanSamples } from './lib/scan-samples.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CHECK = process.argv.includes('--check');
+const argOut = process.argv.indexOf('--out');
+const OUT = argOut === -1
+  ? path.join(ROOT, 'web', 'apps.json')
+  : path.resolve(process.argv[argOut + 1]);
+
+/* The repository the source links point into. The page is built from main, so
+ * that is the ref both the blob links and the raw links the playground fetches
+ * have to follow. */
+const REPO = 'abap2UI5/samples';
+const REF = 'main';
+const SOURCE = `https://github.com/${REPO}/blob/${REF}/`;
+const RAW = `https://raw.githubusercontent.com/${REPO}/${REF}/`;
+
+/* Where a class can be opened and run without a system at all. `?src=` takes
+ * raw GitHub URLs and starts the class in the FIRST one (playground
+ * src/shell/deep-link.mjs), which is why `deps` below is ordered app-first. */
+const PLAYGROUND = 'https://abap2ui5.github.io/playground/';
+
+const DOCS_SITE = 'https://abap2ui5.github.io/docs/';
+
+/* --------------------------------------------------------- the class index */
+
+/** Every ABAP class in the tree, lowercase name -> repository-relative file.
+ *  Not the scan: this has to see the ZZZ helpers and the shared context
+ *  classes under src/00/01 too, because those are what a sample REFERENCES. */
+function classIndex() {
+  const index = {};
+  const walk = (dir) => {
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      if (fs.statSync(full).isDirectory()) walk(full);
+      else if (name.endsWith('.clas.abap')) {
+        index[path.basename(name, '.clas.abap').toLowerCase()] = path
+          .relative(ROOT, full).split(path.sep).join('/');
+      }
+    }
+  };
+  walk(SRC);
+  return index;
+}
+
+/** The other classes a sample needs to actually run, app first.
+ *
+ *  A sample is one class - except when it is not: `nav_app_call` starts a
+ *  second app, a value help reads a shared context class, and half of a
+ *  navigation demo is the app it navigates to. Passing only the first file to
+ *  the playground opens something that dies on the first click, so every
+ *  `z2ui5_cl_smp*` class the source names is collected, transitively, and
+ *  becomes another `?src=`. Framework classes (z2ui5_cl_ajson, z2ui5_cl_util,
+ *  the view builder) are not collected - the playground bundles abap2UI5
+ *  itself, and linking them would be linking the framework twice.
+ */
+function dependencies(cls, index) {
+  const seen = new Set([cls]);
+  const queue = [cls];
+  const files = [];
+  while (queue.length) {
+    const current = queue.shift();
+    files.push(index[current]);
+    const source = fs.readFileSync(path.join(ROOT, index[current]), 'utf8');
+    const named = new Set((source.match(/z2ui5_cl_smp[a-z0-9_]*/gi) || []).map((n) => n.toLowerCase()));
+    for (const name of [...named].sort()) {
+      if (seen.has(name) || !index[name]) continue;
+      seen.add(name);
+      queue.push(name);
+    }
+  }
+  return files;
+}
+
+/* ------------------------------------------------------------ the ordering */
+
+const ROMAN = { I: 1, V: 5, X: 10, L: 50, C: 100, D: 500, M: 1000 };
+
+/** The value of a trailing Roman numeral, or null - `Basics IV` -> 4.
+ *  Where a series exists the numeral IS the reading order, and sorting
+ *  `Basics IX` after `Basics VIII` alphabetically only works by accident. */
+function step(header) {
+  const last = header.split(' ').pop();
+  if (!/^[IVXLCDM]+$/.test(last) || header.split(' ').length < 2) return null;
+  let total = 0;
+  for (let i = 0; i < last.length; i++) {
+    const value = ROMAN[last[i]];
+    total += value < ROMAN[last[i + 1]] ? -value : value;
+  }
+  return total;
+}
+
+/** A gate says what is wrong and stops. A stack trace over a missing entry in
+ *  an editorial JSON file only buries the sentence that says what to do. */
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+/* ------------------------------------------------------------------- build */
+
+const { areas } = scanSamples();
+const tiles = areas['01'];
+const index = classIndex();
+
+const byCategory = new Map();
+for (const tile of tiles) {
+  if (!byCategory.has(tile.base)) byCategory.set(tile.base, []);
+  byCategory.get(tile.base).push(tile);
+}
+for (const list of byCategory.values()) {
+  list.sort((a, b) => (step(a.header) ?? 0) - (step(b.header) ?? 0)
+    || a.header.localeCompare(b.header)
+    || a.sub.localeCompare(b.sub));
+}
+
+const pathFile = path.join(HERE, 'lib', 'learning-path.json');
+const { stages } = JSON.parse(fs.readFileSync(pathFile, 'utf8'));
+
+/* The two rules that keep the page from drifting away from the tree, and the
+ * reason this generator has a `--check` mode at all. Both failures are silent
+ * otherwise: a new category would simply not be on the page, and a renamed one
+ * would leave a heading with nothing under it. */
+const placed = new Map();
+for (const stage of stages) {
+  for (const name of stage.categories) {
+    if (placed.has(name)) {
+      fail(`category "${name}" is in two stages (${placed.get(name)} and ${stage.id}) — scripts/lib/learning-path.json`);
+    }
+    placed.set(name, stage.id);
+    if (!byCategory.has(name)) {
+      fail(`stage "${stage.id}" names category "${name}", which no sample in src/01 carries.\n`
+        + 'Drop it from scripts/lib/learning-path.json, or put the category back on a sample\'s DESCRIPT.');
+    }
+  }
+}
+const unplaced = [...byCategory.keys()].filter((name) => !placed.has(name));
+if (unplaced.length) {
+  fail(
+    `${unplaced.length} categor${unplaced.length === 1 ? 'y belongs' : 'ies belong'} to no stage of the learning path: ${unplaced.join(', ')}\n`
+    + `Add ${unplaced.length === 1 ? 'it' : 'them'} to scripts/lib/learning-path.json — a category with no stage is a sample nobody on the page can reach.`,
+  );
+}
+
+const sample = (tile) => {
+  const deps = dependencies(tile.app, index);
+  return {
+    class: tile.app,
+    title: tile.header,
+    step: step(tile.header),
+    what: tile.sub,
+    summary: tile.summary,
+    keywords: tile.keywords ? tile.keywords.split(/\s+/) : [],
+    docs: tile.docs.map((url) => ({ chapter: url.replace(DOCS_SITE, ''), url })),
+    file: deps[0],
+    /* the extra files the playground needs, app first and without it */
+    deps: deps.slice(1),
+  };
+};
+
+const data = {
+  repo: REPO,
+  source: SOURCE,
+  raw: RAW,
+  playground: PLAYGROUND,
+  docsSite: DOCS_SITE,
+  overviewApp: 'z2ui5_cl_smp_app_000',
+  counts: {
+    samples: tiles.length,
+    categories: byCategory.size,
+    stages: stages.length,
+  },
+  stages: stages.map((stage) => ({
+    id: stage.id,
+    title: stage.title,
+    blurb: stage.blurb,
+    categories: stage.categories.map((name) => ({
+      name,
+      samples: byCategory.get(name).map(sample),
+    })),
+  })),
+};
+
+/* A link that 404s is reproduced by a regeneration as faithfully as a working
+ * one, so the files are checked to exist rather than trusted. */
+for (const stage of data.stages) {
+  for (const category of stage.categories) {
+    for (const entry of category.samples) {
+      for (const file of [entry.file, ...entry.deps]) {
+        if (!fs.existsSync(path.join(ROOT, file))) fail(`link would 404: ${file}`);
+      }
+    }
+  }
+}
+
+const listed = data.stages.flatMap((s) => s.categories.flatMap((c) => c.samples)).length;
+if (listed !== tiles.length) fail(`${tiles.length} samples scanned, ${listed} on the page`);
+
+const summary = `${listed} samples · ${byCategory.size} categories · ${stages.length} stages`;
+if (CHECK) {
+  console.log(`overview-index: the learning path covers src/01 — ${summary}`);
+} else {
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, `${JSON.stringify(data, null, 1)}\n`);
+  console.log(`${path.relative(ROOT, OUT)}: ${summary}`);
+}

--- a/scripts/lib/learning-path.json
+++ b/scripts/lib/learning-path.json
@@ -1,0 +1,58 @@
+{
+  "_comment": [
+    "The learning path of the overview page (web/), and the ONE editorial file behind it.",
+    "",
+    "Everything else on that page is derived from the tree by scan-samples.mjs: a sample's",
+    "title, its one-sentence summary, its keywords, its documentation chapters. What the scan",
+    "cannot know is the ORDER somebody learns them in - the categories are the header of a",
+    "DESCRIPT and sort alphabetically, so 'Browser' lands between 'Binding' and 'CSS' and a",
+    "reader following the page top to bottom meets the browser API before they have bound a",
+    "field. That order is a teaching decision, so it is written here and nowhere else.",
+    "",
+    "Rules the generator enforces (scripts/generate-overview-index.mjs):",
+    "  - every category in src/01 belongs to EXACTLY ONE stage - a new one fails the build",
+    "    rather than being dropped silently off the page,",
+    "  - a category named here that no sample uses fails too, so a renamed DESCRIPT cannot",
+    "    leave a dead entry behind.",
+    "The category is the tile header without its trailing Roman numeral (headerBase in",
+    "scan-samples.mjs) - the same blocking the overview app and SAMPLES.md use."
+  ],
+  "stages": [
+    {
+      "id": "start",
+      "title": "Start here",
+      "blurb": "Five apps in reading order. One class, one view, one roundtrip - the shape every other sample in this repository grows from, plus the developer tools you will open when something does not render.",
+      "categories": ["Basics"]
+    },
+    {
+      "id": "data",
+      "title": "Get your data on screen",
+      "blurb": "How an ABAP field becomes something a user reads and edits: binding an attribute, the types that convert it, formatters, and views built from data rather than written out.",
+      "categories": ["Binding", "Formatter", "Templating"]
+    },
+    {
+      "id": "rows",
+      "title": "Show many rows",
+      "blurb": "Internal tables on screen - the responsive table, the grid table for large sets, lists and trees - with growing, selection, editing and everything a row can carry.",
+      "categories": ["Table", "Grid Table", "List", "Tree"]
+    },
+    {
+      "id": "talk",
+      "title": "Talk to the user",
+      "blurb": "The other direction: events arriving from the view, messages and message boxes going back, and the popups, popovers and menus that ask before something happens.",
+      "categories": ["Event", "Message", "Popup", "Popover", "Menu"]
+    },
+    {
+      "id": "move",
+      "title": "Move through the app",
+      "blurb": "More than one view and more than one app: navigation and app calls, views nested inside views, and the small things that decide where the user is looking - focus, scrolling, a timer.",
+      "categories": ["Navigation", "Nested View", "Focus", "Scroll", "Timer"]
+    },
+    {
+      "id": "beyond",
+      "title": "Reach outside the view",
+      "blurb": "Where an app stops being only a view: the browser it runs in, the device it runs on, files in and out, custom CSS, and driving a control from the backend by its id.",
+      "categories": ["Browser", "Device", "File", "CSS", "Control Behaviour"]
+    }
+  ]
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,43 @@
+# `web/` — the overview page
+
+The learning path of this repository as a page, for somebody who has not
+installed anything yet: **https://abap2ui5.github.io/samples/** (published by
+the `deploy-web` workflow, which needs *Settings → Pages → Source =
+GitHub Actions*).
+
+It is the third view of the same catalogue, and the three are generated from
+one scan (`scripts/lib/scan-samples.mjs`) so they cannot disagree:
+
+| Where | For whom |
+|---|---|
+| `Z2UI5_CL_SMP_APP_000`, the overview app | somebody who has the repository in a system |
+| [`SAMPLES.md`](../SAMPLES.md) | somebody reading the repository on GitHub |
+| this page | somebody who has not installed anything and is asking where to start |
+
+## What is in here
+
+| File | |
+|---|---|
+| `index.html` | the page — one file, no framework |
+| `overview.css` | one stylesheet, light and dark |
+| `overview.js` | draws the path, narrows it on a search, remembers what you ticked (`localStorage`, this browser only) |
+| `apps.json` | **generated, not committed** — `node scripts/generate-overview-index.mjs` |
+
+Only `src/01` is on the page: the portable set that survives every build.
+`src/00/97` is unfinished and `src/00/98` is run by a check rather than learned
+from, and a page that teaches must not lead anybody into either.
+
+## Working on it
+
+```
+node scripts/generate-overview-index.mjs     # writes web/apps.json
+python3 -m http.server 8000 --directory web  # any static server will do
+```
+
+`file://` does not work — the page `fetch`es `apps.json`.
+
+The **order** the samples are in is the one thing not derived from the tree:
+it is a teaching decision and lives in `scripts/lib/learning-path.json`, which
+assigns every category to a stage. `npm run check:overview` fails when a
+category has no stage or a stage names a category nobody uses, so a new sample
+category cannot quietly fall off the page.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Learn abap2UI5 · the sample path</title>
+<meta name="description" content="Every abap2UI5 sample of this repository, in the order somebody learns them: six stages from the smallest app that runs to files, devices and custom CSS. Read the source, or start a sample in the playground without installing anything.">
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="overview.css">
+</head>
+<body>
+
+<header class="masthead">
+  <div class="inner">
+    <p class="brand"><a href="https://github.com/abap2UI5/samples">abap2UI5 · samples</a></p>
+    <h1>Learn abap2UI5, one sample at a time</h1>
+    <p class="lede">
+      <strong id="total">…</strong> apps, each one a single ABAP class, each adding
+      exactly one idea. This page is the order they are meant to be read in —
+      <strong id="stagecount">…</strong> stages from the smallest app that runs to
+      files, devices and custom CSS. Start at the top, or use the search to jump
+      to the one thing you need today.
+    </p>
+    <p class="cta">
+      <a class="button" href="#stage-start" id="startlink">Start at the beginning</a>
+      <button type="button" class="button ghost" id="continue" hidden>Continue where you stopped</button>
+      <a class="button ghost" href="#how">How to run a sample</a>
+    </p>
+  </div>
+</header>
+
+<div class="layout">
+
+  <aside class="rail">
+    <div class="progress" id="progress">
+      <p class="progress-line"><b id="donecount">0</b> of <b id="alltotal">…</b> read</p>
+      <div class="bar"><span id="barfill"></span></div>
+      <button type="button" class="linkish" id="clearprogress" hidden>reset</button>
+      <p class="note">Ticking a sample stores it in this browser only — nothing is sent anywhere.</p>
+    </div>
+    <nav id="stagenav" aria-label="The stages"></nav>
+  </aside>
+
+  <main>
+    <form class="find" id="find" role="search" autocomplete="off">
+      <label class="sr-only" for="q">Search the samples</label>
+      <input type="search" id="q" name="q" placeholder="table, popup, f4, upload, nav_app_call …" spellcheck="false">
+      <kbd>/</kbd>
+      <span class="found" id="found"></span>
+      <button type="button" class="linkish" id="clearq" hidden>clear</button>
+    </form>
+
+    <p class="empty" id="empty" hidden>
+      Nothing on the path matches that. <button type="button" class="linkish" id="clearq2">Clear the search</button>
+      — or read <a href="https://github.com/abap2UI5/samples/blob/main/SAMPLES.md">SAMPLES.md</a>,
+      which also lists the experimental and testing apps this page deliberately leaves out.
+    </p>
+
+    <div id="stages"></div>
+
+    <section class="how" id="how">
+      <h2>How to run one</h2>
+      <ol>
+        <li>
+          <b>In your system.</b> Install
+          <a href="https://github.com/abap2UI5/abap2UI5">abap2UI5</a> — this
+          repository ships apps, not the framework — then pull it with
+          <a href="https://abapgit.org">abapGit</a> (<code>main</code> for
+          NW 7.50+ and ABAP Cloud, <code>702</code> for NW 7.02 – 7.4x) and open
+          <code>&lt;your endpoint&gt;?app_start=&lt;the class&gt;</code>. Every card
+          below copies that class name for you.
+        </li>
+        <li>
+          <b>Without a system.</b> <b>Playground&nbsp;↗</b> opens the same class in
+          an ABAP editor with the app running beside it, in the browser. Where a
+          sample calls a second app or a shared data class, the link carries those
+          files too, so the button in it still works.
+        </li>
+        <li>
+          <b>All of them at once.</b> Run
+          <code id="overviewapp">Z2UI5_CL_SMP_APP_000</code>, the overview app —
+          the same catalogue, inside your system.
+        </li>
+      </ol>
+    </section>
+  </main>
+</div>
+
+<footer>
+  <p>
+    Built from the repository itself: the folder tree, each class's abapGit short
+    text, and the <code>@keywords</code>, <code>@summary</code> and
+    <code>@docs</code> lines it carries — the same scan behind the overview app
+    and <a href="https://github.com/abap2UI5/samples/blob/main/SAMPLES.md">SAMPLES.md</a>,
+    so the three cannot disagree. Only <code>src/01</code> is here: the portable
+    set that survives every build. Regenerated on every deploy.
+  </p>
+  <p>
+    <a href="https://github.com/abap2UI5/samples">Repository</a> ·
+    <a href="https://github.com/abap2UI5/samples/blob/main/SAMPLES.md">The full catalogue</a> ·
+    <a href="https://abap2ui5.github.io/docs/">Documentation</a> ·
+    <a href="https://abap2ui5.github.io/playground/">Playground</a> ·
+    <a href="https://abap2ui5.github.io/samples-controls/search/">The control reference next door</a>
+  </p>
+</footer>
+
+<script src="overview.js"></script>
+</body>
+</html>

--- a/web/overview.css
+++ b/web/overview.css
@@ -1,0 +1,287 @@
+/*
+ * The overview page. One stylesheet, no framework, no build step.
+ *
+ * The layout is the argument: a numbered rail on the left that says where you
+ * are in the path and how far you have come, stages as chapters down the
+ * middle, and a card per sample that answers "is this the one I want" before
+ * anybody clicks. Search narrows the path in place rather than replacing it
+ * with a result list - the order is the content here.
+ */
+
+:root {
+  color-scheme: light dark;
+
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --ink: #16181d;
+  --ink-soft: #565b66;
+  --ink-faint: #858b98;
+  --line: #e2e5ea;
+  --line-soft: #eef0f4;
+  --accent: #0a6ed1;          /* the UI5 blue this ecosystem is written in */
+  --accent-soft: #e8f1fb;
+  --accent-ink: #06508f;
+  --done: #1a7f4b;
+  --done-soft: #e6f4ec;
+  --mark: #fff2a8;
+  --shadow: 0 1px 2px rgba(16, 20, 30, .05), 0 8px 24px rgba(16, 20, 30, .05);
+  --radius: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14161a;
+    --panel: #1c1f25;
+    --ink: #e9ebf0;
+    --ink-soft: #a7adba;
+    --ink-faint: #7d8494;
+    --line: #2c313a;
+    --line-soft: #23272e;
+    --accent: #6cb1f0;
+    --accent-soft: #1b2c3e;
+    --accent-ink: #9ecbf7;
+    --done: #5fc48d;
+    --done-soft: #1a2c22;
+    --mark: #5a4d12;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 8px 24px rgba(0, 0, 0, .25);
+  }
+}
+
+* { box-sizing: border-box; }
+
+/* `hidden` has to win over the display of anything the page hides - the
+ * buttons and the cards a search removes both set one. */
+[hidden] { display: none !important; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); }
+code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; font-size: .92em; }
+
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+/* ------------------------------------------------------------- masthead */
+
+.masthead {
+  background: linear-gradient(160deg, var(--accent-soft), transparent 70%), var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.masthead .inner { max-width: 1180px; margin: 0 auto; padding: 34px 24px 30px; }
+.brand { margin: 0 0 14px; font-size: .82rem; letter-spacing: .09em; text-transform: uppercase; }
+.brand a { color: var(--ink-faint); text-decoration: none; }
+.brand a:hover { color: var(--accent); }
+.masthead h1 { margin: 0 0 10px; font-size: clamp(1.7rem, 3.6vw, 2.5rem); line-height: 1.15; letter-spacing: -.02em; }
+.lede { margin: 0; max-width: 62ch; color: var(--ink-soft); font-size: 1.03rem; }
+.lede strong { color: var(--ink); }
+
+.cta { margin: 22px 0 0; display: flex; flex-wrap: wrap; gap: 10px; }
+.button {
+  display: inline-block; padding: 9px 16px; border: 1px solid transparent; border-radius: 8px;
+  background: var(--accent); color: #fff; font-size: .93rem; font-weight: 600;
+  text-decoration: none; cursor: pointer; font-family: inherit;
+}
+.button:hover { filter: brightness(1.07); }
+.button.ghost { background: var(--panel); color: var(--ink); border-color: var(--line); }
+.button.ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+/* --------------------------------------------------------------- layout */
+
+.layout {
+  max-width: 1180px; margin: 0 auto; padding: 26px 24px 60px;
+  display: grid; grid-template-columns: 250px minmax(0, 1fr); gap: 34px; align-items: start;
+}
+@media (max-width: 900px) { .layout { grid-template-columns: minmax(0, 1fr); gap: 18px; } }
+
+/* ----------------------------------------------------------------- rail */
+
+/* min-width so the swipeable stage row on a phone really scrolls inside the
+ * rail instead of widening the grid column - a grid item is auto-sized to its
+ * content unless it is told otherwise, and then the whole PAGE scrolls. */
+.rail { position: sticky; top: 20px; min-width: 0; }
+.layout > main { min-width: 0; }
+@media (max-width: 900px) { .rail { position: static; } }
+
+.progress {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 14px 16px; margin-bottom: 16px; box-shadow: var(--shadow);
+}
+.progress-line { margin: 0 0 8px; font-size: .92rem; color: var(--ink-soft); }
+.progress-line b { color: var(--ink); }
+.bar { height: 6px; border-radius: 99px; background: var(--line-soft); overflow: hidden; }
+.bar span { display: block; height: 100%; width: 0; background: var(--done); transition: width .25s ease; }
+.progress .note { margin: 10px 0 0; font-size: .76rem; color: var(--ink-faint); line-height: 1.4; }
+.linkish {
+  background: none; border: 0; padding: 0; margin-top: 8px; color: var(--accent);
+  font: inherit; font-size: .84rem; cursor: pointer; text-decoration: underline;
+}
+
+#stagenav ol { list-style: none; margin: 0; padding: 0; }
+#stagenav li { position: relative; }
+/* the path: one line running behind the stage numbers */
+#stagenav li::before {
+  content: ""; position: absolute; left: 15px; top: 0; bottom: 0; width: 2px; background: var(--line);
+}
+#stagenav li:first-child::before { top: 50%; }
+#stagenav li:last-child::before { bottom: 50%; }
+#stagenav a {
+  position: relative; display: grid; grid-template-columns: 30px minmax(0, 1fr); gap: 10px;
+  align-items: center; padding: 7px 8px; border-radius: 8px;
+  color: var(--ink-soft); text-decoration: none; font-size: .9rem;
+}
+#stagenav a:hover { background: var(--line-soft); color: var(--ink); }
+#stagenav a.here { color: var(--ink); font-weight: 600; }
+#stagenav .n {
+  position: relative; z-index: 1; width: 30px; height: 30px; border-radius: 50%;
+  display: grid; place-items: center; font-size: .84rem; font-weight: 600;
+  background: var(--panel); border: 2px solid var(--line); color: var(--ink-faint);
+}
+#stagenav a.here .n { border-color: var(--accent); color: var(--accent); }
+#stagenav a.complete .n { border-color: var(--done); background: var(--done-soft); color: var(--done); }
+#stagenav .small { display: block; font-size: .76rem; color: var(--ink-faint); font-weight: 400; }
+
+/* On a phone the rail is above the path rather than beside it, so the six
+ * stages become a row you swipe instead of six rows the reader scrolls past
+ * before reaching the first sample. */
+@media (max-width: 900px) {
+  #stagenav ol { display: flex; gap: 8px; overflow-x: auto; padding-bottom: 4px; }
+  #stagenav li { flex: 0 0 auto; }
+  #stagenav li::before { display: none; }
+  #stagenav a {
+    grid-template-columns: 24px auto; gap: 8px;
+    border: 1px solid var(--line); border-radius: 99px; background: var(--panel);
+    padding: 5px 12px 5px 6px; white-space: nowrap;
+  }
+  #stagenav .n { width: 24px; height: 24px; font-size: .76rem; border-width: 1px; }
+  #stagenav .small { display: none; }
+}
+
+
+/* --------------------------------------------------------------- search */
+
+.find {
+  position: sticky; top: 0; z-index: 5;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 10px 14px; margin-bottom: 24px; box-shadow: var(--shadow);
+}
+.find input {
+  flex: 1 1 240px; min-width: 0; border: 0; background: none; color: var(--ink);
+  font: inherit; font-size: 1rem; padding: 4px 0;
+}
+.find input:focus { outline: none; }
+.find kbd {
+  border: 1px solid var(--line); border-bottom-width: 2px; border-radius: 5px;
+  padding: 1px 6px; font-size: .74rem; color: var(--ink-faint);
+}
+.find .found { font-size: .86rem; color: var(--ink-faint); }
+.find .linkish { margin: 0; }
+
+.empty {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 18px; color: var(--ink-soft);
+}
+
+/* --------------------------------------------------------------- stages */
+
+.stage { margin: 0 0 44px; scroll-margin-top: 74px; }
+.stage-head { display: grid; grid-template-columns: 44px minmax(0, 1fr); gap: 14px; align-items: start; margin-bottom: 18px; }
+.stage-head .n {
+  width: 44px; height: 44px; border-radius: 50%; display: grid; place-items: center;
+  background: var(--accent); color: #fff; font-weight: 700; font-size: 1.05rem;
+}
+.stage.done .stage-head .n { background: var(--done); }
+.stage-head h2 { margin: 6px 0 4px; font-size: 1.4rem; letter-spacing: -.01em; }
+.stage-head .blurb { margin: 0; color: var(--ink-soft); max-width: 68ch; font-size: .96rem; }
+.stage-head .tally { margin: 8px 0 0; font-size: .82rem; color: var(--ink-faint); }
+
+.category { margin: 0 0 22px; padding-left: 58px; }
+@media (max-width: 640px) { .category { padding-left: 0; } .stage-head { grid-template-columns: 36px minmax(0, 1fr); } .stage-head .n { width: 36px; height: 36px; font-size: .95rem; } }
+.category h3 {
+  margin: 0 0 10px; font-size: .8rem; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--ink-faint); font-weight: 700;
+}
+.category h3 span { font-weight: 400; text-transform: none; letter-spacing: 0; }
+
+.cards { display: grid; gap: 12px; }
+
+/* ---------------------------------------------------------------- card */
+
+.card {
+  position: relative; background: var(--panel); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 14px 16px 12px 46px; box-shadow: var(--shadow);
+}
+.card.read { border-color: var(--done); background: linear-gradient(90deg, var(--done-soft), var(--panel) 260px); }
+.card.flash { animation: flash 1.4s ease; }
+@keyframes flash { from { border-color: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); } }
+
+.tick {
+  position: absolute; left: 13px; top: 15px; width: 21px; height: 21px; padding: 0;
+  border: 2px solid var(--line); border-radius: 6px; background: var(--panel);
+  color: transparent; cursor: pointer; font-size: .8rem; line-height: 1;
+}
+.tick:hover { border-color: var(--done); color: var(--ink-faint); }
+.card.read .tick { background: var(--done); border-color: var(--done); color: #fff; }
+
+/* An abap2UI5 identifier does not break - `client->nav_app_call` is one word to
+ * a browser - and on a phone one of them is wider than the card. */
+.card h4, .card .what, .card .says { overflow-wrap: anywhere; }
+
+.card h4 { margin: 0 0 2px; font-size: 1.02rem; letter-spacing: -.01em; }
+.card h4 .step {
+  display: inline-block; margin-right: 7px; padding: 0 7px; border-radius: 99px;
+  background: var(--accent-soft); color: var(--accent-ink); font-size: .74rem; font-weight: 700;
+  vertical-align: 2px;
+}
+.card .what { margin: 0 0 6px; color: var(--ink-soft); font-size: .93rem; }
+.card .says { margin: 0 0 10px; font-size: .93rem; max-width: 74ch; }
+
+.terms { margin: 0 0 10px; display: flex; flex-wrap: wrap; gap: 5px; }
+.terms button {
+  border: 1px solid var(--line); border-radius: 99px; background: none; color: var(--ink-faint);
+  font: inherit; font-size: .74rem; padding: 1px 8px; cursor: pointer;
+}
+.terms button:hover { border-color: var(--accent); color: var(--accent); }
+
+/* A documentation path is one long word too (cookbook/event_navigation/…), and
+ * a flex item refuses to shrink below its longest word unless it is allowed
+ * to break - which on a phone pushes the whole card past the screen. */
+.actions { display: flex; flex-wrap: wrap; gap: 8px 14px; align-items: center; font-size: .86rem; min-width: 0; }
+.actions > * { min-width: 0; overflow-wrap: anywhere; }
+.actions a { text-decoration: none; font-weight: 600; }
+.actions a:hover { text-decoration: underline; }
+.actions .copy { border: 0; background: none; padding: 0; font: inherit; font-size: .86rem; color: var(--ink-faint); cursor: pointer; }
+.actions .copy:hover { color: var(--accent); }
+.actions .chapters { color: var(--ink-faint); font-weight: 400; }
+.actions .chapters a { font-weight: 400; color: var(--ink-faint); }
+.actions .chapters a:hover { color: var(--accent); }
+
+mark { background: var(--mark); color: inherit; border-radius: 3px; padding: 0 1px; }
+
+/* ------------------------------------------------------------------ how */
+
+.how {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 20px 24px; scroll-margin-top: 74px;
+}
+.how h2 { margin: 0 0 12px; font-size: 1.15rem; }
+.how ol { margin: 0; padding-left: 20px; color: var(--ink-soft); }
+.how li { margin-bottom: 10px; max-width: 74ch; }
+.how b { color: var(--ink); }
+
+/* --------------------------------------------------------------- footer */
+
+footer {
+  border-top: 1px solid var(--line); background: var(--panel);
+  padding: 26px 24px 40px; color: var(--ink-faint); font-size: .86rem;
+}
+footer p { max-width: 1180px; margin: 0 auto 10px; }
+footer a { color: var(--ink-soft); }

--- a/web/overview.js
+++ b/web/overview.js
@@ -1,0 +1,351 @@
+/*
+ * The overview page - plain ES2020, no dependencies, no build step.
+ *
+ * Everything it knows comes from apps.json (scripts/generate-overview-index.mjs),
+ * regenerated on every deploy. This file only draws the path, narrows it and
+ * remembers what you have read.
+ *
+ * Two decisions worth knowing before changing anything here:
+ *
+ *   Search NARROWS the path, it does not replace it with a result list. The
+ *   order is the content of this page - a sample means something different
+ *   inside "Show many rows" than it does as row 41 of a table - so a query
+ *   hides what does not match and leaves the stages that remain standing.
+ *
+ *   What you have read lives in localStorage and nowhere else. There is no
+ *   account here and there should not be one; the cost is that the marks are
+ *   per browser, which the rail says out loud rather than pretending otherwise.
+ */
+
+const $ = (id) => document.getElementById(id);
+const STORE = 'abap2ui5-samples-path-read';
+
+let DATA = null;
+let ALL = [];                 // every sample, in path order
+let read = new Set();
+
+/* ------------------------------------------------------------------ util */
+
+const esc = (s) => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+/** Wrap every query token found in `text`. Escapes first, so the marks stay
+ *  the only markup that reaches a card. */
+function highlight(text, tokens) {
+  const out = esc(text);
+  if (!tokens.length) return out;
+  const pattern = tokens
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .sort((a, b) => b.length - a.length)
+    .join('|');
+  return out.replace(new RegExp(`(${pattern})`, 'gi'), '<mark>$1</mark>');
+}
+
+/** The one string a query is matched against. The stage and category names are
+ *  in it on purpose: "popup" should find the Popup samples, and so should
+ *  "talk to the user". */
+const haystack = (s) => [
+  s.class, s.title, s.what, s.summary, s.keywords.join(' '),
+  s.category, s.stageTitle, s.docs.map((d) => d.chapter).join(' '),
+].join(' ').toLowerCase();
+
+/** The playground link: the class first, then the files it needs to run - a
+ *  second app it navigates to, a shared data class it reads. The playground
+ *  starts whatever is in the first `src`. */
+function playUrl(sample) {
+  const params = [sample.file, ...sample.deps]
+    .map((file) => `src=${encodeURIComponent(DATA.raw + file)}`)
+    .join('&');
+  return `${DATA.playground}?${params}`;
+}
+
+/* ---------------------------------------------------------------- render */
+
+function card(sample) {
+  /* The position in the topic, which is the reading order - the same marker
+   * the rail puts on a stage, one level down. */
+  const step = `<span class="step">${esc(sample.pos)}</span>`;
+  const terms = sample.keywords.length
+    ? `<p class="terms">${sample.keywords
+      .map((k) => `<button type="button" data-term="${esc(k)}">${esc(k)}</button>`).join('')}</p>`
+    : '';
+  const chapters = sample.docs.length
+    ? `<span class="chapters">docs: ${sample.docs
+      .map((d) => `<a href="${esc(d.url)}" target="_blank" rel="noopener">${esc(d.chapter)}</a>`)
+      .join(', ')}</span>`
+    : '';
+  const extra = sample.deps.length
+    ? ` (with the ${sample.deps.length} class${sample.deps.length === 1 ? '' : 'es'} it calls)`
+    : '';
+
+  return `
+    <article class="card" id="s-${esc(sample.class)}" data-class="${esc(sample.class)}">
+      <button type="button" class="tick" aria-pressed="false" title="mark as read">✓</button>
+      <h4>${step}<span class="t"></span></h4>
+      ${sample.sub ? '<p class="what"></p>' : ''}
+      <p class="says"></p>
+      ${terms}
+      <div class="actions">
+        <a href="${esc(DATA.source + sample.file)}" target="_blank" rel="noopener">Source ↗</a>
+        <a href="${esc(playUrl(sample))}" target="_blank" rel="noopener"
+           title="Open this class in the browser playground${esc(extra)}">Playground ↗</a>
+        <button type="button" class="copy" data-copy="${esc(sample.class.toUpperCase())}"
+                title="the class to put behind ?app_start= in your own system">${esc(sample.class.toUpperCase())}</button>
+        ${chapters}
+      </div>
+    </article>`;
+}
+
+function drawStages() {
+  $('stages').innerHTML = DATA.stages.map((stage, i) => `
+    <section class="stage" id="stage-${esc(stage.id)}" data-stage="${esc(stage.id)}">
+      <div class="stage-head">
+        <div class="n">${i + 1}</div>
+        <div>
+          <h2>${esc(stage.title)}</h2>
+          <p class="blurb">${esc(stage.blurb)}</p>
+          <p class="tally"></p>
+        </div>
+      </div>
+      ${stage.categories.map((category) => `
+        <div class="category" data-category="${esc(category.name)}">
+          <h3>${esc(category.name)} <span>· ${category.samples.length}</span></h3>
+          <div class="cards">${category.samples.map(card).join('')}</div>
+        </div>`).join('')}
+    </section>`).join('');
+
+  $('stagenav').innerHTML = `<ol>${DATA.stages.map((stage, i) => `
+    <li><a href="#stage-${esc(stage.id)}" data-stage="${esc(stage.id)}">
+      <span class="n">${i + 1}</span>
+      <span>${esc(stage.title)}<span class="small" data-count="${esc(stage.id)}"></span></span>
+    </a></li>`).join('')}</ol>`;
+}
+
+/** The text of every visible card, with the query marked. Separate from
+ *  drawStages because it re-runs on every keystroke while the DOM does not. */
+function paint(tokens) {
+  for (const sample of ALL) {
+    const el = sample.el;
+    if (el.hidden) continue;
+    el.querySelector('h4 .t').innerHTML = highlight(sample.label, tokens);
+    if (sample.sub) el.querySelector('.what').innerHTML = highlight(sample.sub, tokens);
+    el.querySelector('.says').innerHTML = highlight(sample.summary, tokens);
+  }
+}
+
+/* ---------------------------------------------------------------- filter */
+
+function apply() {
+  const q = $('q').value.trim().toLowerCase();
+  const tokens = q ? q.split(/\s+/).filter(Boolean) : [];
+
+  let hits = 0;
+  for (const sample of ALL) {
+    const match = tokens.every((t) => sample.hay.includes(t));
+    sample.el.hidden = !match;
+    if (match) hits++;
+  }
+
+  /* A heading over nothing is worse than no heading: a category or a stage
+   * with no surviving card disappears with its cards. The ones that survive
+   * say how much of themselves is left, so a narrowed path still reads as a
+   * path rather than as an arbitrary handful of cards. */
+  for (const el of document.querySelectorAll('.category')) {
+    const cards = [...el.querySelectorAll('.card')];
+    const shown = cards.filter((c) => !c.hidden).length;
+    el.hidden = shown === 0;
+    el.querySelector('h3 span').textContent = tokens.length && shown !== cards.length
+      ? `· ${shown} of ${cards.length}`
+      : `· ${cards.length}`;
+  }
+  for (const el of document.querySelectorAll('.stage')) {
+    const cards = [...el.querySelectorAll('.card')];
+    const shown = cards.filter((c) => !c.hidden).length;
+    el.hidden = shown === 0;
+    if (tokens.length) {
+      el.querySelector('.tally').textContent =
+        `${shown} of ${cards.length} sample${cards.length === 1 ? '' : 's'} match`;
+    }
+  }
+  /* Nothing is being searched for, so the stages go back to saying how far the
+   * reader has come through them. */
+  if (!tokens.length && ALL.every((s) => s.el)) drawProgress();
+
+  $('found').textContent = tokens.length
+    ? `${hits} of ${ALL.length} samples`
+    : `${ALL.length} samples · ${DATA.counts.categories} topics`;
+  $('empty').hidden = hits > 0;
+  $('clearq').hidden = !tokens.length;
+
+  paint(tokens);
+  const url = new URL(location.href);
+  if (q) url.searchParams.set('q', q); else url.searchParams.delete('q');
+  history.replaceState(null, '', url.pathname + url.search + url.hash);
+}
+
+/* -------------------------------------------------------------- progress */
+
+function saveProgress() {
+  try { localStorage.setItem(STORE, JSON.stringify([...read])); } catch { /* private mode */ }
+}
+
+function drawProgress() {
+  const done = ALL.filter((s) => read.has(s.class)).length;
+  $('donecount').textContent = String(done);
+  $('barfill').style.width = `${ALL.length ? (done / ALL.length) * 100 : 0}%`;
+  $('clearprogress').hidden = done === 0;
+
+  for (const sample of ALL) {
+    const on = read.has(sample.class);
+    sample.el.classList.toggle('read', on);
+    sample.el.querySelector('.tick').setAttribute('aria-pressed', String(on));
+  }
+
+  for (const stage of DATA.stages) {
+    const samples = ALL.filter((s) => s.stage === stage.id);
+    const n = samples.filter((s) => read.has(s.class)).length;
+    const section = document.querySelector(`.stage[data-stage="${stage.id}"]`);
+    section.classList.toggle('done', n === samples.length);
+    section.querySelector('.tally').textContent =
+      `${samples.length} samples in ${stage.categories.length} topic${stage.categories.length === 1 ? '' : 's'}`
+      + (n ? ` · ${n} read` : '');
+    document.querySelector(`[data-count="${stage.id}"]`).textContent =
+      n ? `${n}/${samples.length} read` : `${samples.length} samples`;
+    document.querySelector(`#stagenav a[data-stage="${stage.id}"]`)
+      .classList.toggle('complete', n === samples.length && samples.length > 0);
+  }
+
+  const next = ALL.find((s) => !read.has(s.class));
+  $('continue').hidden = done === 0 || !next;
+  if (next) $('continue').dataset.target = next.class;
+}
+
+function jumpTo(cls) {
+  const el = document.getElementById(`s-${cls}`);
+  if (!el) return;
+  if (el.hidden) { $('q').value = ''; apply(); }
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  el.classList.remove('flash');
+  void el.offsetWidth;                         // restart the animation
+  el.classList.add('flash');
+}
+
+/* ------------------------------------------------------------------ boot */
+
+async function boot() {
+  try {
+    const res = await fetch('apps.json');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    DATA = await res.json();
+  } catch (err) {
+    $('stages').innerHTML = `<p class="empty">The catalogue could not be loaded (${esc(err.message)}).
+      It is written by the deploy build; on a local checkout run
+      <code>node scripts/generate-overview-index.mjs</code> first.</p>`;
+    return;
+  }
+
+  for (const stage of DATA.stages) {
+    for (const category of stage.categories) {
+      category.samples.forEach((sample, i) => {
+        sample.stage = stage.id;
+        sample.stageTitle = stage.title;
+        sample.category = category.name;
+        sample.pos = i + 1;
+        /* A title that only repeats the heading it sits under says nothing -
+         * "Table" seven times under TABLE - so where the tile header IS the
+         * category, the card is titled with what the sample actually shows and
+         * the second line disappears. Same rule as SAMPLES.md; a numbered
+         * series keeps its header, because there the numeral is the order. */
+        const repeats = sample.title === category.name;
+        sample.label = repeats ? sample.what : sample.title;
+        sample.sub = repeats ? '' : sample.what;
+        sample.hay = haystack(sample);
+        ALL.push(sample);
+      });
+    }
+  }
+
+  $('total').textContent = String(DATA.counts.samples);
+  $('alltotal').textContent = String(DATA.counts.samples);
+  $('stagecount').textContent = String(DATA.counts.stages);
+  $('overviewapp').textContent = DATA.overviewApp.toUpperCase();
+
+  drawStages();
+  for (const sample of ALL) sample.el = document.getElementById(`s-${sample.class}`);
+
+  try { read = new Set(JSON.parse(localStorage.getItem(STORE) || '[]')); } catch { read = new Set(); }
+  /* A class that has been removed or renamed since the last visit must not
+   * count towards a progress bar over samples that exist. */
+  read = new Set([...read].filter((cls) => ALL.some((s) => s.class === cls)));
+
+  $('q').value = new URLSearchParams(location.search).get('q') || '';
+  apply();
+  drawProgress();
+  if (location.hash.startsWith('#s-')) jumpTo(location.hash.slice(3));
+
+  /* --------------------------------------------------------- interaction */
+
+  $('find').addEventListener('submit', (e) => e.preventDefault());
+  $('q').addEventListener('input', apply);
+  for (const id of ['clearq', 'clearq2']) {
+    $(id).addEventListener('click', () => { $('q').value = ''; apply(); $('q').focus(); });
+  }
+
+  $('stages').addEventListener('click', (e) => {
+    const tick = e.target.closest('.tick');
+    if (tick) {
+      const cls = tick.closest('.card').dataset.class;
+      if (read.has(cls)) read.delete(cls); else read.add(cls);
+      saveProgress();
+      drawProgress();
+      return;
+    }
+    const term = e.target.closest('[data-term]');
+    if (term) {
+      $('q').value = term.dataset.term;
+      apply();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    const copy = e.target.closest('[data-copy]');
+    if (copy) {
+      navigator.clipboard?.writeText(copy.dataset.copy);
+      const was = copy.textContent;
+      copy.textContent = 'copied ✓';
+      setTimeout(() => { copy.textContent = was; }, 1200);
+    }
+  });
+
+  $('continue').addEventListener('click', () => jumpTo($('continue').dataset.target));
+
+  $('clearprogress').addEventListener('click', () => {
+    read = new Set();
+    saveProgress();
+    drawProgress();
+  });
+
+  /* Which stage the reader is in, for the rail. Bottom-heavy margins so the
+   * stage whose cards fill the screen is the one that lights up, not the one
+   * whose heading has just scrolled past. */
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      for (const a of document.querySelectorAll('#stagenav a')) {
+        a.classList.toggle('here', a.dataset.stage === entry.target.dataset.stage);
+      }
+    }
+  }, { rootMargin: '-90px 0px -65% 0px' });
+  for (const el of document.querySelectorAll('.stage')) observer.observe(el);
+
+  /* `/` focuses the search box, the way a documentation site does. */
+  document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && !/^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement.tagName)) {
+      e.preventDefault();
+      $('q').focus();
+      $('q').select();
+    }
+  });
+}
+
+boot();


### PR DESCRIPTION
**https://abap2ui5.github.io/samples/** — the 97 samples of `src/01` as the course they already are, for a reader who has not installed anything yet.

samples-controls publishes a search box, which is the right question there: it is a control reference, and whoever arrives already knows which control they came for. Here the reader usually does not — this collection is a course, "each sample adds one idea" — and a search box asks them the one thing they cannot answer yet. So this page is the path rather than a filter over it: six stages from the smallest app that runs to files, devices and custom CSS, each stage a few topics, each topic its samples in reading order.

- **Search narrows the path in place** instead of replacing it with a result list — the stages that survive say how much of themselves is left. Here the order *is* the content: a table sample means something different inside "Show many rows" than as row 41 of a table.
- **What you have read is ticked off per sample**, so a course somebody walks over several evenings can be resumed. `localStorage`, this browser only, and the rail says so rather than pretending otherwise.
- **Playground links carry the extra classes a sample calls** (a second app, `z2ui5_cl_smp_context`), so the button inside a navigation demo still works — 12 of the 97.
- A card whose title only repeats its heading ("Table", seven times) is titled with what the sample shows instead — the same rule `SAMPLES.md` applies.

**Only `src/01` is on it.** `src/00/97` is unfinished and `src/00/98` is run by a check rather than learned from, and both are stripped from `702` — a page that teaches must not lead anybody into either. The ZZZ helpers are out for the reason they carry no tile.

### It has no facts of its own

The page is the third view of one catalogue, and all three are rendered from the same scan (`scripts/lib/scan-samples.mjs`): the overview app for a reader with the repository in a system, `SAMPLES.md` for a reader on GitHub, this for a reader still deciding whether to install it. A card's title, the sentence under it, its search terms and its documentation chapters are the class's `DESCRIPT`, `@summary`, `@keywords` and `@docs` — change them on the class, as always, and all three follow.

The one thing the tree cannot say is the **order**: the categories are `DESCRIPT` headers and sort alphabetically, which puts `Browser` between `Binding` and `CSS`. So the grouping into stages is a teaching decision, written in `scripts/lib/learning-path.json` and nowhere else — and gated: `npm run check:overview` fails when a category belongs to no stage, when two stages claim one, or when a stage names a category no sample carries. A new category is therefore a decision somebody makes, not a section quietly missing from the page.

### What is in the diff

| | |
|---|---|
| `web/index.html`, `web/overview.css`, `web/overview.js` | the page — no framework, no build step |
| `scripts/generate-overview-index.mjs` | writes `web/apps.json` from the scan; `--check` is the gate |
| `scripts/lib/learning-path.json` | the stages — the one editorial file |
| `.github/workflows/deploy-web.yaml` | the Pages deploy; regenerates `apps.json` on every push |
| `.github/workflows/check-docs.yaml` | one job more: the learning path covers `src/01` |
| `AGENTS.md`, `web/README.md`, `README.md` | what the page is, how to run it locally, and the two places a reader without a system arrives |

`web/apps.json` is generated and **not committed**, the way a bundle is: the workflow writes it on every deploy, so it cannot be staler than the tree, and a sample pull request carries no diff of derived data.

Checked in Chromium at 1280 and 390 px, light and dark: 97 cards, no console errors, no horizontal scroll.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM7nF4NpU3kKgdxJHZ8jem)_