### PR TITLE
Ecosystem review: catalogue contract gate, current pins, measured docs

### DIFF
--- a/.github/abaplint/abap_cloud.jsonc
+++ b/.github/abaplint/abap_cloud.jsonc
@@ -10,7 +10,7 @@
     },
     {
       "url": "https://github.com/abap2UI5/abap2UI5",
-      "branch": "1.143.0",
+      "branch": "1.144.0",
       "folder": "/abap2UI5",
       "files": "/src/**/*.*"
     }

--- a/.github/abaplint/rename_test.jsonc
+++ b/.github/abaplint/rename_test.jsonc
@@ -22,7 +22,7 @@
     },
     {
       "url": "https://github.com/abap2UI5/abap2UI5",
-      "branch": "1.143.0",
+      "branch": "1.144.0",
       "files": "/src/**/*.*"
     }
   ],

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -77,6 +77,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,7 +504,7 @@ Four things it shows that the app does not, on purpose:
 
 | | Why |
 |---|---|
-| the `src/00` packages | they have no overview app (§3); listing them nowhere is how its 49 apps became invisible |
+| the `src/00` packages | they have no overview app (§3); listing them nowhere is how its 45 apps became invisible |
 | the `ZZZ` helper apps | they must not get a tile — but a catalogue claiming to account for the tree has to say they exist |
 | the `@keywords` | never rendered in the app (§4); here they are what `Ctrl+F` finds |
 | the `@docs` link | the chapter that explains the pattern the sample demonstrates (§4) — the app has no room for it, and a page does |
@@ -725,7 +725,7 @@ over there, which meant a pull request HERE could add a stale or invented link
 and stay green until somebody regenerated the documentation; and the first half
 existed nowhere at all. The scan refuses a URL that is not on the documentation
 site, which catches a typo in the **host** and nothing whatsoever about the
-path — and 96 classes carry one of these lines. Nothing fails when a page is
+path — and 97 classes carry one of these lines. Nothing fails when a page is
 renamed: the class compiles, `SAMPLES.md` renders the link, and it 404s for
 every reader who follows it.
 
@@ -881,7 +881,6 @@ In the order they fail fastest:
 | `npm run lint` | `abap-standard` | `abaplint` reports 0 issues (`abaplint.jsonc`, `v750`) |
 | `npm run check:cloud` | `abap-cloud` | the same tree against the ABAP Cloud API — `main` is installed there as it is (§2) |
 | `npm run check:abap2ui5` | `check-abap2UI5` | the abap2UI5-linter: the app class and the view it builds, plus a headless render of every view. New findings fail; `abap2ui5lint-baseline.json` holds the debt frozen at adoption, and an entry whose finding is gone fails too |
-| `npm run check:chains` | `check-docs` | the builder chains are in the house layout (§10) |
 | `npm run check:agents` | `check-docs` | no drift between the §1 tree and the actual `package.devc.xml` CTEXTs |
 | `npm run check:strip` | `check-docs` | no drift in the strip list (§2) |
 | `npm run check:keywords` | `check-keywords` | every sample carries `@keywords` and `@summary`, first line, lowercase (§4) |
@@ -968,7 +967,7 @@ By hand, because no script covers it:
   both against §7 and §9; `abapdoc` treats demos as a published API; seven
   rules read a view builder chain or a `VALUE #( )` data table as a
   malformed parameter list, and that layout has its own gate
-  (`npm run check:chains`, §10); `prefer_inline` /
+  (`chain-house-layout` in `npm run check:abap2ui5`, §10); `prefer_inline` /
   `no_inline_in_optional_branches` move declarations the samples place
   deliberately; `prefer_corresponding` proposes a rewrite that does not
   activate on a generic field symbol; and `smim_consistency` cannot resolve
@@ -1013,7 +1012,9 @@ By hand, because no script covers it:
 - CI: `abap2UI5` — as opposed to `abap-standard` / `abap-cloud` /
   `abap-702`, which lint ABAP itself against three target releases
 - **The gate is effective**: 148 app classes, 172 reconstructed views, and
