### PR TITLE
Stop naming z2ui5_if_types: device constants from z2ui5_if_client, the rest declared locally

### DIFF
--- a/src/01/z2ui5_cl_smp_app_064.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_064.clas.abap
@@ -74,12 +74,10 @@ CLASS z2ui5_cl_smp_app_064 IMPLEMENTATION.
 
   METHOD on_init.
 
-    DATA temp1 TYPE z2ui5_if_types=>ty_t_name_value.
     DATA view TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA page1 TYPE REF TO z2ui5_cl_ui5_view_builder.
     DATA temp5 TYPE abap_bool.
     DATA layout TYPE REF TO z2ui5_cl_ui5_view_builder.
-    temp1 = VALUE #( ).
 
     mv_check_enabled = abap_true.
     view             = z2ui5_cl_ui5_view_builder=>factory(

--- a/src/01/z2ui5_cl_smp_app_070.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_070.clas.abap
@@ -23,7 +23,14 @@ CLASS z2ui5_cl_smp_app_070 DEFINITION PUBLIC.
         process_state    TYPE string,
       END OF ty_s_tab.
 
-    DATA mt_mapping TYPE z2ui5_if_types=>ty_t_name_value.
+    " the operator shorthands, name and value
+    TYPES:
+      BEGIN OF ty_s_mapping,
+        n TYPE string,
+        v TYPE string,
+      END OF ty_s_mapping.
+
+    DATA mt_mapping TYPE STANDARD TABLE OF ty_s_mapping WITH EMPTY KEY.
     DATA mv_search_value TYPE string.
     DATA mt_table TYPE STANDARD TABLE OF ty_s_tab WITH EMPTY KEY.
     DATA lv_selkz TYPE abap_bool.

--- a/src/01/z2ui5_cl_smp_app_122.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_122.clas.abap
@@ -51,10 +51,10 @@ CLASS z2ui5_cl_smp_app_122 IMPLEMENTATION.
     device_orientation     = ls_get-s_device-orientation.
     device_height          = CONV string( ls_get-s_device-resize-height ).
     device_width           = CONV string( ls_get-s_device-resize-width ).
-    device_phone           = xsdbool( ls_get-s_device-system = z2ui5_if_types=>cs_device-system-phone ).
-    device_desktop         = xsdbool( ls_get-s_device-system = z2ui5_if_types=>cs_device-system-desktop ).
-    device_tablet          = xsdbool( ls_get-s_device-system = z2ui5_if_types=>cs_device-system-tablet ).
-    device_combi           = xsdbool( ls_get-s_device-system = z2ui5_if_types=>cs_device-system-combi ).
+    device_phone           = xsdbool( ls_get-s_device-system = z2ui5_if_client=>cs_device-system-phone ).
+    device_desktop         = xsdbool( ls_get-s_device-system = z2ui5_if_client=>cs_device-system-desktop ).
+    device_tablet          = xsdbool( ls_get-s_device-system = z2ui5_if_client=>cs_device-system-tablet ).
+    device_combi           = xsdbool( ls_get-s_device-system = z2ui5_if_client=>cs_device-system-combi ).
     device_touch           = ls_get-s_device-support-touch.
     device_pointer         = ls_get-s_device-support-pointer.
     device_retina          = ls_get-s_device-support-retina.


### PR DESCRIPTION
`z2ui5_if_types` is retired in the framework (abap2UI5/abap2UI5#2647) — every type it held now sits on the object that uses it, and the interface itself ships on from the frozen package so nothing breaks. These were the three classes here that still named it.

**App 122** (device info) reads `cs_device-system-*` four times — now from `z2ui5_if_client`, which has carried those constants since before 1.143.0, so it compiles against the release this repository is pinned to.

**App 070** declares the shape it fills: `ty_s_mapping`, components `n` and `v`, same content. A sample that carries its own type needs no framework type at all — and `ty_t_name_value`'s new home is not in a release yet, so this was the only way to do it now rather than later.

**App 064** had `DATA temp1 TYPE z2ui5_if_types=>ty_t_name_value` and a `temp1 = VALUE #( )` next to it, and nothing reads either — a downport leftover in a local method. Both lines are gone.

## One thing left for you to decide

App 070's `mt_mapping` is filled in `on_init` and **never read** — not bound, not in a view path. I retyped it rather than removed it: it is `PUBLIC` and therefore part of the app's serialized model, so dropping it is a decision about the sample, not about the type rename. Say the word and it goes.

## Checks

`npm run check` green end to end: `check:pin`, abaplint strict and cloud (307 files each, 0 issues), `abap2ui5lint`, agents/strip/keywords/launchpad/overview/prose/docs-links/app-rules/family-nav, and the rename run (210 files, 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j2333w6boi4XEDiWo8qBF

---
_Generated by [Claude Code](https://claude.ai/code/session_018j2333w6boi4XEDiWo8qBF)_