### PR TITLE
Bump to linter 0.6.1 and empty the baseline it makes stale

### DIFF
--- a/abap2ui5lint-baseline.json
+++ b/abap2ui5lint-baseline.json
@@ -1,7 +1,4 @@
 {
-  "note": "abap2ui5-linter baseline: findings that existed when the linter was adopted. Suppressed on every run; NEW findings still fail, a STALE entry fails too. Regenerate with --update-baseline. The two entries below are NOT adoption debt and NOT accepted defects - they are one linter false positive, entered by hand so that the day the linter stops producing it, this file FAILS and they come out. Nothing else is baselined on purpose: the two control-state-lost-on-rebuild hints 0.6.0 also reports are real, do not fail the gate, and are left visible in the report where somebody can act on them.",
-  "findings": {
-    "src/01/z2ui5_cl_smp_app_306.clas.abap|relative-binding-without-context|sap.ui.core.Item|key|KEY": 1,
-    "src/01/z2ui5_cl_smp_app_306.clas.abap|relative-binding-without-context|sap.ui.core.Item|text|TEXT": 1
-  }
+  "note": "abap2ui5-linter baseline: findings that existed when the linter was adopted. Suppressed on every run; NEW findings still fail, a STALE entry fails too. Regenerate with --update-baseline. Empty since 0.6.1: the two relative-binding-without-context entries it briefly held were a linter false positive on app 306's bound CameraSelector, and that release fixed it - the entries went stale on the bump and came out, which is what putting them here rather than switching the rule off was for.",
+  "findings": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.6.0",
+        "@abap2ui5/linter": "^0.6.1",
         "@abap2ui5/render-runtime": "^0.4.1",
         "@abaplint/cli": "^2.120.23"
       },
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.6.0.tgz",
-      "integrity": "sha512-9KhmEFdKtuTEbtmiWMUofJBl86fz8mosalkRP3W/LQFhwdNxA8bPEZlN2DD5jHZQinTSIE/jbQe/oFzp1BHIUg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.6.1.tgz",
+      "integrity": "sha512-0VCspV/Mn3m5v66GcoezDLY7GPo9A7YO111uP3qTm4c8uH0pSzp4/LNhYlmPwAmupc3v9kICLdMWTuCi5vGYrg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.6.0",
+    "@abap2ui5/linter": "^0.6.1",
     "@abap2ui5/render-runtime": "^0.4.1",
     "@abaplint/cli": "^2.120.23"
   },


### PR DESCRIPTION
The follow-up to #810, and the shortest possible one.

## What happened

#810 put two entries in the baseline and called them what they were — a linter false positive, not accepted debt:

```
relative-binding-without-context  ×2  on app 306
```

The two `core:Item`s are the template of the CameraSelector's bound `items` aggregation, so `{KEY}` and `{TEXT}` are relative to the row and correct. The linter's property walk declined to look into a non-`sap.` namespace and handed the children no context at all — [abap2UI5/linter#82](https://github.com/abap2UI5/linter/pull/82), released as **0.6.1**.

So the entries go stale on this bump:

```
baselined  0 findings suppressed, 2 STALE — the finding is gone
  ! stale: …app_306…|relative-binding-without-context|sap.ui.core.Item|key|KEY
  ! stale: …app_306…|relative-binding-without-context|sap.ui.core.Item|text|TEXT
```

and come out here.

That is what putting them in the baseline rather than switching the rule off was for. The file **fails** on a stale entry, so the fix landing is what removes them — not somebody remembering to. The note is rewritten to say the file is empty and why, so the next reader does not have to reconstruct it from the history.

## Unchanged, deliberately

The two `control-state-lost-on-rebuild` hints on apps 202 and 474 are still reported. Both are real, both are hints, hints do not fail this gate, and they stay visible in the report where somebody can act on them. Baselining them would have been the one-command answer and the wrong one — that was true in #810 and it is still true.

## Verification

```
npm run check    # green end to end: 0 failing over 148 files, no stale entries,
                 # 212 files through abaplint
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01472ydUNKidXgDH29MLq4Cw)_