### PR TITLE
Close the family-nav host check at the slash

### DIFF
--- a/scripts/check-family-nav.mjs
+++ b/scripts/check-family-nav.mjs
@@ -53,6 +53,14 @@ const PAGES = [
 
 const TOOLS = [`${BASE}/playground/`, `${BASE}/docs/`];
 
+/* Our own origin, with the trailing slash, for the "is this one of ours?"
+ * filter below. The slash is not cosmetic: a host name may continue where a
+ * prefix stops, so `startsWith(BASE)` also accepts
+ * `https://abap2ui5.github.io.example.com/samples/` - a link to somebody
+ * else entirely, counted as one of the three and compared against the wanted
+ * list as if it were. With the slash the host is closed. */
+const OURS = `${BASE}/`;
+
 /* The catalogue moved to the root of its Pages site when the in-browser demo
  * was dropped, so this address is a 404 and stayed in one footer for a while.
  * Nothing may link to it again. */
@@ -101,7 +109,7 @@ if (!three) fail(`${PAGE_HTML}: no three-pages:start / three-pages:end block`);
 
 if (nav) {
   const want = [...PAGES.map((p) => p.url), ...TOOLS];
-  const got = hrefs(nav).filter((h) => h.startsWith(BASE));
+  const got = hrefs(nav).filter((h) => h.startsWith(OURS));
   if (got.join(' ') !== want.join(' ')) {
     fail(`the bar links to\n    ${got.join('\n    ')}\n  but must link, in this order, to\n    ${want.join('\n    ')}`);
   }
@@ -122,7 +130,7 @@ if (nav) {
 
 if (three) {
   const want = PAGES.map((p) => p.url);
-  const got = hrefs(three).filter((h) => h.startsWith(BASE));
+  const got = hrefs(three).filter((h) => h.startsWith(OURS));
   if (got.join(' ') !== want.join(' ')) {
     fail(`the three-pages strip links to\n    ${got.join('\n    ')}\n  but must link, in this order, to\n    ${want.join('\n    ')}`);
   }

--- a/scripts/check-framework-pin.mjs
+++ b/scripts/check-framework-pin.mjs
@@ -61,7 +61,16 @@ const ALLOWED_BRANCHES = new Map([
   ['.github/abaplint/abap_702.jsonc', '702'],
 ]);
 
-const A2UI5_URL_RE = /github\.com\/abap2UI5\/abap2UI5/i;
+/* The framework dependency, identified by its url VALUE rather than by a
+ * substring of the entry.
+ *
+ * `/github\.com\/abap2UI5\/abap2UI5/` matched anywhere in the object slice and
+ * stopped at the repository name without closing it, so
+ * `https://github.com/abap2UI5/abap2UI5-local` - a different repository in
+ * the same organisation, and a plausible thing for a config to depend on -
+ * was read as the framework and had its "branch" key checked as if it were.
+ * Anchoring at the key and closing at the quote leaves only the framework. */
+const A2UI5_URL_RE = /"url"\s*:\s*"https:\/\/github\.com\/abap2UI5\/abap2UI5(?:\.git)?\/?"/i;
 const RELEASE_RE = /^\d+\.\d+\.\d+$/;
 
 let errors = 0;


### PR DESCRIPTION
`scripts/check-family-nav.mjs` collected "our" links with
`h.startsWith(BASE)`, where `BASE` is `https://abap2ui5.github.io` — a prefix
test on a URL that a host name may continue past.
`https://abap2ui5.github.io.example.com/samples/` starts with it, so a link to
somebody else entirely would have been collected as one of the three and
compared, in order, against the wanted list. The check whose whole job is to
say which pages the bar links to could not have caught that.

With the trailing slash (`https://abap2ui5.github.io/`) the host is closed and
the prefix can only match this origin. Every real link already carries it, so
nothing about the current pages changes.

Found by reproducing this organisation's CodeQL configuration locally
(`security-extended`): it is `js/incomplete-url-substring-sanitization`, high
severity, twice in this file. Verified gone after the change, with the rest of
the result set unchanged.

The body of this file is shared with `abap2UI5/.github/shared/check-family-nav.mjs`
and the two sibling sample repositories, and is gated against them — it is
changed in all four or in none. The matching pull requests are open in
`samples-controls` and `samples-stack`; the `abap2UI5` half follows once these
are merged, because its gate reads the consumers from `main`.

`node scripts/check-family-nav.mjs` passes here and in both siblings.

---
_Generated by [Claude Code](https://claude.ai/code/session_0146Q9UP9JavNhdDd8bqdQik)_