### PR TITLE
Tie the three sample pages together with one shared header

### DIFF
--- a/.github/workflows/check-family-nav.yaml
+++ b/.github/workflows/check-family-nav.yaml
@@ -1,0 +1,38 @@
+name: check-family-nav
+
+# The bar at the top of the page and the card strip at the end of it are three
+# copies of the same markup, one per sample repository - abap2UI5/samples,
+# abap2UI5/samples-controls and abap2UI5/samples-stack. Copies drift, and the
+# way they drift is quiet: a subtitle reworded on one page only, a "you are
+# here" marker left on whichever page was copied from, a sibling dropped from
+# the footer, a link to an address that has since become a 404. None of that
+# breaks a build, and all of it is visible to every reader.
+#
+# The check is offline on purpose. Diffing the three against each other needs
+# the network, and then this repository goes red because github.com is having a
+# morning. It checks the canonical wording it carries itself instead - the same
+# strings in all three copies, so rewording one means editing three files. That
+# is the point, not a cost.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-family-nav-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-family-nav:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: '22'
+    - run: node scripts/check-family-nav.mjs

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "check:prose": "node scripts/check-prose-names.mjs",
     "check:docs-links": "node scripts/check-docs-links.mjs",
     "check:app-rules": "node scripts/check-app-rules.mjs",
+    "check:family-nav": "node scripts/check-family-nav.mjs",
     "rename": "abaplint .github/abaplint/rename_test.jsonc --rename",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "downport": "rm -rf src/00/97 src/00/98 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && node scripts/generate-samples-md.mjs",
