### PR TITLE
Fold App State into the Hash category

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -34,13 +34,7 @@ plain OpenUI5 1.71. Each adds one idea. With the 6
 helper apps they call and the overview app itself, that is the **109
 ready-to-run apps** the README leads with.
 
-[App State](#app-state) · [Basics](#basics) · [Binding](#binding) · [Browser](#browser) · [Control Behaviour](#control-behaviour) · [CSS](#css) · [Device](#device) · [Event](#event) · [File](#file) · [Focus](#focus) · [Formatter](#formatter) · [Grid Table](#grid-table) · [Hash](#hash) · [List](#list) · [Menu](#menu) · [Message](#message) · [Navigation](#navigation) · [Nested View](#nested-view) · [Popover](#popover) · [Popup](#popup) · [Scroll](#scroll) · [Table](#table) · [Templating](#templating) · [Timer](#timer) · [Tree](#tree)
-
-### App State
-
-| Sample | Class |
-|---|---|
-| Bookmark and Share<br>The Fiori app-state pattern: the URL carries the state id, so a bookmark, a reload or a shared link restores the entered data.<br><sub>app state url bookmark share clipboard copy link restore deep link reload app_state_set_active app_state_get_href sap-iapp-state sap-xapp-state</sub><br><sub>docs: [cookbook/expert_more/app_state_share](https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share)</sub> | [`Z2UI5_CL_SMP_APP_498`](src/01/z2ui5_cl_smp_app_498.clas.abap) |
+[Basics](#basics) · [Binding](#binding) · [Browser](#browser) · [Control Behaviour](#control-behaviour) · [CSS](#css) · [Device](#device) · [Event](#event) · [File](#file) · [Focus](#focus) · [Formatter](#formatter) · [Grid Table](#grid-table) · [Hash](#hash) · [List](#list) · [Menu](#menu) · [Message](#message) · [Navigation](#navigation) · [Nested View](#nested-view) · [Popover](#popover) · [Popup](#popup) · [Scroll](#scroll) · [Table](#table) · [Templating](#templating) · [Timer](#timer) · [Tree](#tree)
 
 ### Basics
 
@@ -152,6 +146,7 @@ ready-to-run apps** the README leads with.
 
 | Sample | Class |
 |---|---|
+| App State, Bookmark and Share<br>The Fiori app-state pattern: the URL carries the state id, so a bookmark, a reload or a shared link restores the entered data.<br><sub>app state url bookmark share clipboard copy link restore deep link reload app_state_set_active app_state_get_href sap-iapp-state sap-xapp-state</sub><br><sub>docs: [cookbook/expert_more/app_state_share](https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share)</sub> | [`Z2UI5_CL_SMP_APP_498`](src/01/z2ui5_cl_smp_app_498.clas.abap) |
 | App-Owned Routing (#/detail)<br>The whole hash_* family in one app: hash_set pushes #/detail, hash_replace rewrites it in place, hash_back steps back like a router, a deep link restores.<br><sub>routing hash url page browser back forward history deep link reload hash_set hash_replace hash_back hash_attach_changed navcontainer router onnavback</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_499`](src/01/z2ui5_cl_smp_app_499.clas.abap) |
 | Routing mode fresh<br>Hash routing in mode FRESH: the URL names the CLASS, so Back and a bookmark restart the app as a new instance.<br><sub>routing mode fresh navigation restart new instance nav_app_call</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_468`](src/01/z2ui5_cl_smp_app_468.clas.abap) |
 | Routing mode keep<br>Hash routing in mode KEEP: the URL carries the app-state draft as well, so Back and Forward return to the state, not just to the app.<br><sub>routing mode keep navigation state preserved back nav_app_call</sub><br><sub>docs: [cookbook/event_navigation/routing](https://abap2ui5.github.io/docs/cookbook/event_navigation/routing)</sub> | [`Z2UI5_CL_SMP_APP_480`](src/01/z2ui5_cl_smp_app_480.clas.abap) |

--- a/catalogue.json
+++ b/catalogue.json
@@ -58,40 +58,10 @@
  ],
  "counts": {
   "samples": 102,
-  "categories": 25,
+  "categories": 24,
   "stages": 6
  },
  "samples": [
-  {
-   "class": "z2ui5_cl_smp_app_498",
-   "file": "src/01/z2ui5_cl_smp_app_498.clas.abap",
-   "category": "App State",
-   "stage": "move",
-   "title": "App State",
-   "description": "Bookmark and Share",
-   "summary": "The Fiori app-state pattern: the URL carries the state id, so a bookmark, a reload or a shared link restores the entered data.",
-   "keywords": [
-    "app",
-    "state",
-    "url",
-    "bookmark",
-    "share",
-    "clipboard",
-    "copy",
-    "link",
-    "restore",
-    "deep",
-    "link",
-    "reload",
-    "app_state_set_active",
-    "app_state_get_href",
-    "sap-iapp-state",
-    "sap-xapp-state"
-   ],
-   "docs": [
-    "https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share"
-   ]
-  },
   {
    "class": "z2ui5_cl_smp_app_493",
    "file": "src/01/z2ui5_cl_smp_app_493.clas.abap",
@@ -1170,6 +1140,36 @@
    ],
    "docs": [
     "https://abap2ui5.github.io/docs/cookbook/model/tables"
+   ]
+  },
+  {
+   "class": "z2ui5_cl_smp_app_498",
+   "file": "src/01/z2ui5_cl_smp_app_498.clas.abap",
+   "category": "Hash",
+   "stage": "move",
+   "title": "Hash",
+   "description": "App State, Bookmark and Share",
+   "summary": "The Fiori app-state pattern: the URL carries the state id, so a bookmark, a reload or a shared link restores the entered data.",
+   "keywords": [
+    "app",
+    "state",
+    "url",
+    "bookmark",
+    "share",
+    "clipboard",
+    "copy",
+    "link",
+    "restore",
+    "deep",
+    "link",
+    "reload",
+    "app_state_set_active",
+    "app_state_get_href",
+    "sap-iapp-state",
+    "sap-xapp-state"
+   ],
+   "docs": [
+    "https://abap2ui5.github.io/docs/cookbook/expert_more/app_state_share"
    ]
   },
   {

--- a/scripts/lib/learning-path.json
+++ b/scripts/lib/learning-path.json
@@ -66,7 +66,6 @@
    "categories": [
     "Navigation",
     "Hash",
-    "App State",
     "Nested View",
     "Focus",
     "Scroll",

--- a/src/01/z2ui5_cl_smp_app_498.clas.xml
+++ b/src/01/z2ui5_cl_smp_app_498.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>Z2UI5_CL_SMP_APP_498</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>App State - Bookmark and Share</DESCRIPT>
+    <DESCRIPT>Hash - App State, Bookmark and Share</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -686,10 +686,6 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
   METHOD get_catalog.
 
     result = VALUE #(
-      ( group = `samples` header = `App State`
-        sub = `Bookmark and Share`
-        keywords = `app state url bookmark share clipboard copy link restore deep link reload app_state_set_active app_state_get_href sap-iapp-state sap-xapp-state`
-        path = `src/01` app = `z2ui5_cl_smp_app_498` )
       ( group = `samples` header = `Basics I` sub = `Hello World, the Smallest App` keywords = `hello world smallest first app minimal start here template` path = `src/01` app = `z2ui5_cl_smp_app_493` )
       ( group = `samples` header = `Basics II` sub = `Data Binding: Input and Button` keywords = `binding _bind model attribute value input button serialize` path = `src/01` app = `z2ui5_cl_smp_app_494` )
       ( group = `samples` header = `Basics III` sub = `Lifecycle: Init, Event, Navigated` keywords = `lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated` path = `src/01` app = `z2ui5_cl_smp_app_495` )
@@ -747,6 +743,10 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
       ( group = `samples` header = `Grid Table` sub = `Events on Cell Level` keywords = `cell enter row index event grid alv` path = `src/01` app = `z2ui5_cl_smp_app_160` )
       ( group = `samples` header = `Grid Table` sub = `Full Example with sap.ui.table` keywords = `grid alv dynamicpage column row action currency search sort filter` path = `src/01` app = `z2ui5_cl_smp_app_070` )
       ( group = `samples` header = `Grid Table` sub = `Keep Column Filters on Refresh (C)` keywords = `column filter reset refresh uitableext grid alv` path = `src/01` app = `z2ui5_cl_smp_app_143` )
+      ( group = `samples` header = `Hash`
+        sub = `App State, Bookmark and Share`
+        keywords = `app state url bookmark share clipboard copy link restore deep link reload app_state_set_active app_state_get_href sap-iapp-state sap-xapp-state`
+        path = `src/01` app = `z2ui5_cl_smp_app_498` )
       ( group = `samples` header = `Hash`
         sub = `App-Owned Routing (#/detail)`
         keywords = `routing hash url page browser back forward history deep link reload hash_set hash_replace hash_back hash_attach_changed navcontainer router onnavback`


### PR DESCRIPTION
Per the maintainer: every URL-carrying sample in ONE place. `z2ui5_cl_smp_app_498` (bookmark and share) moves from its own App State category into **Hash**, next to 468 (routing mode fresh), 480 (keep) and 499 (app-owned routing). The App State category leaves the learning path with it; launchpad, SAMPLES.md and catalogue regenerated. The eight abaplint reds against the 1.144.0 tag are unchanged and by design until the next framework release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX

---
_Generated by [Claude Code](https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX)_