### PR TITLE
Bump the linter to 0.6.0, and answer the four findings it can now see

### DIFF
--- a/.github/badges/check-abap2ui5.json
+++ b/.github/badges/check-abap2ui5.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "check-abap2UI5",
-  "message": "91 rules passed",
-  "color": "4c1",
+  "message": "2 problems",
+  "color": "dfb317",
   "labelColor": "555",
   "cacheSeconds": 3600
 }

--- a/abap2ui5lint-baseline.json
+++ b/abap2ui5lint-baseline.json
@@ -1,6 +1,7 @@
 {
-  "note": "abap2ui5-linter baseline: findings that existed when the linter was adopted. Suppressed on every run; NEW findings still fail, a STALE entry fails too. Regenerate with --update-baseline.",
+  "note": "abap2ui5-linter baseline: findings that existed when the linter was adopted. Suppressed on every run; NEW findings still fail, a STALE entry fails too. Regenerate with --update-baseline. The two entries below are NOT adoption debt and NOT accepted defects - they are one linter false positive, entered by hand so that the day the linter stops producing it, this file FAILS and they come out. Nothing else is baselined on purpose: the two control-state-lost-on-rebuild hints 0.6.0 also reports are real, do not fail the gate, and are left visible in the report where somebody can act on them.",
   "findings": {
-    "src/01/z2ui5_cl_smp_app_449.clas.abap|commercial-ui5-host|||hana.ondemand.com": 1
+    "src/01/z2ui5_cl_smp_app_306.clas.abap|relative-binding-without-context|sap.ui.core.Item|key|KEY": 1,
+    "src/01/z2ui5_cl_smp_app_306.clas.abap|relative-binding-without-context|sap.ui.core.Item|text|TEXT": 1
   }
 }

--- a/abap2ui5lint.jsonc
+++ b/abap2ui5lint.jsonc
@@ -120,6 +120,22 @@
     // pin moves, a pattern anchored on the folder is the one that holds.
     "non-released-api": { "exclude": ["/00/98/"] },
 
+    /* Same folder, same reason, added with the 0.6.0 bump that brought the
+     * rule. `frontend-action-too-new` reports a follow_up_action(
+     * control_global, … ) whose target the frontend resolves with a lazy
+     * require, so below its release the require returns undefined and the wire
+     * does nothing. That is worth knowing everywhere EXCEPT here: app 446 is a
+     * test app whose subject IS the control_global surface, and one of the
+     * five actions it exercises is THEMING.setTheme (@since 1.118). Reporting
+     * it asks the app to stop demonstrating the thing it exists to
+     * demonstrate - the same shape as `non-released-api` above, and §2's own
+     * reading of `src/00/98`: a sample held back BY ITS PURPOSE, deleted
+     * before the 702 build and never shipped as an example to copy.
+     *
+     * Scoped to the folder, not switched off: a control_global action too new
+     * for the floor in `src/01` is a real defect and still fails. */
+    "frontend-action-too-new": { "exclude": ["/00/98/"] },
+
     /* 0.2.0 brought `missing-on-navigated-branch`, and it is RIGHT: 85 apps
      * here dispatch on check_on_init( ) alone, so nothing re-displays when a
      * called app or a popup hands control back, or when a bookmarked state is

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.4.1",
+        "@abap2ui5/linter": "^0.6.0",
         "@abap2ui5/render-runtime": "^0.4.1",
         "@abaplint/cli": "^2.120.23"
       },
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.4.1.tgz",
-      "integrity": "sha512-lhPjNhRv0/rVNgeI37lJ1ceVh81KuUe2Bcfpz2N/WtHcfVcRDJDMzSzE7dS2/r+uvg+J32Ovez/L0dfuijsbmQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.6.0.tgz",
+      "integrity": "sha512-9KhmEFdKtuTEbtmiWMUofJBl86fz8mosalkRP3W/LQFhwdNxA8bPEZlN2DD5jHZQinTSIE/jbQe/oFzp1BHIUg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -33,7 +33,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@abap2ui5/render-runtime": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0"
+        "@abap2ui5/render-runtime": ">=0.1.0 <0.7.0"
       },
       "peerDependenciesMeta": {
         "@abap2ui5/render-runtime": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.4.1",
+    "@abap2ui5/linter": "^0.6.0",
     "@abap2ui5/render-runtime": "^0.4.1",
     "@abaplint/cli": "^2.120.23"
   },


### PR DESCRIPTION
## Why now

The pin was `^0.4.1`, two minors behind, and the bump was owed regardless: the baseline entry for app 449's `commercial-ui5-host` had gone **stale**, because 0.6.0 scopes that rule to a *runtime load* and the demo-kit hyperlink it was holding is correctly no longer reported. That was failing the linter's own downstream job.

The entry could not simply be deleted. Measured on both: **0.4.1 still fires it**, so removing it alone would have turned this repository's CI red. Bump and removal belong in one commit.

## The four findings 0.4.1 could not produce

Measured: 0.4.1 reports one finding on this corpus, 0.6.0 reports five. Each is answered on its own terms rather than baselined as a batch.

**`frontend-action-too-new` on app 446** (`THEMING.setTheme`, `@since 1.118`) — scoped out for `src/00/98` only. That folder is the test-app package, §2's "held back by its purpose", deleted before the 702 build and never shipped as an example to copy; app 446 exists to exercise the `control_global` surface, `setTheme` included. Asking it to stop is asking it to stop being the app. Same shape as the `non-released-api` exclusion directly above it in the config, and scoped the same way — the rule still fails on anything in `src/01`.

**`relative-binding-without-context` ×2 on app 306** is a linter **false positive**, and is baselined as one with the reason in the file. The two `core:Item`s are the template of the CameraSelector's bound `items` aggregation, so `{KEY}` and `{TEXT}` are relative to the row and correct:

```abap
)->ele( n = `CameraSelector` ns = `z2ui5`
    )->a( n = `items` v = |\{path:'{ client->_bind( val = devices path = abap_true ) }', sorter: …\}|
    )->tag( n = `Item` ns = `core`
        )->a( n = `key`  v = `{KEY}`
        )->a( n = `text` v = `{TEXT}` ).
```

`z2ui5.cc.CameraSelector` is in no UI5 snapshot (checked: zero `z2ui5*` entries in `data/properties.json`), and every one of these controls extends a real one — CameraSelector extends `sap.m.ComboBox` and inherits its `items`. I could not confirm which branch of `lib/properties.mjs` produces it, so I am reporting it rather than guessing at a fix: an attempted patch to the unknown-control branch passed the linter's 88 tests but did not change this finding, so it was not the cause and was reverted rather than shipped.

The baseline entry is the right holding place either way: it goes **stale and fails** the moment the linter stops producing the finding, which is what makes it self-clearing rather than a silenced rule.

**`control-state-lost-on-rebuild` ×2** (apps 202, 474) is deliberately **not** baselined. Both are real, both are hints, and hints do not fail this gate — so they stay visible in the report where somebody can act on them. Baselining them would have been the one-command answer and the wrong one.

## Verification

```
npm run check    # green end to end: 0 failing over 148 files, 212 through abaplint
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01472ydUNKidXgDH29MLq4Cw)_