-    "check": "npm run lint && npm run check:cloud && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip && npm run check:keywords && npm run check:launchpad && npm run check:overview && npm run check:prose && npm run check:docs-links && npm run check:app-rules && npm run rename"
+    "check": "npm run lint && npm run check:cloud && npm run check:abap2ui5 && npm run check:chains && npm run check:agents && npm run check:strip && npm run check:keywords && npm run check:launchpad && npm run check:overview && npm run check:prose && npm run check:docs-links && npm run check:app-rules && npm run check:family-nav && npm run rename"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-family-nav.mjs
+++ b/scripts/check-family-nav.mjs
@@ -1,0 +1,164 @@
+/*
+ * The family blocks are three copies of the same markup, one per sample
+ * repository, and copies drift. This is what stops them.
+ *
+ * It does NOT diff the blocks byte for byte against the other two - a check
+ * that needs the network to say whether this repository is correct fails for
+ * reasons that have nothing to do with the change under review. It checks the
+ * things a wrong copy actually gets wrong: a link that goes somewhere else, a
+ * verb or a subtitle reworded on one page only, the "you are here" marker left
+ * on whichever page was copied from, a sibling missing from the footer.
+ *
+ * The canonical wording lives below and is identical in all three copies, so
+ * rewording a subtitle means editing three files - which is the point.
+ *
+ * Only these three lines differ between the copies.
+ */
+const SELF = 'samples';
+const PAGE_HTML = 'web/index.html';
+const PAGE_CSS = 'web/overview.css';
+
+import { readFileSync } from 'node:fs';
+
+/* --------------------------------------------------------------- canon */
+
+const BASE = 'https://abap2ui5.github.io';
+
+const PAGES = [
+  {
+    key: 'samples',
+    url: `${BASE}/samples/`,
+    repo: 'abap2UI5/samples',
+    verb: 'Learn',
+    subtitle: 'start here, one idea at a time',
+    question: 'Where do I start?',
+  },
+  {
+    key: 'samples-controls',
+    url: `${BASE}/samples-controls/`,
+    repo: 'abap2UI5/samples-controls',
+    verb: 'Controls',
+    subtitle: 'every UI5 control, searchable',
+    question: 'Which control does what?',
+  },
+  {
+    key: 'samples-stack',
+    url: `${BASE}/samples-stack/`,
+    repo: 'abap2UI5/samples-stack',
+    verb: 'Stack',
+    subtitle: 'OData, RAP and your system',
+    question: 'Will my system run it?',
+  },
+];
+
+const TOOLS = [`${BASE}/playground/`, `${BASE}/docs/`];
+
+/* The catalogue moved to the root of its Pages site when the in-browser demo
+ * was dropped, so this address is a 404 and stayed in one footer for a while.
+ * Nothing may link to it again. */
+const RETIRED = `${BASE}/samples-controls/search/`;
+
+/* ------------------------------------------------------------- helpers */
+
+const problems = [];
+const fail = (msg) => problems.push(msg);
+
+/** The text between two markers, or null. */
+function between(text, name) {
+  const start = text.indexOf(`${name}:start`);
+  const end = text.indexOf(`${name}:end`);
+  if (start < 0 || end < 0 || end < start) return null;
+  return text.slice(start, end);
+}
+
+/** Every href in source order. */
+const hrefs = (block) => [...block.matchAll(/href="([^"]+)"/g)].map((m) => m[1]);
+
+/** Which of the three pages an <a ... aria-current="page"> points at. */
+function currentPage(block) {
+  const marked = [...block.matchAll(/<a\b[^>]*>/g)]
+    .map((m) => m[0])
+    .filter((tag) => tag.includes('aria-current="page"'));
+  if (marked.length !== 1) return { count: marked.length, key: null };
+  const href = /href="([^"]+)"/.exec(marked[0])?.[1];
+  return { count: 1, key: PAGES.find((p) => p.url === href)?.key ?? href };
+}
+
+/* --------------------------------------------------------------- checks */
+
+const html = readFileSync(PAGE_HTML, 'utf8');
+const css = readFileSync(PAGE_CSS, 'utf8');
+
+if (!between(css, 'family-nav')) {
+  fail(`${PAGE_CSS}: the family-nav:start / family-nav:end styles are missing`);
+}
+
+const nav = between(html, 'family-nav');
+const three = between(html, 'three-pages');
+
+if (!nav) fail(`${PAGE_HTML}: no family-nav:start / family-nav:end block`);
+if (!three) fail(`${PAGE_HTML}: no three-pages:start / three-pages:end block`);
+
+if (nav) {
+  const want = [...PAGES.map((p) => p.url), ...TOOLS];
+  const got = hrefs(nav).filter((h) => h.startsWith(BASE));
+  if (got.join(' ') !== want.join(' ')) {
+    fail(`the bar links to\n    ${got.join('\n    ')}\n  but must link, in this order, to\n    ${want.join('\n    ')}`);
+  }
+
+  for (const page of PAGES) {
+    if (!nav.includes(`<b>${page.verb}</b> <span>${page.subtitle}</span>`)) {
+      fail(`the bar does not carry "${page.verb}" with its subtitle "${page.subtitle}" - reword it in all three repositories or in none`);
+    }
+    if (!nav.includes(`title="${page.repo}"`)) {
+      fail(`the bar does not name the repository ${page.repo} in a title attribute`);
+    }
+  }
+
+  const here = currentPage(nav);
+  if (here.count !== 1) fail(`the bar carries ${here.count} aria-current="page" links; it must carry exactly one`);
+  else if (here.key !== SELF) fail(`the bar marks "${here.key}" as the current page, but this repository is ${SELF}`);
+}
+
+if (three) {
+  const want = PAGES.map((p) => p.url);
+  const got = hrefs(three).filter((h) => h.startsWith(BASE));
+  if (got.join(' ') !== want.join(' ')) {
+    fail(`the three-pages strip links to\n    ${got.join('\n    ')}\n  but must link, in this order, to\n    ${want.join('\n    ')}`);
+  }
+
+  for (const page of PAGES) {
+    for (const [what, text] of [['verb', page.verb], ['repository', page.repo], ['question', page.question]]) {
+      if (!three.includes(text)) {
+        fail(`the three-pages strip is missing the ${what} "${text}" - reword it in all three repositories or in none`);
+      }
+    }
+  }
+
+  const here = currentPage(three);
+  if (here.count !== 1) fail(`the three-pages strip carries ${here.count} aria-current="page" cards; it must carry exactly one`);
+  else if (here.key !== SELF) fail(`the three-pages strip marks "${here.key}" as the current page, but this repository is ${SELF}`);
+}
+
+/* The footer is not a shared block - each repository links its own catalogue -
+ * but both siblings have to be reachable from it. */
+const footer = html.slice(html.indexOf('<footer>'));
+for (const page of PAGES.filter((p) => p.key !== SELF)) {
+  if (!footer.includes(page.url)) fail(`the footer does not link ${page.url}`);
+}
+
+if (html.includes(RETIRED)) {
+  fail(`${PAGE_HTML} links ${RETIRED}, which is a 404 - the catalogue is served from the root of that site`);
+}
+
+/* ---------------------------------------------------------------- report */
+
+if (problems.length) {
+  console.error(`check:family-nav - ${problems.length} problem${problems.length === 1 ? '' : 's'} in ${SELF}:\n`);
+  for (const p of problems) console.error(`  * ${p}\n`);
+  console.error('The bar and the strip are shared with abap2UI5/samples, /samples-controls');
+  console.error('and /samples-stack. Change them in all three repositories or in none.');
+  process.exit(1);
+}
+
+console.log(`check:family-nav - the shared blocks in ${SELF} are intact`);

