### PR TITLE
Add sample 497: a data browser for any table, typed at runtime

### DIFF
--- a/.github/badges/abap2ui5.json
+++ b/.github/badges/abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "abap2UI5",
-  "message": "147 apps · 171 views · 2,169 controls",
+  "message": "148 apps · 172 views · 2,178 controls",
   "color": "007ec6",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # abap2UI5 — samples
 
-**Learn the abap2UI5 basics — 104 ready-to-run apps, from a two-line Hello
+**Learn the abap2UI5 basics — 105 ready-to-run apps, from a two-line Hello
 World to complete applications.**
 
 Install them, click through, read the source: every sample adds one idea — a

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -3,11 +3,11 @@
 
 # The sample catalogue
 
-Every app in this repository — 149 of them — with what it shows and a link
+Every app in this repository — 150 of them — with what it shows and a link
 to its source. This is the [overview app](src/z2ui5_cl_smp_app_000.clas.abap)
 as a page you can read here, before installing anything.
 
-**104 of them ship on every branch** — the portable set the README counts:
+**105 of them ship on every branch** — the portable set the README counts:
 `src/01` plus this overview app. The other 45 are under `src/00` and are
 stripped from `702`. 2 further classes carry the sample name and are
 data objects the samples share rather than apps; they are listed too, so nothing
