### PR TITLE
Ask two abap_bool fields for their value, straighten app_342's condition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1062,6 +1062,7 @@ manually or via editor tooling that the above rules are met.
 
 - Follow the [SAP ABAP Style Guide](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md).
 - Never use an init flag attribute (`check_initialized`, `mv_init`, `is_initialized`, etc.). Always use `client->check_on_init( )` instead.
+- An `abap_bool` is compared to `abap_true` / `abap_false` — never asked with `IS INITIAL` / `IS NOT INITIAL`, which is the question for a string that might be empty (`IF mv_flag = abap_false.`, `DELETE lt_x WHERE flag = abap_false.`). The three `check_on_*( )` methods return `abap_bool` as well, and there the corpus writes the predicative call itself: `IF client->check_on_init( ).`, `` ELSEIF client->check_on_event( `LOCK` ). ``, `IF client->check_on_init( ) OR client->check_on_navigated( ).`. Only a NEGATIVE branch is spelled out, as `= abap_false` — there is no negated predicative form here. The rule and its reasons live in abap2UI5's `build-an-app` skill.
 - Use backticks for all string literals, not single quotes.
 - Use string templates (`|...|` with `{ }` for embedded expressions) instead of `&&` for string concatenation (e.g. `|item { name }|` not `` `item ` && name ``).
 - Prefer functional to procedural language constructs — use `var = VALUE #( ).` to reset a variable, never `CLEAR var.`.

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -184,7 +184,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF mv_init IS INITIAL.
+    IF mv_init = abap_false.
       mv_init = abap_true.
 
       get_data( ).

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -193,8 +193,8 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
     ENDIF.
 
-    IF client->check_on_navigated( )     = abap_true
-        AND client->check_on_init( )          = abap_false.
+    IF client->check_on_navigated( )
+        AND client->check_on_init( ) = abap_false.
       render_main( client ).
     ENDIF.
 

--- a/src/01/z2ui5_cl_smp_app_081.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_081.clas.abap
@@ -190,7 +190,7 @@ CLASS z2ui5_cl_smp_app_081 IMPLEMENTATION.
 
       WHEN `SEL_CHANGE`.
         DATA(lt_sel) = mt_tab.
-        DELETE lt_sel WHERE selected IS INITIAL.
+        DELETE lt_sel WHERE selected = abap_false.
 
       WHEN `POPOVER_LIST`.
         popover_list_display( `TEST` ).


### PR DESCRIPTION
Two fields in the corpus were asked whether they are *empty* when what was meant
is whether they are *true*:

- `z2ui5_cl_smp_app_342:187` — `IF mv_init IS INITIAL.` (`mv_init TYPE abap_bool`)
- `z2ui5_cl_smp_app_081:193` — `DELETE lt_sel WHERE selected IS INITIAL.`
  (`selected TYPE abap_bool`)

Both now compare to `abap_false`, which is what they mean and what the rest of
the corpus does.

## The condition below the first one

```abap
IF client->check_on_navigated( )     = abap_true
    AND client->check_on_init( )          = abap_false.
```

The padding lined up nothing, and `= abap_true` on a predicative call is a word
the rest of the corpus does not write. It reads as the corpus writes it now:

```abap
IF client->check_on_navigated( )
    AND client->check_on_init( ) = abap_false.
```

Continuation indented four, as in `z2ui5_cl_smp_app_421` and
`z2ui5_cl_smp_app_461`. Only the negative half stays spelled out — there is no
negated predicative form here.

## And the rule behind it

`AGENTS.md` §7 gains one bullet, next to the init-flag entry it belongs with: an
`abap_bool` is compared to `abap_true` / `abap_false`, never asked with
`IS INITIAL`; and the `check_on_*( )` methods are asked with the call itself.
The long form and its reasons live in abap2UI5's `build-an-app` skill — this is
the pointer, not a second owner.

## How to test

No behaviour change: `mv_init = abap_false` and `mv_init IS INITIAL` decide
identically for an `abap_bool`, as do the other two.

Both changed classes were run through abaplint's `parser_error` at v750 — 0
findings. (`indentation` is off in this repository's `abaplint.jsonc`, so the
continuation indent is house style, matched against the two files above rather
than a rule.)

One thing this PR does **not** fix: §7 forbids init-flag attributes
(*"never use `check_initialized`, `mv_init`, …, always use
`client->check_on_init( )`"*), and `app_342` has exactly such an `mv_init`.
Removing it is a rewrite of that app's dispatcher, not a style fix, so it is
left for its own change.

Companion PRs: `abap2UI5/abap2UI5#2649` (`node/srv` plus the rule) and
`abap2UI5/playground#19` (every shipped snippet).

*Correction to the first version of this description, made after the merge: it
said "the other 610 apps". 610 counted `check_on_init( )` occurrences across
four repositories, not apps — 133 classes here use it, out of a catalogue of
149. The number appears nowhere in the merged diff.*