### PR TITLE
Add Basics VI sample: Unit Tests for App Logic

### DIFF
--- a/.github/badges/abap2ui5.json
+++ b/.github/badges/abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "abap2UI5",
-  "message": "149 apps · 172 views · 2,299 controls",
+  "message": "150 apps · 173 views · 2,312 controls",
   "color": "007ec6",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -759,7 +759,7 @@ newcomer would actually type:
 
 | Header | What belongs in it |
 |--------|--------------------|
-| `Basics I` … `IV` | the entry point — first app, lifecycle, the minimum loop. The only numbered series: the Roman numeral orders them as a learning path (rule 5 sorts by `header`), and `header_base( )` still renders them as one block |
+| `Basics I` … `VI` | the entry point — first app, lifecycle, the minimum loop, and what you reach for around it (the developer tools, a unit test on the app's own logic). The only numbered series: the Roman numeral orders them as a learning path (rule 5 sorts by `header`), and `header_base( )` still renders them as one block |
 | `Binding` | `_bind( )`, binding syntax, UI5 model types, the model itself |
 | `Browser` | the browser page and tab: URL, title, favicon, reload, clipboard, storage, logout |
 | `Control Behaviour` | one UI5 control is the topic — how it *behaves* and how the backend drives it, typically by calling its methods by ID. **Not** a control reference: that is [samples-controls](https://github.com/abap2UI5/samples-controls), and the header says so (§1) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # abap2UI5 — samples
 
-**Learn the abap2UI5 basics — 110 ready-to-run apps, from a two-line Hello
+**Learn the abap2UI5 basics — 111 ready-to-run apps, from a two-line Hello
 World to complete applications.**
 
 Install them, click through, read the source: every sample adds one idea — a

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -3,11 +3,11 @@
 
 # The sample catalogue
 
-Every app in this repository — 151 of them — with what it shows and a link
+Every app in this repository — 152 of them — with what it shows and a link
 to its source. This is the [overview app](src/z2ui5_cl_smp_app_000.clas.abap)
 as a page you can read here, before installing anything.
 
-**110 of them ship on every branch** — the portable set the README counts:
+**111 of them ship on every branch** — the portable set the README counts:
 `src/01` plus this overview app. The other 41 are under `src/00` and are
 stripped from `702`. 2 further classes carry the sample name and are
 data objects the samples share rather than apps; they are listed too, so nothing
@@ -16,7 +16,7 @@ in the tree is invisible.
 **To run one:** install [abap2UI5](https://github.com/abap2UI5/abap2UI5), pull
 this repository with [abapGit](https://abapgit.org), then open
 `<your endpoint>?app_start=<the class in the right-hand column>`. Or run
-`Z2UI5_CL_SMP_APP_000` and click through the 103 samples below —
+`Z2UI5_CL_SMP_APP_000` and click through the 104 samples below —
 that is the same list, in the app.
 
 **To read one:** click the class. Every sample is a single class, so the link
@@ -29,9 +29,9 @@ New to abap2UI5? Start at [Basics](#basics), then the
 
 ## The learning path — `src/01`
 
-The 103 samples the overview app lists: cloud-ready, downportable,
+The 104 samples the overview app lists: cloud-ready, downportable,
 plain OpenUI5 1.71. Each adds one idea. With the 6
-helper apps they call and the overview app itself, that is the **110
+helper apps they call and the overview app itself, that is the **111
 ready-to-run apps** the README leads with.
 
 [Basics](#basics) · [Binding](#binding) · [Browser](#browser) · [Control Behaviour](#control-behaviour) · [CSS](#css) · [Device](#device) · [Event](#event) · [File](#file) · [Focus](#focus) · [Formatter](#formatter) · [Grid Table](#grid-table) · [Hash](#hash) · [List](#list) · [Menu](#menu) · [Message](#message) · [Navigation](#navigation) · [Nested View](#nested-view) · [Popover](#popover) · [Popup](#popup) · [Scroll](#scroll) · [Table](#table) · [Templating](#templating) · [Timer](#timer) · [Tree](#tree)
@@ -45,6 +45,7 @@ ready-to-run apps** the README leads with.
 | **Basics III** — Lifecycle: Init, Event, Navigated<br>The three questions main( ) asks - init, event, navigated - as one dispatcher, showing what survives a roundtrip and what a navigation does to it.<br><sub>lifecycle roundtrip main dispatcher state serialize check_on_init check_on_event check_on_navigated</sub><br><sub>docs: [cookbook/event_navigation/life_cycle](https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle), [cookbook/expert_more/snippets](https://abap2ui5.github.io/docs/cookbook/expert_more/snippets), [tutorials/walkthrough/step-3](https://abap2ui5.github.io/docs/tutorials/walkthrough/step-3)</sub> | [`Z2UI5_CL_SMP_APP_495`](src/01/z2ui5_cl_smp_app_495.clas.abap) |
 | **Basics IV** — Events, Views and Roundtrips<br>What one event does to a running app: a second view replaces the first, the state comes back with it, and an uncaught error surfaces where you can see it.<br><sub>roundtrip restart second view uncaught error controller basics</sub><br><sub>docs: [cookbook/event_navigation/life_cycle](https://abap2ui5.github.io/docs/cookbook/event_navigation/life_cycle), [cookbook/expert_more/snippets](https://abap2ui5.github.io/docs/cookbook/expert_more/snippets), [tutorials/walkthrough/step-3](https://abap2ui5.github.io/docs/tutorials/walkthrough/step-3)</sub> | [`Z2UI5_CL_SMP_APP_004`](src/01/z2ui5_cl_smp_app_004.clas.abap) |
 | **Basics V** — The Developer Tools (Ctrl+F12)<br>What Ctrl+F12 opens: the request and response payload, the generated XML view, the model, the source and the error log - the first place to look when something does not render.<br><sub>developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export</sub><br><sub>docs: [cookbook/troubleshooting/common_failures](https://abap2ui5.github.io/docs/cookbook/troubleshooting/common_failures)</sub> | [`Z2UI5_CL_SMP_APP_496`](src/01/z2ui5_cl_smp_app_496.clas.abap) |
+| **Basics VI** — Unit Tests for the App Logic<br>The app logic in a method of its own - no client, no attributes - so the local test class beside the class can assert it with ABAP Unit.<br><sub>unit test abapunit testclasses assert testable logic method</sub> | [`Z2UI5_CL_SMP_APP_503`](src/01/z2ui5_cl_smp_app_503.clas.abap) |
 
 ### Binding
 

--- a/catalogue-derived.json
+++ b/catalogue-derived.json
@@ -114,7 +114,7 @@
     "sap.m.CustomTreeItem"
   ],
   "counts": {
-    "samples": 103,
+    "samples": 104,
     "controls": 104
   },
   "samples": [
@@ -220,6 +220,7 @@
     {"class":"z2ui5_cl_smp_app_497","minUi5":"1.71","needs":[],"controls":[14,15,0,1,2,16,8,4],"controlCount":9},
     {"class":"z2ui5_cl_smp_app_498","minUi5":"1.71","needs":[],"controls":[5,6,7,0,1,2,4,9],"controlCount":14},
     {"class":"z2ui5_cl_smp_app_499","minUi5":"1.71","needs":[],"controls":[5,6,7,0,40,60,1,80,81,2,4,9],"controlCount":18},
-    {"class":"z2ui5_cl_smp_app_502","minUi5":"1.71","needs":[],"controls":[5,10,7,0,1,2,8,3,86,4,9],"controlCount":97}
+    {"class":"z2ui5_cl_smp_app_502","minUi5":"1.71","needs":[],"controls":[5,10,7,0,1,2,8,3,86,4,9],"controlCount":97},
+    {"class":"z2ui5_cl_smp_app_503","minUi5":"1.71","needs":[],"controls":[5,6,7,0,1,2,8,4,9],"controlCount":13}
   ]
 }

--- a/catalogue.json
+++ b/catalogue.json
@@ -57,7 +57,7 @@
   }
  ],
  "counts": {
-  "samples": 103,
+  "samples": 104,
   "categories": 24,
   "stages": 6
  },
@@ -194,6 +194,26 @@
    "docs": [
     "https://abap2ui5.github.io/docs/cookbook/troubleshooting/common_failures"
    ]
+  },
+  {
+   "class": "z2ui5_cl_smp_app_503",
+   "file": "src/01/z2ui5_cl_smp_app_503.clas.abap",
+   "category": "Basics",
+   "stage": "start",
+   "title": "Basics VI",
+   "description": "Unit Tests for the App Logic",
+   "summary": "The app logic in a method of its own - no client, no attributes - so the local test class beside the class can assert it with ABAP Unit.",
+   "keywords": [
+    "unit",
+    "test",
+    "abapunit",
+    "testclasses",
+    "assert",
+    "testable",
+    "logic",
+    "method"
+   ],
+   "docs": []
   },
   {
    "class": "z2ui5_cl_smp_app_497",

--- a/src/01/z2ui5_cl_smp_app_503.clas.abap
+++ b/src/01/z2ui5_cl_smp_app_503.clas.abap
@@ -1,0 +1,123 @@
+" @keywords unit test abapunit testclasses assert testable logic method
+" @summary The app logic in a method of its own - no client, no attributes - so the local test class beside the class can assert it with ABAP Unit.
+CLASS z2ui5_cl_smp_app_503 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    DATA amount TYPE i.
+    DATA rate   TYPE i.
+    DATA gross  TYPE string.
+
+    "! The logic under test: a net amount plus a percentage, rounded to whole
+    "! units. It takes what it needs and returns what it computes - it reads
+    "! no attribute, touches no client and starts no roundtrip, which is the
+    "! whole reason a test can call it.
+    "!
+    "! @parameter net | the net amount
+    "! @parameter percent | the tax rate, in percent
+    "! @parameter result | the gross amount, rounded to whole units
+    METHODS gross_amount
+      IMPORTING
+        net           TYPE i
+        percent       TYPE i
+      RETURNING
+        VALUE(result) TYPE i.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS view_display.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_smp_app_503 IMPLEMENTATION.
+
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+
+    IF client->check_on_init( ).
+
+      amount = 100.
+      rate   = 19.
+
+      view_display( ).
+
+    ELSEIF client->check_on_navigated( ).
+      view_display( ).
+
+    ELSEIF client->check_on_event( `CALC` ).
+      gross = |{ gross_amount( net = amount percent = rate ) }|.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD gross_amount.
+
+    " the rounding is the part worth a test: + 50 before the integer division
+    " rounds the half up instead of cutting it off
+    result = net + ( net * percent + 50 ) DIV 100.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
+        )->ele( n = `View` ns = `mvc`
+            )->a( n = `displayBlock` v = `true`
+            )->a( n = `height`       v = `100%`
+            )->a( n = `xmlns`        v = `sap.m`
+            )->a( n = `xmlns:mvc`    v = `sap.ui.core.mvc`
+            )->a( n = `xmlns:form`   v = `sap.ui.layout.form` ).
+
+    DATA(page) = view->ele( `Shell`
+        )->ele( `Page`
+            )->a( n = `title`          v = `abap2UI5 - Basics VI - Unit Tests for the App Logic`
+            )->a( n = `showNavButton`  b = client->check_app_prev_stack( )
+            )->a( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
+
+    page->tag( `MessageStrip`
+        )->a( n = `text`     v = `The sum below is computed by gross_amount( ), a method that takes what it needs and ` &&
+                   `returns what it computes - it reads no attribute and never sees the client. That is what makes ` &&
+                   `it testable: the local test class in z2ui5_cl_smp_app_503.clas.testclasses.abap calls it with ` &&
+                   `three inputs and asserts the three answers, without a browser, a view or a roundtrip. abapGit ` &&
+                   `keeps that file beside the class, and CLSCCINCL in the .clas.xml is what says the class has one.`
+        )->a( n = `type`     v = `Information`
+        )->a( n = `showIcon` b = abap_true
+        )->a( n = `class`    v = `sapUiSmallMargin` ).
+
+    page->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `title`    v = `Gross from net`
+        )->a( n = `editable` b = abap_true
+        )->a( n = `layout`   v = `ResponsiveGridLayout`
+        )->ele( n = `content` ns = `form`
+            )->tag( `Label`
+                )->a( n = `text` v = `Net amount`
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( amount )
+            )->tag( `Label`
+                )->a( n = `text` v = `Tax rate in percent`
+            )->tag( `Input`
+                )->a( n = `value` v = client->_bind( rate )
+            )->tag( `Label`
+                )->a( n = `text` v = `Gross amount`
+            )->tag( `Text`
+                )->a( n = `text` v = client->_bind( gross )
+            )->tag( `Label`
+                )->a( n = `text` v = `Run the logic`
+            )->tag( `Button`
+                )->a( n = `text`  v = `gross_amount( )`
+                )->a( n = `type`  v = `Emphasized`
+                )->a( n = `press` v = client->_event( `CALC` ) ).
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_503.clas.testclasses.abap
+++ b/src/01/z2ui5_cl_smp_app_503.clas.testclasses.abap
@@ -1,0 +1,50 @@
+CLASS ltcl_gross_amount DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+
+  PRIVATE SECTION.
+    DATA cut TYPE REF TO z2ui5_cl_smp_app_503.
+
+    METHODS setup.
+    METHODS test_nineteen_percent FOR TESTING.
+    METHODS test_rounds_the_half_up FOR TESTING.
+    METHODS test_zero_changes_nothing FOR TESTING.
+
+ENDCLASS.
+
+
+CLASS ltcl_gross_amount IMPLEMENTATION.
+
+  METHOD setup.
+
+    " the app class instantiated like any other class - the test needs no
+    " client, no HTTP handler and no frontend to build one
+    cut = NEW #( ).
+
+  ENDMETHOD.
+
+  METHOD test_nineteen_percent.
+
+    cl_abap_unit_assert=>assert_equals( exp = 119
+                                        act = cut->gross_amount( net     = 100
+                                                                 percent = 19 ) ).
+
+  ENDMETHOD.
+
+  METHOD test_rounds_the_half_up.
+
+    " 7% of 10 is 0.7 - the integer division would cut it off, the + 50 in
+    " gross_amount( ) rounds it up to a whole unit
+    cl_abap_unit_assert=>assert_equals( exp = 11
+                                        act = cut->gross_amount( net     = 10
+                                                                 percent = 7 ) ).
+
+  ENDMETHOD.
+
+  METHOD test_zero_changes_nothing.
+
+    cl_abap_unit_assert=>assert_equals( exp = 42
+                                        act = cut->gross_amount( net     = 42
+                                                                 percent = 0 ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/z2ui5_cl_smp_app_503.clas.xml
+++ b/src/01/z2ui5_cl_smp_app_503.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_SMP_APP_503</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Basics VI - Unit Tests for the App Logic</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/z2ui5_cl_smp_app_000.clas.abap
+++ b/src/z2ui5_cl_smp_app_000.clas.abap
@@ -694,6 +694,7 @@ CLASS z2ui5_cl_smp_app_000 IMPLEMENTATION.
         sub = `The Developer Tools (Ctrl+F12)`
         keywords = `developer tools devtools ctrl f12 debug inspect payload previous request response view xml view model source code log error adt export`
         path = `src/01` app = `z2ui5_cl_smp_app_496` )
+      ( group = `samples` header = `Basics VI` sub = `Unit Tests for the App Logic` keywords = `unit test abapunit testclasses assert testable logic method` path = `src/01` app = `z2ui5_cl_smp_app_503` )
       ( group = `samples` header = `Binding`
         sub = `A View Built From RTTI, No Field Named`
         keywords = `rtti generic view runtime columns get_components describe_by_data no field name itab structure column cell binding`


### PR DESCRIPTION
## Summary
Adds a new sample app demonstrating how to write testable ABAP code in abap2UI5 by isolating business logic into methods that can be unit tested without requiring a client, HTTP handler, or frontend.

## Changes
- **New sample app `z2ui5_cl_smp_app_503`**: Demonstrates the `gross_amount()` method pattern — a pure function that takes inputs and returns computed results without reading attributes or touching the client
- **Unit test class `ltcl_gross_amount`**: Three test cases covering:
  - Standard percentage calculation (19% tax on 100 = 119)
  - Rounding behavior (7% of 10 rounds 0.7 up to 1, not down to 0)
  - Zero percent edge case (no change to net amount)
- **UI implementation**: Simple form with net amount and tax rate inputs, displaying the computed gross amount via the testable `gross_amount()` method
- **Metadata updates**: Registered new sample in `catalogue.json`, `SAMPLES.md`, `catalogue-derived.json`, and overview app; updated badge counts and documentation

## Implementation Details
The key insight demonstrated: by implementing business logic as a method that only uses its parameters and return value (no `me->` attribute access, no client calls), the method becomes directly testable via ABAP Unit without any infrastructure. The test class instantiates the app class normally and calls `gross_amount()` with test inputs, asserting results — no browser, no view, no roundtrip needed.

The rounding logic (`net + ( net * percent + 50 ) DIV 100`) is the specific behavior worth testing, as it rounds half-up rather than truncating.

https://claude.ai/code/session_01TP6dMcnEZhzYDZJmkG7qog