@@ -16,7 +16,7 @@ in the tree is invisible.
 **To run one:** install [abap2UI5](https://github.com/abap2UI5/abap2UI5), pull
 this repository with [abapGit](https://abapgit.org), then open
 `<your endpoint>?app_start=<the class in the right-hand column>`. Or run
-`Z2UI5_CL_SMP_APP_000` and click through the 97 samples below —
+`Z2UI5_CL_SMP_APP_000` and click through the 98 samples below —
 that is the same list, in the app.
 
 **To read one:** click the class. Every sample is a single class, so the link
@@ -29,9 +29,9 @@ New to abap2UI5? Start at [Basics](#basics), then the
 
 ## The learning path — `src/01`
 
-The 97 samples the overview app lists: cloud-ready, downportable,
+The 98 samples the overview app lists: cloud-ready, downportable,
 plain OpenUI5 1.71. Each adds one idea. With the 6
-helper apps they call and the overview app itself, that is the **104
+helper apps they call and the overview app itself, that is the **105
 ready-to-run apps** the README leads with.
 
 [Basics](#basics) · [Binding](#binding) · [Browser](#browser) · [Control Behaviour](#control-behaviour) · [CSS](#css) · [Device](#device) · [Event](#event) · [File](#file) · [Focus](#focus) · [Formatter](#formatter) · [Grid Table](#grid-table) · [List](#list) · [Menu](#menu) · [Message](#message) · [Navigation](#navigation) · [Nested View](#nested-view) · [Popover](#popover) · [Popup](#popup) · [Scroll](#scroll) · [Table](#table) · [Templating](#templating) · [Timer](#timer) · [Tree](#tree)
@@ -50,6 +50,7 @@ ready-to-run apps** the README leads with.
 
 | Sample | Class |
 |---|---|
+| A View Built From RTTI, No Field Named<br>The view names no field: RTTI reads the components of the internal table and derives every column and every cell binding from them, so changing the structure changes the screen with no view code touched.<br><sub>rtti generic view runtime columns get_components describe_by_data no field name itab structure column cell binding</sub> | [`Z2UI5_CL_SMP_APP_497`](src/01/z2ui5_cl_smp_app_497.clas.abap) |
 | Currency Amounts (sap.ui.model.type.Currency)<br>Formats amounts with sap.ui.model.type.Currency, so decimals and leading zeros follow the currency rather than the ABAP field.<br><sub>amount decimals leading zeros number format</sub><br><sub>docs: [cookbook/model/formatter](https://abap2ui5.github.io/docs/cookbook/model/formatter)</sub> | [`Z2UI5_CL_SMP_APP_067`](src/01/z2ui5_cl_smp_app_067.clas.abap) |
 | Dynamic Table Typed at Runtime (RTTI)<br>Builds a table whose columns are only known at runtime: RTTI over a DDIC name, CREATE DATA, and the generic reference bound into the view.<br><sub>generic data reference create data ddic dynamic itab</sub><br><sub>docs: [cookbook/model/binding](https://abap2ui5.github.io/docs/cookbook/model/binding)</sub> | [`Z2UI5_CL_SMP_APP_061`](src/01/z2ui5_cl_smp_app_061.clas.abap) |
 | Expression Binding, Types and Composite Parts<br>Expression binding in the view - conditions, composite parts and a regular expression decide visible and enabled without asking the backend.<br><sub>formatter parts conditional regexp visible enabled syntax</sub><br><sub>docs: [cookbook/model/expression_binding](https://abap2ui5.github.io/docs/cookbook/model/expression_binding)</sub> | [`Z2UI5_CL_SMP_APP_027`](src/01/z2ui5_cl_smp_app_027.clas.abap) |

--- a/catalogue.json
+++ b/catalogue.json
@@ -57,7 +57,7 @@
   }
  ],
  "counts": {
-  "samples": 97,
+  "samples": 98,
   "categories": 23,
   "stages": 6
  },
@@ -194,6 +194,33 @@
    "docs": [
     "https://abap2ui5.github.io/docs/cookbook/troubleshooting/common_failures"
    ]
+  },
+  {
+   "class": "z2ui5_cl_smp_app_497",
+   "file": "src/01/z2ui5_cl_smp_app_497.clas.abap",
+   "category": "Binding",
+   "stage": "data",
+   "title": "Binding",
+   "description": "A View Built From RTTI, No Field Named",
+   "summary": "The view names no field: RTTI reads the components of the internal table and derives every column and every cell binding from them, so changing the structure changes the screen with no view code touched.",
+   "keywords": [
+    "rtti",
+    "generic",
+    "view",
+    "runtime",
+    "columns",
+    "get_components",
+    "describe_by_data",
+    "no",
+    "field",
+    "name",
+    "itab",
+    "structure",
+    "column",
+    "cell",
+    "binding"
+   ],
+   "docs": []
   },
   {
    "class": "z2ui5_cl_smp_app_067",

--- a/src/01/z2ui5_cl_smp_app_497.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_497.clas.abap
@@ -1,0 +1,124 @@
+" @keywords rtti generic view runtime columns get_components describe_by_data no field name itab structure column cell binding
+" @summary The view names no field: RTTI reads the components of the internal table and derives every column and every cell binding from them, so changing the structure changes the screen with no view code touched.
+CLASS z2ui5_cl_smp_app_497 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    TYPES:
+      BEGIN OF ty_s_flight,
+        carrid   TYPE c LENGTH 3,
+        connid   TYPE n LENGTH 4,
+        fldate   TYPE d,
+        price    TYPE p LENGTH 9 DECIMALS 2,
+        currency TYPE c LENGTH 5,
+      END OF ty_s_flight.
+
+    " the only place in this app that names a field - add one here and it
+    " appears on the screen, because the view below is derived from this type
+    DATA rows TYPE STANDARD TABLE OF ty_s_flight WITH EMPTY KEY.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS set_view.
+    METHODS render_any
+      IMPORTING
+        parent TYPE REF TO z2ui5_cl_ui5_view_builder
+        tab    TYPE STANDARD TABLE.
+    METHODS model_init.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_smp_app_497 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+
+    IF client->check_on_init( ).
+      model_init( ).
+      set_view( ).
+    ELSEIF client->check_on_navigated( ).
+      set_view( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD set_view.
+
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `displayBlock` v = `true`
+            )->a( n = `height`       v = `100%`
+            )->a( n = `xmlns`        v = `sap.m`
+            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ).
+
+    DATA(page) = view->ele( `Shell`
+        )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Binding - A View Built From RTTI`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
+
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `Not one field name appears in the view code. RTTI reads the ` &&
+                                 `components of the internal table, and every column header and ` &&
+                                 `cell binding below is derived from them.`
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
+
+    " the renderer only ever sees TYPE STANDARD TABLE - the same shape
+    " cl_salv_table=>factory( ) has taken since forever
+    render_any( parent = page
+                tab    = rows ).
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD render_any.
+
+    DATA(comps) = CAST cl_abap_structdescr(
+                      CAST cl_abap_tabledescr(
+                          cl_abap_typedescr=>describe_by_data( tab )
+                        )->get_table_line_type( ) )->get_components( ).
+
+    DATA(ui_table) = parent->ele( `Table`
+        )->a( n = `items`      v = client->_bind( tab )
+        )->a( n = `headerText` v = |{ lines( tab ) } rows, { lines( comps ) } columns| ).
+
+    " one column per component - discovered, not declared
+    DATA(columns) = ui_table->ele( `columns` ).
+    LOOP AT comps INTO DATA(comp).
+      columns->ele( `Column`
+          )->ele( `header`
+              )->tag( `Text`
+                  )->a( n = `text` v = comp-name ).
+    ENDLOOP.
+
+    " one cell per component, bound by field name
+    DATA(cells) = ui_table->ele( `items`
+        )->ele( `ColumnListItem`
+            )->ele( `cells` ).
+    LOOP AT comps INTO comp.
+      cells->tag( `Text`
+          )->a( n = `text` v = |\{{ comp-name }\}| ).
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD model_init.
+
+    " fill it however you like - a SELECT, a function module, an EML read
+    rows = VALUE #(
+        ( carrid = 'LH' connid = '0400' fldate = '20260825' price = '899.00' currency = 'EUR' )
+        ( carrid = 'LH' connid = '0402' fldate = '20260826' price = '915.00' currency = 'EUR' )
+        ( carrid = 'AA' connid = '0017' fldate = '20260827' price = '422.50' currency = 'USD' )
+        ( carrid = 'UA' connid = '0941' fldate = '20260828' price = '780.00' currency = 'USD' ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_497.clas.xml
+++ b/src/01/z2ui5_cl_smp_app_497.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_SMP_APP_497</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Binding - A View Built From RTTI, No Field Named</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -694,6 +694,10 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
         sub = `The Developer Tools (Ctrl+F12)`
         keywords = `developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export`
         path = `src/01` app = `z2ui5_cl_smp_app_496` )
+      ( group = `samples` header = `Binding`
+        sub = `A View Built From RTTI, No Field Named`
+        keywords = `rtti generic view runtime columns get_components describe_by_data no field name itab structure column cell binding`
+        path = `src/01` app = `z2ui5_cl_smp_app_497` )
       ( group = `samples` header = `Binding` sub = `Currency Amounts (sap.ui.model.type.Currency)` keywords = `amount decimals leading zeros number format` path = `src/01` app = `z2ui5_cl_smp_app_067` )
       ( group = `samples` header = `Binding` sub = `Dynamic Table Typed at Runtime (RTTI)` keywords = `generic data reference create data ddic dynamic itab` path = `src/01` app = `z2ui5_cl_smp_app_061` )
       ( group = `samples` header = `Binding` sub = `Expression Binding, Types and Composite Parts` keywords = `formatter parts conditional regexp visible enabled syntax` path = `src/01` app = `z2ui5_cl_smp_app_027` )


### PR DESCRIPTION
`render_any( )` takes `TYPE STANDARD TABLE`, asks RTTI for the components, and derives every column header and every cell binding from them. **Not one field name appears in the view code.** Change `ty_s_flight` and the screen changes with it, without `set_view( )` being touched.

The signature is the point as much as the body: `TYPE STANDARD TABLE` is the shape `cl_salv_table=>factory( )` has taken since forever, which is what makes this recognisable rather than clever.

`Binding - A View Built From RTTI, No Field Named`, `src/01`.

## Why not just extend 061?

The fair question, and I checked before writing this.

061 and this one are opposite halves. **061 types the data at runtime and then writes the view by hand** — it names `uuid`, `time`, `previous` in the columns and `{ID}`, `{TIMESTAMPL}`, `{ID_PREV}` in the cells. So its data is generic and its screen is not. This sample closes the other half.

Converting 061 itself does not work: `Z2UI5_T_01` has eight fields including `MANDT` and the `DATA` blob, so a table derived from all its components is unusable — which is precisely why 061 picks three by hand. A legible RTTI-derived view needs a small structure, which is what this sample brings.

061 does have two real defects, found while writing this, and they are fixed separately in #802 (its `@summary` promises RTTI the class never calls, and it binds `selected="{SELKZ}"` to a field the table does not have).

## No dynamic anything

An earlier revision of this branch took a DDIC name from an input field and went through `CREATE DATA ... TYPE STANDARD TABLE OF (name)` plus a dynamic `SELECT`. It demos well and is a poor thing to publish as a pattern: an app that reads whatever table it is handed.

The genericity worth showing lives in the view, not in the data access. The data here is a local typed table filled with `VALUE #( )` — no database, no dynamic call, nothing to copy into a productive system by mistake. It also drops the two problems that version had: `select_performance` (the repo forbids a `noIssues` entry to get past it, rightly) and `cl_abap_elemdescr->get_ddic_field( )` not being released for the cloud build.

## Verification

| | |
|---|---|
| `npm run lint` (standard, v750) | 0 issues, 309 files |
| `npm run check:cloud` | 0 issues, 309 files |
| `npm run check:abap2ui5` | 0 findings, 148 files — incl. `chain-house-layout` |
| 702 downport build | `npm run downport` then `abaplint abap_702.jsonc` — 0 issues, 212 files |
| everything else in `npm run check` | green |

The README count moves 104 → 105 because `generate-samples-md` refuses to run otherwise; `SAMPLES.md`, `catalogue.json`, the overview app and the badge are regenerated.

`check:docs-links` still reports the **9 broken walkthrough links it already reports on `main`** (verified against a clean tree). This branch adds none: the sample carries no `@docs` line, because that pairing has to be declared in `abap2UI5/docs` and would make this pull request wait on another one. Happy to add it together with a `samples:` frontmatter entry in a follow-up.