-  the adoption-time debt frozen in `abap2ui5lint-baseline.json` (#753). It was
+  an `abap2ui5lint-baseline.json` that froze the adoption-time debt (#753)
+  until every entry was fixed — empty since 0.6.1, kept so the next adoption
+  has its shape. It was
   not always: while the linter still looked for the view builder's former name
   it found no checkable file at all, and a green `check-abap2UI5` badge then
   meant "nothing was checkable", not "the apps are clean".
@@ -1026,10 +1027,12 @@ By hand, because no script covers it:
   ```
   sources    148 app classes
   views      172 documents reconstructed, nested 11 deep, 7 classes produced none
-  judged     2,176 controls of 106 types, 547 bindings, 69 icons, 4,164 attributes
+  judged     2,178 controls of 106 types, 551 bindings, 68 icons, 4,178 attributes
   gates      properties 148 files, render 172 documents
-  baselined  1 finding suppressed by abap2ui5lint-baseline.json (commercial-ui5-host 1)
   ```
+
+  (No `baselined` line any more: `abap2ui5lint-baseline.json` has been empty
+  since 0.6.1 — the one frozen finding was fixed rather than carried.)
 
   A `judged` line of zeroes, or `148 classes produced none`, is the earlier
   failure repeating itself — and now it says so instead of printing
@@ -1037,7 +1040,7 @@ By hand, because no script covers it:
 - **The two README badges** (`.github/badges/abap2ui5.json` and
   `.github/badges/check-abap2ui5.json`, shields.io endpoint files) carry the
   same statement, split along what they mean: *abap2UI5 | 148 apps · 172 views
-  · 2,176 controls* is what is here, blue, a fact; *check-abap2UI5 | 86 rules
+  · 2,178 controls* is what is here, blue, a fact; *check-abap2UI5 | 86 rules
   passed* is what the gate made of it, green (or *3 problems*, *7 errors*,
   red). A run that finds nothing checkable turns both grey and says so. Every
   run rewrites them, `check-abap2UI5` commits them onto the pull request
@@ -1462,17 +1465,11 @@ The rules above are also the **`view-chain-layout` skill**
 (`.claude/skills/view-chain-layout/`), kept byte-identical in `abap2UI5` and
 `abap2UI5/samples-controls` — read it before writing or reformatting a chain.
 
-`node scripts/chain-format.mjs` (`npm run check:chains`, and a job in
-`check-docs.yaml`) checks all six rules and `npm run fmt:chains` applies them.
-It rewrites whitespace *between* chain segments only, and verifies that
-collapsing every run of code-whitespace leaves the file identical — a
+The linter's `chain-house-layout` rule (part of `npm run check:abap2ui5`,
+in `check-abap2UI5.yaml`) checks all six rules and `npm run fmt:chains`
+applies them. The fixer rewrites whitespace *between* chain segments only,
+and the layout survives because every fix is verified against the rule — a
 formatting change can never alter what the view builds.
-
-The abap2UI5-linter covers part of it: `chain-indentation` and
-`chain-element-per-line` are both raised to `warning` in `abap2ui5lint.jsonc`
-and the baseline holds none of either any more. Neither rule judges the *step*,
-though — a chain uniformly indented by 8 passes both — which is what
-`chain-format` is for.
 
 #### Namespaces
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![ABAP NW 7.02 to ABAP Cloud](https://img.shields.io/badge/ABAP-NW%207.02%20%E2%86%92%20Cloud-blue)](#try-it-in-60-seconds)
 [![namespace](https://img.shields.io/badge/namespace-z2ui5__cl__smp-blue)](abaplint.jsonc)
-[![abap2UI5](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fabap2ui5.json)](#learn-abap2ui5)
+[![abap2UI5](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fabap2UI5%2Fsamples%2Fmain%2F.github%2Fbadges%2Fabap2ui5.json)](#the-learning-path)
 <br><br>
 [![abap-standard](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-standard.yaml)
 [![abap-cloud](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/abap-cloud.yaml)
@@ -63,7 +63,7 @@ Every sample is `Z2UI5_CL_SMP_APP_<no>`, and you start it with
 `?app_start=z2ui5_cl_smp_app_<no>`. **The number alone does not name a sample:
 each of the three repositories numbers from its own sequence, and the class
 prefix is what says which one you mean** — `Z2UI5_CL_SMP_APP_493` is the Hello
-World below, while `Z2UI5_CL_SMPS_APP_493` in
+World here, while `Z2UI5_CL_SMPS_APP_493` in
 [samples-stack](https://github.com/abap2UI5/samples-stack) is a FilterBar with
 variant management. So the catalogue always gives you the class, not a number.
 

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -13,7 +13,7 @@
     },
     {
       "url": "https://github.com/abap2UI5/abap2UI5",
-      "branch": "1.143.0",
+      "branch": "1.144.0",
       "folder": "/abap2UI5",
       "files": "/src/**/*.*"
     }

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -72,7 +72,7 @@
     "abapdoc": false,
     // --- off: the view builder chain owns its own layout --------------
     // A view is one statement spanning up to several hundred lines, laid out
-    // by rules that "npm run check:chains" (scripts/chain-format.mjs) gates -
+    // by rules that the linter's chain-house-layout ("npm run check:abap2ui5") gates -
     // and that gate is stricter than anything here. Every one of these rules
     // reads a chain as a malformed parameter list: 5,087 findings from
     // line_break_multiple_parameters alone, all of them correct chains.

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.120.24",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.24.tgz",
-      "integrity": "sha512-NOIxEvjhFeUDTxa3UYwiAbGiHaEC9r9u/b8eh3LoqWitt6rG7Z/FGAYnGgD8swGfpZe3vXp5atDyOJFhZ2DbUQ==",
+      "version": "2.120.39",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.39.tgz",
+      "integrity": "sha512-Aq0CyET/VmQXwgLcY5y0IMQtvuYs4va5xRqsbl4X12uR/AbSNWMQuWpv98zJPxSpky0lmcVt3+IFLh19qZuq8Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@abap2ui5/linter": "^0.6.1",
-        "@abap2ui5/render-runtime": "^0.4.1",
+        "@abap2ui5/render-runtime": "^0.6.1",
         "@abaplint/cli": "^2.120.23"
       },
       "engines": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@abap2ui5/render-runtime": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/render-runtime/-/render-runtime-0.4.1.tgz",
-      "integrity": "sha512-DHB4ea/bl7wNMQYBZmr2JeqLzI8IjCpYPLpAI4zEDIOGdlwn/ltMVjD0YVBwng0mA2uEUg073eldJVDF5rvtJQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/render-runtime/-/render-runtime-0.6.1.tgz",
+      "integrity": "sha512-s45w9UZ6N0IWRONUcybKL/pYQTmeByy5CWb5mA1AsxCvK7+3xZ8LhuIAYJa2OxJxjRDuY2j1TtqU92m716Kg0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/abap2UI5/samples#readme",
   "devDependencies": {
     "@abap2ui5/linter": "^0.6.1",
-    "@abap2ui5/render-runtime": "^0.4.1",
+    "@abap2ui5/render-runtime": "^0.6.1",
     "@abaplint/cli": "^2.120.23"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:strip": "node scripts/check-strip-lists.mjs",
     "check:keywords": "node scripts/check-keywords.mjs",
     "check:launchpad": "node scripts/generate-launchpad.mjs --check && node scripts/generate-samples-md.mjs --check",
-    "check:catalogue": "node scripts/generate-catalogue.mjs --check",
+    "check:catalogue": "node scripts/generate-catalogue.mjs --check && node scripts/check-catalogue-contract.mjs",
     "check:overview": "node scripts/generate-overview-index.mjs --check",
     "check:prose": "node scripts/check-prose-names.mjs",
     "check:docs-links": "node scripts/check-docs-links.mjs",

--- a/scripts/check-catalogue-contract.mjs
+++ b/scripts/check-catalogue-contract.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/*
+ * check-catalogue-contract — the root `catalogue.json` is a PUBLISHED
+ * interface, and this pins its shape.
+ *
+ * Three repositories publish one: abap2UI5/samples, abap2UI5/samples-controls
+ * and abap2UI5/samples-stack. At least three programs outside them parse all
+ * three shapes independently — abap2UI5/mcp-server's `lib/examples.mjs`, the
+ * vscode-extension's `src/catalogue.ts` and the playground's examples browser
+ * fetch these files raw from GitHub main — so a generator "tidying" a key
+ * breaks consumers whose tests stay green, in repositories that only find out
+ * from users. Each repository's own `generate-catalogue.mjs --check` proves
+ * the file matches the TREE it was generated from; nothing proved it still
+ * matches what the CONSUMERS parse. This does.
+ *
+ * The shapes deliberately differ per repository and this file pins them AS
+ * THEY ARE, divergences included:
+ *
+ *   - samples names itself under `repository`, the other two under `repo`
+ *   - samples and samples-controls put the source path in `file`,
+ *     samples-stack in `path`
+ *   - `keywords` is an ARRAY of words in samples and samples-stack, and one
+ *     space-joined STRING in samples-controls
+ *
+ * Do not "fix" any of these here or in a generator: every consumer above
+ * handles all three spellings today, and unifying them is a coordinated
+ * cross-repository decision (producers, their committed catalogues, three
+ * consumers), not a cleanup. Until that decision is made, changing a spelling
+ * is drift, and this gate is what makes it a failing check instead of a
+ * support issue.
+ *
+ * One copy per publishing repository, byte-identical; the source is
+ * abap2UI5/.github/shared/check-catalogue-contract.mjs (`check:shared` gates
+ * the copies, `sync-shared.yaml` pulls them). The file identifies which
+ * repository it is running in from the catalogue itself, so the copies carry
+ * nothing repository-specific.
+ *
+ *   node scripts/check-catalogue-contract.mjs        (from the repository root)
+ */
+import fs from 'node:fs';
+
+const problems = [];
+const fail = (msg) => problems.push(msg);
+
+const text = fs.readFileSync('catalogue.json', 'utf8');
+let cat;
+try {
+  cat = JSON.parse(text);
+} catch (err) {
+  console.error(`catalogue.json is not JSON: ${err.message}`);
+  process.exit(1);
+}
+
+/* ------------------------------------------------------------- primitives */
+
+const isStr = (v) => typeof v === 'string' && v.length > 0;
+const isStrArray = (v) => Array.isArray(v) && v.every((x) => typeof x === 'string');
+
+/** Every entry carries EXACTLY the declared keys. Exact, not "at least":
+ *  all three catalogues have had no optional entry keys since they exist,
+ *  a consumer may rely on that, and a new key appearing on some entries only
+ *  is the start of the optionality no parser over there handles. */
+function checkEntries(list, listName, fields) {
+  const names = Object.keys(fields);
+  list.forEach((e, i) => {
+    const id = e?.class ?? `#${i}`;
+    const keys = Object.keys(e ?? {});
+    for (const k of keys) if (!names.includes(k)) fail(`${listName}[${id}]: unexpected key "${k}"`);
+    for (const [k, ok] of Object.entries(fields)) {
+      if (!(k in e)) { fail(`${listName}[${id}]: key "${k}" is missing`); continue; }
+      if (!ok(e[k])) fail(`${listName}[${id}]: "${k}" has the wrong shape (${JSON.stringify(e[k]).slice(0, 60)})`);
+    }
+  });
+}
+
+function checkTop(required, listKey) {
+  const keys = Object.keys(cat);
+  for (const k of required) if (!keys.includes(k)) fail(`top level: key "${k}" is missing`);
+  for (const k of keys) if (!required.includes(k)) fail(`top level: unexpected key "${k}"`);
+  if (!Array.isArray(cat[listKey])) fail(`top level: "${listKey}" is not an array`);
+  return Array.isArray(cat[listKey]) ? cat[listKey] : [];
+}
+
+function checkCommon(list, listName, prefix, pathKey) {
+  const seen = new Set();
+  for (const e of list) {
+    const cls = String(e?.class ?? '');
+    if (!cls.toUpperCase().startsWith(prefix)) fail(`${listName}[${cls}]: class does not carry the ${prefix}* prefix`);
+    if (seen.has(cls.toUpperCase())) fail(`${listName}[${cls}]: class listed twice`);
+    seen.add(cls.toUpperCase());
+    /* the path must point INTO this checkout — a catalogue naming a file the
+     * tree no longer has is stale, whatever generated it */
+    const p = e?.[pathKey];
+    if (isStr(p) && !fs.existsSync(p)) fail(`${listName}[${cls}]: ${pathKey} "${p}" does not exist in this repository`);
+  }
+}
+
+/* ------------------------------------------------- one spec per publisher */
+
+const who = cat.repository ?? cat.repo;
+
+if (who === 'abap2UI5/samples') {
+  const list = checkTop(
+    ['purpose', 'repository', 'role', 'family', 'naming', 'scope', 'learningPath', 'counts', 'samples'],
+    'samples',
+  );
+  const stages = new Set((cat.learningPath ?? []).map((s) => s.id));
+  checkEntries(list, 'samples', {
+    class: isStr,
+    file: isStr,
+    category: isStr,
+    stage: (v) => isStr(v) && stages.has(v),
+    title: isStr,
+    description: isStr,
+    summary: isStr,
+    keywords: isStrArray,
+    docs: isStrArray,
+  });
+  checkCommon(list, 'samples', 'Z2UI5_CL_SMP_', 'file');
+  if (cat.counts?.samples !== list.length) fail(`counts.samples says ${cat.counts?.samples}, the array has ${list.length}`);
+} else if (who === 'abap2UI5/samples-controls') {
+  const list = checkTop(
+    ['note', 'repo', 'role', 'caveat', 'categories', 'statuses', 'deviationTypes', 'ui5Snapshot', 'counts', 'ports'],
+    'ports',
+  );
+  const statuses = new Set(Object.keys(cat.statuses ?? {}));
+  const categories = new Set(Object.keys(cat.categories ?? {}));
+  const deviationTypes = Object.keys(cat.deviationTypes ?? {});
+  checkEntries(list, 'ports', {
+    class: isStr,
+    file: isStr,
+    category: (v) => isStr(v) && categories.has(v),
+    library: isStr,
+    // empty on the src/03 SAPUI5 collection - those are free rebuilds with no
+    // single demo kit original, so the KEY is the contract, not its content
+    sample: (v) => typeof v === 'string',
+    entity: (v) => typeof v === 'string',
+    title: isStr,
+    summary: isStr,
+    // one space-joined string here, an array in the sibling repositories —
+    // pinned as-is, see the header
+    keywords: (v) => typeof v === 'string',
+    status: (v) => isStr(v) && statuses.has(v),
+    deviations: (v) => isStrArray(v)
+      && v.every((d) => deviationTypes.some((t) => d.startsWith(t))),
+  });
+  checkCommon(list, 'ports', 'Z2UI5_CL_SMPC_', 'file');
+  if (cat.counts?.entries !== list.length) fail(`counts.entries says ${cat.counts?.entries}, the array has ${list.length}`);
+} else if (who === 'abap2UI5/samples-stack') {
+  const list = checkTop(
+    ['comment', 'repo', 'role', 'start', 'overviewApp', 'packages', 'samples'],
+    'samples',
+  );
+  const packages = new Set((cat.packages ?? []).map((p) => p.package));
+  const branches = new Set((cat.packages ?? []).map((p) => p.branch));
+  checkEntries(list, 'samples', {
+    class: isStr,
+    path: isStr,
+    package: (v) => isStr(v) && packages.has(v),
+    technology: isStr,
+    title: isStr,
+    summary: isStr,
+    keywords: isStrArray,
+    runsOn: isStr,
+    cloud: (v) => typeof v === 'boolean',
+    needs: isStr,
+    branch: (v) => isStr(v) && branches.has(v),
+    setup: isStr,
+  });
+  checkCommon(list, 'samples', 'Z2UI5_CL_SMPS_', 'path');
+} else {
+  fail(`cannot tell which repository this catalogue belongs to — neither "repository" nor "repo" names one this contract knows (got ${JSON.stringify(who)})`);
+}
+
+/* ------------------------------------------------------------------ report */
+
+if (problems.length) {
+  console.error(`catalogue.json breaks the published contract - ${problems.length} problem(s):`);
+  for (const p of problems.slice(0, 25)) console.error(`  ${p}`);
+  if (problems.length > 25) console.error(`  ... and ${problems.length - 25} more`);
+  console.error('\nthe shape is pinned by scripts/check-catalogue-contract.mjs (source: abap2UI5/.github/shared/) -');
+  console.error('mcp-server, the vscode-extension and the playground parse this file from GitHub main.');
+  process.exit(1);
+}
+const n = (cat.samples ?? cat.ports).length;
+console.log(`catalogue.json keeps the published contract - ${n} entries in the ${who} shape`);


### PR DESCRIPTION
Six commits from the 2026-08-30 ecosystem review:

- **`scripts/check-catalogue-contract.mjs`** — byte-identical copy of the new shared checker (source: `abap2UI5/.github/shared/`, `check:shared`-gated, `sync-shared`-pulled). Pins this repository's published `catalogue.json` shape — the interface mcp-server, the vscode-extension and the playground parse from GitHub main. Wired into `check:catalogue`.
- **Pins current**: framework pin 1.143.0 → **1.144.0** in all three abaplint configs (the Tuesday bump a few days early), `@abap2ui5/render-runtime` 0.4.1 → 0.6.1 (one release line with the linter), `@abaplint/cli` lock → 2.120.39.
- **Docs held to measurement**: the retired `check:chains`/`chain-format.mjs` ghosts are gone from four places (the linter's `chain-house-layout` is the gate now, as the shared skill already said), the linter example block and badge quote carry the numbers today's run prints, the empty-since-0.6.1 baseline is described as such, `src/00` counts match line 86, the README badge points at a heading that exists, and the 493 sentence no longer promises a Hello World "below" that is above.

**Validated**: the full `npm run check` chain green on the new pins — abaplint against the 1.144.0 clone, `check:cloud`, the abap2UI5 linter with render (148 files), every generator check, `check:agents`, `check:prose`, and the rename test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuzK8EC2CdQ5PJ6YCdfKJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuzK8EC2CdQ5PJ6YCdfKJc)_