### PR TITLE
Hand the nested-view sub-apps the Page they build into

### DIFF
--- a/src/00/98/z2ui5_cl_smp_app_117.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_117.clas.abap
@@ -74,7 +74,17 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -116,10 +126,15 @@ CLASS z2ui5_cl_smp_app_117 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_131.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_131.clas.abap
@@ -76,7 +76,17 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -119,10 +129,15 @@ CLASS z2ui5_cl_smp_app_131 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_185.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_185.clas.abap
@@ -76,7 +76,17 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -103,10 +113,15 @@ CLASS z2ui5_cl_smp_app_185 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_191.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_191.clas.abap
@@ -77,7 +77,17 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -104,10 +114,15 @@ CLASS z2ui5_cl_smp_app_191 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_195.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_195.clas.abap
@@ -77,7 +77,17 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -103,10 +113,15 @@ CLASS z2ui5_cl_smp_app_195 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_211.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_211.clas.abap
@@ -88,7 +88,17 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -131,10 +141,15 @@ CLASS z2ui5_cl_smp_app_211 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)

--- a/src/00/98/z2ui5_cl_smp_app_338.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_338.clas.abap
@@ -76,7 +76,17 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
       lo_items->ele( `IconTabSeparator` ).
     ENDLOOP.
 
-    mo_main_page = lo_items.
+    " the PAGE, not lo_items - this reference is what the sub-app receives as
+    " its mo_parent_page, and a sub-app builds STRAIGHT into whatever it is
+    " handed (it used to walk up to the Page itself, which is what the move to
+    " z2ui5_cl_ui5_view_builder replaced with this contract). Hand over the
+    " IconTabBar's `items` node instead and the sub-app's own content lands in
+    " that aggregation, where sap.m.IconTabHeader=>addItem calls getKey( ) on
+    " everything that is not an IconTabSeparator - so the view dies with
+    " "e.getKey is not a function" before UI5 ever type-checks the aggregation.
+    " Which reference is handed over does not change the rendered view:
+    " stringify( ) renders from the root of the tree, not from this node.
+    mo_main_page = page.
 
   ENDMETHOD.
 
@@ -118,10 +128,15 @@ CLASS z2ui5_cl_smp_app_338 IMPLEMENTATION.
 
         view_display( ).
 
-        ASSIGN mo_app->(`MO_PARENT_VIEW`) TO FIELD-SYMBOL(<view>).
+        " MO_PARENT_PAGE: the sub-apps renamed the attribute when they moved
+        " to z2ui5_cl_ui5_view_builder. This ASSIGN kept naming the old
+        " MO_PARENT_VIEW, so it found nothing, the IF below never ran and the
+        " sub-app rendered its own standalone view instead of into this one -
+        " silently, because a failed ASSIGN only sets sy-subrc
+        ASSIGN mo_app->(`MO_PARENT_PAGE`) TO FIELD-SYMBOL(<page>).
 
-        IF <view> IS ASSIGNED.
-          <view> = mo_main_page.
+        IF <page> IS ASSIGNED.
+          <page> = mo_main_page.
         ENDIF.
 
         CALL METHOD mo_app->(`Z2UI5_IF_APP~MAIN`)


### PR DESCRIPTION
# Description

`Z2UI5_CL_SMP_APP_338` dies on render with

```
_processAfterRendering: unexpected error
TypeError: e.getKey is not a function
    at O.addItem (…/sap/m/library-preload.js)
    at sap.ui.predefine.P.add (…)      <- AggregationForwarder
    at c.addAggregation / c.addItem / c.applySettings
```

`sap.m.IconTabBar.items` is a forwarded aggregation (`IconTabBar.js:254`, `forwarding: {getter: "_getIconTabHeader", aggregation: "items"}`) — the two nested `add` frames — and `IconTabHeader.prototype.addItem` (`IconTabHeader.js:784`, read at `@openui5/sap.m@1.136.16`) does:

```js
IconTabHeader.prototype.addItem = function (oItem) {
    if (!(oItem instanceof IconTabSeparator)) {
        var sKey = oItem.getKey();          // <- the TypeError
        …
    }
    this.addAggregation("items", oItem);    // type check only happens HERE
```

`getKey()` runs **before** `addAggregation` validates the type, which is why this surfaces as a raw `TypeError` rather than UI5's *"is not valid for aggregation items"*. So something that is neither an `IconTabFilter` nor an `IconTabSeparator` reached the `items` aggregation — and in these samples that can only be the embedded sub-app's own content.

The eight nested-view sub-apps take the container they render into as `mo_parent_page` and build **straight into it**; the move to `z2ui5_cl_ui5_view_builder` (#752) replaced the earlier walk up to a named `Page` ancestor (`mo_parent_view->get( 'Page' )`) with that contract, and `AGENTS.md` §10.3 states it. The seven host apps were not moved with it, in two ways that hid each other:

- they hand over `lo_items`, the IconTabBar's `items` aggregation node, instead of the Page — so a sub-app's content lands in that aggregation and the view dies as above;
- they `ASSIGN mo_app->(`MO_PARENT_VIEW`)`, the attribute's pre-migration name. Nothing declares it any more, so on current `main` the `ASSIGN` finds nothing, the `IF … IS ASSIGNED` never fires, the handover does not happen and each sub-app displays its own standalone view instead — which `slot_display( )` then discards, since the last display of a slot wins. Silently: a failed `ASSIGN` only sets `sy-subrc`.

Fixing the name alone would have turned seven silently-not-embedding samples into seven crashing ones, so both go together: hand over `page`, and assign `MO_PARENT_PAGE`. Which node is handed over does not change the host's own view — `stringify( )` renders from the root of the tree, not from the node it is called on.

Apps **117, 131, 185, 191, 195, 211, 338**. The reasoning sits as a comment at both code sites in each.

This restores the pre-#752 layout, where the sub-app renders in the Page below the IconTabBar and the tabs act purely as a selector. Rendering into the IconTabBar's own `content` aggregation would be the more idiomatic UI5 shape for this pattern, but that is a design change beyond the defect and is left for a separate decision.

## How to test

Start `Z2UI5_CL_SMP_APP_338` and switch tabs: the sub-app (`…_339` / `…_342`) renders inside the host view instead of crashing the view or replacing it. Same for the other six hosts.

`npm run check` is green end to end — abaplint 0 issues over 305 files, `abap2ui5lint` 146 files / 0 failing, and every generator/consistency gate. The two `control-state-lost-on-rebuild` hints it reports are pre-existing and in other apps.

Note: neither gate can catch this class of defect — the sub-app's content is appended at runtime through a dynamic `ASSIGN`, so no static reading of a builder chain sees what ends up in the aggregation.

---
_Generated by [Claude Code](https://claude.ai/code/session_012uN8XhNGx3SCxzf91LbwAf)_