--- a/web/README.md
+++ b/web/README.md
@@ -27,6 +27,44 @@ Only `src/01` is on the page: the portable set that survives every build.
 `src/00/97` is unfinished and `src/00/98` is run by a check rather than learned
 from, and a page that teaches must not lead anybody into either.
 
+## The bar at the top is shared, and so is the strip at the bottom
+
+Three repositories publish three pages that answer three different questions,
+and until now only one of them said so. A reader who arrived on
+[samples-controls](https://abap2ui5.github.io/samples-controls/) — the biggest
+of the three, and the likeliest thing a search engine hands somebody — was
+told nothing about the other two.
+
+Two blocks fix that, and both are **identical in all three repositories**:
+
+| | |
+|---|---|
+| `<nav class="family">` | above the masthead: *Learn · Controls · Stack*, the current one marked with `aria-current`, and the playground and the documentation set apart on the right as the tools they are |
+| `<section class="three">` | before the footer: one card per page with the question it answers, because the end of a page is where a reader who is done with it arrives |
+
+They carry verbs rather than repository names — `samples-controls` tells a
+newcomer nothing, *Controls / every UI5 control, searchable* tells them
+everything — and the repository name lives in the `title` attribute and the
+footer instead. There is no numbering: *step 3 of 3* used to be on the
+samples-stack page and claimed an order that does not hold, since Controls is
+a reference you come back to rather than a step you finish.
+
+Three repositories cannot share a file at run time without one page fetching
+something from another host, which is exactly what these pages avoid, so the
+blocks are **copied**. That is already the practice here — the design tokens
+in `samples-stack` are a declared copy of the ones in `samples-controls` — and
+`npm run check:family-nav` is what keeps the copies honest: it fails when a
+subtitle is reworded on one page only, when the *you are here* marker is left
+on whichever page was copied from, when a sibling drops out of the footer, or
+when anything links `…/samples-controls/search/` again, which has been a 404
+since that catalogue moved to the root of its site.
+
+The styles sit at the end of `overview.css` between the same markers and read
+three tokens this page sets in `:root` — `--family-width`, `--family-gutter`
+and `--family-bleed`. Those three are the *only* thing the copies are allowed
+to differ in, because the three pages are built around containers of different
+widths.
+
 ## Working on it
 
 ```

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,26 @@
 </head>
 <body>
 
+<!-- family-nav:start — IDENTICAL in abap2UI5/samples, abap2UI5/samples-controls
+     and abap2UI5/samples-stack; only aria-current moves. Change it in all three
+     repositories or in none — `npm run check:family-nav` fails when a copy
+     drifts. The styles for it are at the end of the stylesheet. -->
+<nav class="family" aria-label="The abap2UI5 sample pages">
+  <div class="family-inner">
+    <a class="family-brand" href="https://github.com/abap2UI5/abap2UI5">abap2UI5</a>
+    <a class="family-page" href="https://abap2ui5.github.io/samples/"
+       title="abap2UI5/samples" aria-current="page"><b>Learn</b> <span>start here, one idea at a time</span></a>
+    <a class="family-page" href="https://abap2ui5.github.io/samples-controls/"
+       title="abap2UI5/samples-controls"><b>Controls</b> <span>every UI5 control, searchable</span></a>
+    <a class="family-page" href="https://abap2ui5.github.io/samples-stack/"
+       title="abap2UI5/samples-stack"><b>Stack</b> <span>OData, RAP and your system</span></a>
+    <span class="family-spacer"></span>
+    <a class="family-tool" href="https://abap2ui5.github.io/playground/">Playground ↗</a>
+    <a class="family-tool" href="https://abap2ui5.github.io/docs/">Docs ↗</a>
+  </div>
+</nav>
+<!-- family-nav:end -->
+
 <header class="masthead">
   <div class="inner">
     <p class="brand"><a href="https://github.com/abap2UI5/samples">abap2UI5 · samples</a></p>
@@ -54,9 +74,37 @@
       Nothing on the path matches that. <button type="button" class="linkish" id="clearq2">Clear the search</button>
       — or read <a href="https://github.com/abap2UI5/samples/blob/main/SAMPLES.md">SAMPLES.md</a>,
       which also lists the experimental and testing apps this page deliberately leaves out.
+      <br>
+      Looking for one specific UI5 control? All of them are on
+      <a href="https://abap2ui5.github.io/samples-controls/">Controls</a>. Something that
+      needs OData, RAP, WebSockets or the launchpad? That lives on
+      <a href="https://abap2ui5.github.io/samples-stack/">Stack</a>.
     </p>
 
     <div id="stages"></div>
+
+    <!-- Shown by overview.js once every sample on the path is ticked. The end
+         of the path is the one moment this page KNOWS a reader is ready for
+         the other two, so it is the one place that says so unprompted. -->
+    <section class="whatsnext" id="whatsnext" hidden>
+      <h2>You have walked the path</h2>
+      <p>
+        All <b id="nexttotal">…</b> samples ticked. abap2UI5 itself holds no more
+        surprises for you — what is left is everything it meets:
+      </p>
+      <ul>
+        <li>
+          <a href="https://abap2ui5.github.io/samples-controls/"><b>Controls ↗</b></a>
+          when you need one specific UI5 control and the shape of its API — the demo
+          kit rebuilt in ABAP, searchable by control, library and release.
+        </li>
+        <li>
+          <a href="https://abap2ui5.github.io/samples-stack/"><b>Stack ↗</b></a>
+          when your app has to meet the rest of your system — OData, RAP, business
+          events, WebSockets, the Fiori Launchpad.
+        </li>
+      </ul>
+    </section>
 
     <section class="how" id="how">
       <h2>How to run one</h2>
@@ -86,6 +134,43 @@
   </main>
 </div>
 
+<!-- three-pages:start — IDENTICAL in the same three repositories, same rule:
+     change it in all three or in none. Only aria-current moves. -->
+<section class="three" aria-labelledby="three-h">
+  <h2 id="three-h">The three sample pages</h2>
+  <p class="three-lede">
+    Three repositories, three questions. They are not three steps to work
+    through in order — pick the one that matches what you are asking today.
+  </p>
+  <div class="three-cards">
+    <a class="three-card" href="https://abap2ui5.github.io/samples/" aria-current="page">
+      <span class="three-verb">Learn</span>
+      <span class="three-repo">abap2UI5/samples</span>
+      <span class="three-q">“Where do I start?”</span>
+      <span class="three-what">The path from the smallest app that runs to files, devices and
+        custom CSS — one idea per sample, in the order they build on each other.</span>
+      <span class="three-here">📍 you are here</span>
+    </a>
+    <a class="three-card" href="https://abap2ui5.github.io/samples-controls/">
+      <span class="three-verb">Controls</span>
+      <span class="three-repo">abap2UI5/samples-controls</span>
+      <span class="three-q">“Which control does what?”</span>
+      <span class="three-what">The UI5 demo kit rebuilt in ABAP: every control, searchable by
+        name, by library and by the release your system has to be on.</span>
+      <span class="three-here">📍 you are here</span>
+    </a>
+    <a class="three-card" href="https://abap2ui5.github.io/samples-stack/">
+      <span class="three-verb">Stack</span>
+      <span class="three-repo">abap2UI5/samples-stack</span>
+      <span class="three-q">“Will my system run it?”</span>
+      <span class="three-what">OData, RAP, business events, WebSockets, the launchpad — abap2UI5
+        together with what your system already runs, and what each one needs first.</span>
+      <span class="three-here">📍 you are here</span>
+    </a>
+  </div>
+</section>
+<!-- three-pages:end -->
+
 <footer>
   <p>
     Built from the repository itself: the folder tree, each class's abapGit short
@@ -95,12 +180,15 @@
     so the three cannot disagree. Only <code>src/01</code> is here: the portable
     set that survives every build. Regenerated on every deploy.
   </p>
+  <!-- Same links in the same order in all three sample repositories: this
+       repository, its catalogue, the two sibling pages, then the two tools. -->
   <p>
     <a href="https://github.com/abap2UI5/samples">Repository</a> ·
     <a href="https://github.com/abap2UI5/samples/blob/main/SAMPLES.md">The full catalogue</a> ·
-    <a href="https://abap2ui5.github.io/docs/">Documentation</a> ·
+    <a href="https://abap2ui5.github.io/samples-controls/">Controls</a> ·
+    <a href="https://abap2ui5.github.io/samples-stack/">Stack</a> ·
     <a href="https://abap2ui5.github.io/playground/">Playground</a> ·
-    <a href="https://abap2ui5.github.io/samples-controls/search/">The control reference next door</a>
+    <a href="https://abap2ui5.github.io/docs/">Documentation</a>
   </p>
 </footer>
 

--- a/web/overview.css
+++ b/web/overview.css
@@ -26,6 +26,15 @@
   --mark: #fff2a8;
   --shadow: 0 1px 2px rgba(16, 20, 30, .05), 0 8px 24px rgba(16, 20, 30, .05);
   --radius: 12px;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* The three measurements the shared family blocks at the end of this file
+   * read. They are the only thing about those blocks that is allowed to differ
+   * between the three sample repositories, because the three pages are built
+   * around containers of different widths. */
+  --family-width: 1180px;    /* what .masthead .inner and .layout centre in */
+  --family-gutter: 24px;     /* that container's own side padding */
+  --family-bleed: 0px;       /* <body> has none here, so there is none to undo */
 }
 
 @media (prefers-color-scheme: dark) {
@@ -266,6 +275,23 @@ code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, mo
 
 mark { background: var(--mark); color: inherit; border-radius: 3px; padding: 0 1px; }
 
+/* ----------------------------------------------------------- what's next */
+
+/* The card at the end of the path. It is the only thing on this page drawn
+ * from the reader's own progress rather than from the catalogue, so it is
+ * styled as an arrival - the done green, not the accent blue. */
+.whatsnext {
+  background: var(--done-soft); border: 1px solid var(--done); border-radius: var(--radius);
+  padding: 18px 22px; margin-bottom: 22px;
+}
+.whatsnext h2 { margin: 0 0 8px; font-size: 1.15rem; color: var(--done); }
+.whatsnext p { margin: 0 0 10px; color: var(--ink-soft); max-width: 74ch; }
+.whatsnext p b { color: var(--ink); }
+.whatsnext ul { margin: 0; padding-left: 20px; }
+.whatsnext li { margin-bottom: 8px; color: var(--ink-soft); max-width: 74ch; }
+.whatsnext a { text-decoration: none; }
+.whatsnext a:hover { text-decoration: underline; }
+
 /* ------------------------------------------------------------------ how */
 
 .how {
@@ -285,3 +311,181 @@ footer {
 }
 footer p { max-width: 1180px; margin: 0 auto 10px; }
 footer a { color: var(--ink-soft); }
+
+/* ------------------------------------------------------------ family nav */
+
+/* family-nav:start
+ *
+ * The bar that ties the three sample pages together, and the card strip at the
+ * end of the page that says why you would go next door. Both are IDENTICAL in
+ * abap2UI5/samples, abap2UI5/samples-controls and abap2UI5/samples-stack -
+ * change them in all three repositories or in none. `npm run check:family-nav`
+ * fails when a copy drifts.
+ *
+ * They read three tokens each page sets for itself in :root and nothing else
+ * of their own: --family-width (the container the rest of the page centres
+ * in), --family-gutter (that container's own side padding) and --family-bleed
+ * (the side padding on <body>, which the bar breaks out of to reach the edge).
+ * Every colour comes from the palette above, so light and dark come free.
+ *
+ * The bar is deliberately NOT sticky: two of the three pages already stick
+ * their filter panel to the top, and a second sticky strip above it would eat
+ * a phone screen twice over. */
+
+.family {
+  margin: 0 calc(var(--family-bleed) * -1);
+  padding: 0 var(--family-bleed);
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+
+.family-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .1rem;
+  max-width: var(--family-width);
+  margin: 0 auto;
+  padding: .35rem var(--family-gutter);
+}
+
+.family-brand {
+  margin-right: .7rem;
+  font: 700 .78rem/1 var(--mono);
+  letter-spacing: .04em;
+  color: var(--ink);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.family-brand:hover { color: var(--accent); }
+
+/* The verb is what a reader recognises - "samples-controls" tells a newcomer
+ * nothing, "Controls / every UI5 control, searchable" tells them everything -
+ * so the repository name is in the tooltip and the footer, not here. */
+.family-page {
+  display: inline-flex;
+  align-items: baseline;
+  gap: .45em;
+  padding: .3em .65em;
+  border: 1px solid transparent;
+  border-radius: 99px;
+  font-size: .85rem;
+  text-decoration: none;
+}
+.family-page b { font-weight: 600; color: var(--ink); }
+.family-page span { font-size: .8rem; color: var(--ink-faint); }
+.family-page:hover { background: var(--line-soft); }
+
+/* The one thing this bar has to say without spending a word on it: which of
+ * the three you are reading. Drawn off aria-current, so the markup is the
+ * same file on all three pages and only that attribute moves.
+ *
+ * The current page is coloured with --accent and not --accent-ink: the two
+ * repositories next door use --accent-ink for text ON the accent fill, where
+ * it is white, and white on --accent-soft is nothing at all. */
+.family-page[aria-current="page"] {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.family-page[aria-current="page"] b { color: var(--accent); }
+.family-page[aria-current="page"] span { color: var(--ink-soft); }
+
+.family-spacer { flex: 1 1 auto; }
+
+/* The playground and the documentation are tools, not sibling pages: they sit
+ * apart from the three and carry the outward arrow. */
+.family-tool {
+  padding: .3em .5em;
+  font-size: .8rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.family-tool:hover { color: var(--accent); }
+
+.family a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 99px;
+}
+
+/* On a phone the three verbs and the two tools still fit once the subtitles
+ * go. Dropping the bar entirely would be dropping the way out. */
+@media (max-width: 47rem) {
+  .family-page span { display: none; }
+  .family-brand { margin-right: .35rem; }
+}
+
+/* --------------------------------------------------------- three pages */
+
+/* The bar at the top answers "where am I". This answers "why would I go
+ * anywhere else", and it sits at the end because that is where a reader who
+ * is done with this page arrives. */
+
+.three {
+  max-width: var(--family-width);
+  margin: 3rem auto 0;
+  /* A rule above it, because on one of the three pages this lands directly
+   * under another prose section that has one, and without it the strip reads
+   * as that section's tail rather than as its own thing. */
+  padding: 1.4rem var(--family-gutter) 0;
+  border-top: 1px solid var(--line);
+}
+.three > h2 { margin: 0 0 .3rem; font-size: 1.15rem; }
+.three-lede {
+  max-width: 46rem;
+  margin: 0 0 1rem;
+  font-size: .9rem;
+  color: var(--ink-soft);
+}
+
+.three-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: .7rem;
+}
+
+.three-card {
+  display: block;
+  padding: .85rem .95rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+.three-card:hover { border-color: var(--accent); }
+.three-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+.three-verb {
+  display: block;
+  margin-bottom: .15rem;
+  font: 600 .7rem/1 var(--mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.three-repo { display: block; font-size: .95rem; font-weight: 600; color: var(--ink); }
+.three-q {
+  display: block;
+  margin: .3rem 0 .2rem;
+  font-size: .88rem;
+  font-style: italic;
+  color: var(--ink);
+}
+.three-what { display: block; font-size: .85rem; color: var(--ink-soft); }
+
+/* Same trick as the bar, same reason. */
+.three-here { display: none; }
+.three-card[aria-current="page"] {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.three-card[aria-current="page"] .three-here {
+  display: block;
+  margin-top: .5rem;
+  font: 600 .74rem/1 var(--mono);
+  color: var(--accent);
+}
+
+/* family-nav:end */

--- a/web/overview.js
+++ b/web/overview.js
@@ -177,6 +177,10 @@ function apply() {
     : `${ALL.length} samples · ${DATA.counts.categories} topics`;
   $('empty').hidden = hits > 0;
   $('clearq').hidden = !tokens.length;
+  /* A search is a reader looking for one thing, not one finishing the path -
+   * the arrival card would be answering a question nobody asked. drawProgress
+   * puts it back when the query is cleared. */
+  $('whatsnext').hidden = tokens.length > 0 || !ALL.length || read.size !== ALL.length;
 
   paint(tokens);
   const url = new URL(location.href);
@@ -219,6 +223,10 @@ function drawProgress() {
   const next = ALL.find((s) => !read.has(s.class));
   $('continue').hidden = done === 0 || !next;
   if (next) $('continue').dataset.target = next.class;
+
+  /* The end of the path is the one moment this page knows a reader is ready
+   * for the two next door, so it is the one place that says so unprompted. */
+  $('whatsnext').hidden = !ALL.length || done !== ALL.length || $('q').value.trim() !== '';
 }
 
 function jumpTo(cls) {
@@ -268,6 +276,7 @@ async function boot() {
 
   $('total').textContent = String(DATA.counts.samples);
   $('alltotal').textContent = String(DATA.counts.samples);
+  $('nexttotal').textContent = String(DATA.counts.samples);
   $('stagecount').textContent = String(DATA.counts.stages);
   $('overviewapp').textContent = DATA.overviewApp.toUpperCase();
 


### PR DESCRIPTION
Three repositories publish three pages that answer three different questions, and only one of them said so. samples-controls — the biggest of the three, and the likeliest thing a search engine hands somebody — linked neither sibling; this page linked one, through a footer address that has been a **404** since that catalogue moved to the root of its site (`deploy-web` there uploads `web/search` as the artefact root, so `…/samples-controls/search/` no longer exists).

## What lands on the page

Two blocks, **identical in `abap2UI5/samples`, `/samples-controls` and `/samples-stack`** — only `aria-current` moves:

| | |
|---|---|
| `<nav class="family">` | above the masthead: *Learn · Controls · Stack*, the current one marked, and the playground and the documentation set apart on the right as the tools they are |
| `<section class="three">` | before the footer: one card per page with the question it answers, because the end of a page is where a reader who is done with it arrives |

They carry **verbs rather than repository names** — `samples-controls` tells a newcomer nothing, *Controls / every UI5 control, searchable* tells them everything — so the repository name lives in the `title` attribute and the footer instead. There is no numbering: *step 3 of 3* used to be on the samples-stack page and claimed an order that does not hold, since Controls is a reference you come back to rather than a step you finish.

Also here, specific to this page:

- the **footer 404 is fixed**, and the footer link row now has the same shape and order as the other two;
- the **empty search result** names the two pages that would have the answer, instead of only pointing at `SAMPLES.md`;
- a **"You have walked the path" card** appears once every sample is ticked — the one moment this page knows a reader is ready for the other two, so the one place that says so unprompted. It hides again while a search is active or when a sample is un-ticked.

## Why the blocks are copied rather than shared

Three static pages cannot share a file at run time without one of them fetching from another host, which is exactly what these pages avoid. So the blocks are copied — already the practice here, since the design tokens in samples-stack are a declared copy of the ones in samples-controls — and `npm run check:family-nav` keeps the copies honest. It fails on a subtitle reworded on one page only, a *you are here* marker left on whichever page was copied from, a sibling missing from the footer, or that 404 address coming back.

The check is **offline on purpose**: diffing the three repositories against each other needs the network, and then this repository goes red because github.com is having a morning. It checks the canonical strings it carries itself, which are the same in all three copies — so rewording one means editing three files, which is the point rather than a cost. It runs in `npm run check` and as its own workflow.

## Shape of the copies

The styles sit at the end of `overview.css` between the same markers and read three tokens this page sets in `:root` — `--family-width`, `--family-gutter`, `--family-bleed`. Those three are the *only* thing the copies may differ in, because the three pages are built around containers of different widths. Every colour comes from the palette already here, so light and dark come free. The CSS block is byte-identical across the three repositories (verified).

One detail worth knowing: the current page is coloured with `--accent`, not `--accent-ink`. The two repositories next door use `--accent-ink` for text *on* the accent fill, where it is white, and white on `--accent-soft` is nothing at all.

## Verification

Rendered in Chromium on all three pages, light and dark, at 1280px and 390px: the right page marked, exactly one marker per block, no sideways scrolling, no console errors. The arrival card was exercised in four states (fresh reader, everything ticked, active search, one sample un-ticked). `check:overview`, `check:prose` and `check:family-nav` pass; the check was also tested negatively and rejects a wrong `aria-current`, a reworded subtitle and the retired 404 address with exit 1.

No generator, gate or `apps.json` is touched. `deploy-web` already triggers on `web/**`, so the page redeploys on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QKMsbCiREgnpdfVvQYsa2)_