### PR TITLE
Let the lede fill its column, and send the two tools to a new tab

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,8 +24,10 @@
     <a class="family-page" href="https://abap2ui5.github.io/samples-stack/"
        title="abap2UI5/samples-stack"><b>Stack</b> <span>OData, RAP and your system</span></a>
     <span class="family-spacer"></span>
-    <a class="family-tool" href="https://abap2ui5.github.io/playground/">Playground ↗</a>
-    <a class="family-tool" href="https://abap2ui5.github.io/docs/">Docs ↗</a>
+    <a class="family-tool" href="https://abap2ui5.github.io/playground/"
+       target="_blank" rel="noopener">Playground ↗</a>
+    <a class="family-tool" href="https://abap2ui5.github.io/docs/"
+       target="_blank" rel="noopener">Docs ↗</a>
   </div>
 </nav>
 <!-- family-nav:end -->

--- a/web/overview.css
+++ b/web/overview.css
@@ -437,8 +437,10 @@ footer a { color: var(--ink-soft); }
   letter-spacing: -.02em;
 }
 
+/* No max-width: the lede is the page's description and lines up with the
+ * column under it - the search box, the cards, the rail - rather than ending
+ * two thirds of the way across and leaving the masthead looking unfinished. */
 .lede {
-  max-width: 62ch;
   margin: 0;
   color: var(--ink-soft);
   font-size: 1.03rem;
@@ -462,7 +464,6 @@ footer a { color: var(--ink-soft); }
 }
 .three > h2 { margin: 0 0 .3rem; font-size: 1.15rem; }
 .three-lede {
-  max-width: 46rem;
   margin: 0 0 1rem;
   font-size: .9rem;
   color: var(--ink-soft);


### PR DESCRIPTION
Two things a reader ran into on the finished bar.

## The lede stopped short of its own page

`.lede` carried `max-width: 62ch` while everything under it — the rail, the search box, the cards — ran the full 1132px column. The masthead therefore read as a paragraph of unfinished text rather than as the page's description, with the right third of it empty.

It has no `max-width` now and ends exactly where the column does. Measured rather than eyeballed: the lede spans **154 → 1286** and the content block below spans **154 → 1286**, on all three pages.

The same rule is applied to the two other descriptions that sit above a full-width block: the note in the samples-stack masthead, and the `.three-lede` above the card strip.

## Playground and Docs open in a new tab

They are tools, not sibling pages: following one means leaving the catalogue you were reading, and coming back meant the back button. They now carry `target="_blank" rel="noopener"`, which is what the outward arrow on them has been promising all along.

The three **page** links deliberately keep opening in place — switching between Learn, Controls and Stack is navigation within the family, not a departure from it.

## Verification

Both blocks are still byte-identical across the three repositories — the CSS block verbatim, the nav HTML verbatim once `aria-current` is factored out (both checked mechanically, not by eye). Re-ran the full pass on all three pages, light and dark, at 1280px and 390px: right page marked, exactly one marker per block, no sideways scrolling, no console errors, every landmark still starting at x = 154. `check:family-nav` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QKMsbCiREgnpdfVvQYsa2)_