### PR TITLE
##NO_HANDLER where a handler is empty on purpose, a dialog that can be closed, and four re-measured figures

### DIFF
--- a/.github/badges/abap2ui5.json
+++ b/.github/badges/abap2ui5.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "abap2UI5",
-  "message": "150 apps · 173 views · 2,312 controls",
+  "message": "150 apps · 173 views · 2,313 controls",
   "color": "007ec6",
   "labelColor": "555",
   "cacheSeconds": 3600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,7 +717,7 @@ over there, which meant a pull request HERE could add a stale or invented link
 and stay green until somebody regenerated the documentation; and the first half
 existed nowhere at all. The scan refuses a URL that is not on the documentation
 site, which catches a typo in the **host** and nothing whatsoever about the
-path — and 97 classes carry one of these lines. Nothing fails when a page is
+path — and 95 classes carry one of these lines. Nothing fails when a page is
 renamed: the class compiles, `SAMPLES.md` renders the link, and it 404s for
 every reader who follows it.
 
@@ -1003,7 +1003,7 @@ By hand, because no script covers it:
 - Run: `npm run check:abap2ui5`
 - CI: `abap2UI5` — as opposed to `abap-standard` / `abap-cloud` /
   `abap-702`, which lint ABAP itself against three target releases
-- **The gate is effective**: 148 app classes, 172 reconstructed views, and
+- **The gate is effective**: 150 app classes, 173 reconstructed views, and
   an `abap2ui5lint-baseline.json` that froze the adoption-time debt (#753)
   until every entry was fixed — empty since 0.6.1, kept so the next adoption
   has its shape. It was
@@ -1017,22 +1017,22 @@ By hand, because no script covers it:
   histogram, what the baseline swallowed and per rule, the phase times:
 
   ```
-  sources    148 app classes
-  views      172 documents reconstructed, nested 11 deep, 7 classes produced none
-  judged     2,178 controls of 106 types, 551 bindings, 68 icons, 4,178 attributes
-  gates      properties 148 files, render 172 documents
+  sources    150 app classes
+  views      173 documents reconstructed, nested 11 deep, 7 classes produced none
+  judged     2,313 controls of 106 types, 563 bindings, 72 icons, 4,353 attributes
+  gates      properties 150 files, render 173 documents
   ```
 
   (No `baselined` line any more: `abap2ui5lint-baseline.json` has been empty
   since 0.6.1 — the one frozen finding was fixed rather than carried.)
 
-  A `judged` line of zeroes, or `148 classes produced none`, is the earlier
+  A `judged` line of zeroes, or `150 classes produced none`, is the earlier
   failure repeating itself — and now it says so instead of printing
   "Success! No findings detected."
 - **The two README badges** (`.github/badges/abap2ui5.json` and
   `.github/badges/check-abap2ui5.json`, shields.io endpoint files) carry the
-  same statement, split along what they mean: *abap2UI5 | 148 apps · 172 views
-  · 2,178 controls* is what is here, blue, a fact; *check-abap2UI5 | 86 rules
+  same statement, split along what they mean: *abap2UI5 | 150 apps · 173 views
+  · 2,313 controls* is what is here, blue, a fact; *check-abap2UI5 | 111 rules
   passed* is what the gate made of it, green (or *3 problems*, *7 errors*,
   red). A run that finds nothing checkable turns both grey and says so. Every
   run rewrites them, `check-abap2UI5` commits them onto the pull request

--- a/src/00/98/z2ui5_cl_smp_app_126.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_126.clas.abap
@@ -62,7 +62,7 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -72,7 +72,7 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.
@@ -104,7 +104,7 @@ CLASS z2ui5_cl_smp_app_126 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 3 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
     ASSIGN mt_table_tmp->* TO <table_tmp>.

--- a/src/00/98/z2ui5_cl_smp_app_184.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_184.clas.abap
@@ -155,7 +155,7 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 2 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -187,7 +187,7 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
               ENDIF.
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -197,7 +197,7 @@ CLASS z2ui5_cl_smp_app_184 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_190.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_190.clas.abap
@@ -165,7 +165,7 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -193,7 +193,7 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
               ENDIF.
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -203,7 +203,7 @@ CLASS z2ui5_cl_smp_app_190 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_194.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_194.clas.abap
@@ -203,7 +203,7 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -268,7 +268,7 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
               ENDIF.
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -278,7 +278,7 @@ CLASS z2ui5_cl_smp_app_194 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_199.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_199.clas.abap
@@ -143,7 +143,7 @@ CLASS z2ui5_cl_smp_app_199 IMPLEMENTATION.
 
         mv_counter = 2.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_212.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_212.clas.abap
@@ -54,6 +54,8 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
 
     IF client->check_on_event( `ROW_SELECT` ).
       row_select( ).
+    ELSEIF client->check_on_event( `POPUP_CLOSE` ).
+      client->popup_destroy( ).
     ENDIF.
 
   ENDMETHOD.
@@ -130,7 +132,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
           ENDIF.
         ENDLOOP.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.
@@ -172,6 +174,13 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
           )->a( n = `showValueHelp` b = abap_false ).
 
     ENDLOOP.
+
+    content->end(
+    )->end(
+        )->ele( `buttons`
+            )->tag( `Button`
+                )->a( n = `text`  v = `Close`
+                )->a( n = `press` v = client->_event( `POPUP_CLOSE` ) ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -283,7 +292,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 100 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -315,7 +324,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
               ENDIF.
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -325,7 +334,7 @@ CLASS z2ui5_cl_smp_app_212 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_328.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_328.clas.abap
@@ -153,7 +153,7 @@ CLASS z2ui5_cl_smp_app_328 IMPLEMENTATION.
           INTO CORRESPONDING FIELDS OF TABLE @<table>
           UP TO 4 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 

--- a/src/00/98/z2ui5_cl_smp_app_339.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_339.clas.abap
@@ -64,7 +64,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -74,7 +74,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.
@@ -227,7 +227,7 @@ CLASS z2ui5_cl_smp_app_339 IMPLEMENTATION.
 
         SORT <table>.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 

--- a/src/00/98/z2ui5_cl_smp_app_340.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_340.clas.abap
@@ -112,7 +112,7 @@ CLASS z2ui5_cl_smp_app_340 IMPLEMENTATION.
           lo_struct = CAST #( lo_type ).
         ENDIF.
         comp = lo_struct->get_components( ).
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
     TRY.
@@ -125,7 +125,7 @@ CLASS z2ui5_cl_smp_app_340 IMPLEMENTATION.
         CREATE DATA result->mt_data_tmp TYPE HANDLE new_table_desc.
         CREATE DATA result->ms_data_row TYPE HANDLE new_struct_desc.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
     ASSIGN io_table->* TO FIELD-SYMBOL(<table>).

--- a/src/00/98/z2ui5_cl_smp_app_342.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_342.clas.abap
@@ -65,7 +65,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -75,7 +75,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.
@@ -231,7 +231,7 @@ CLASS z2ui5_cl_smp_app_342 IMPLEMENTATION.
 
         SORT <table>.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 

--- a/src/00/98/z2ui5_cl_smp_app_343.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_343.clas.abap
@@ -45,7 +45,7 @@ CLASS Z2UI5_CL_SMP_APP_343 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
         ENDTRY.
 
 
@@ -71,7 +71,7 @@ CLASS Z2UI5_CL_SMP_APP_343 IMPLEMENTATION.
           INTO TABLE @<table1>
           UP TO 5 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_344.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_344.clas.abap
@@ -184,7 +184,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
         SORT <table>.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -215,7 +215,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
         SORT <table>.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
 
     ENDTRY.
 
@@ -247,7 +247,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
 
         ENDTRY.
 
@@ -257,7 +257,7 @@ CLASS z2ui5_cl_smp_app_344 IMPLEMENTATION.
 
         APPEND LINES OF component TO result.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/00/98/z2ui5_cl_smp_app_345.clas.abap
+++ b/src/00/98/z2ui5_cl_smp_app_345.clas.abap
@@ -54,7 +54,7 @@ CLASS Z2UI5_CL_SMP_APP_345 IMPLEMENTATION.
 
             ENDLOOP.
 
-          CATCH cx_root.
+          CATCH cx_root ##NO_HANDLER.
         ENDTRY.
 
 
@@ -80,7 +80,7 @@ CLASS Z2UI5_CL_SMP_APP_345 IMPLEMENTATION.
           INTO TABLE @<table1>
           UP TO 5 ROWS.
 
-      CATCH cx_root.
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
     mo_layout_obj1 = z2ui5_cl_smp_app_333=>factory( i_data = mt_data1 vis_cols = 2 ).


### PR DESCRIPTION
Found by running abap2UI5/linter's `main` over this corpus — seven commits newer than the pinned 0.6.1, so thirteen rules this repository has not seen yet.

### `##NO_HANDLER`

34 `CATCH cx_root.` blocks in `src/00/98` are empty because the sample means them to be — a `describe_by_data` on a system without the demo table, an optional URL parameter. SLIN reports every one of them on a real system, and the pragma is how ABAP says "deliberate": the corpus already wrote it once (app 500) and now writes it everywhere it applies. No behaviour changes.

### App 212's dialog can be closed

Its row-detail dialog had no button, no `afterClose` and no wire of any kind, so only Escape closed it and the app never heard about it — the fragment stayed loaded and the next `popup_display( )` rebuilt it. It gets the Close button the rest of the corpus gives a Dialog, wired to `POPUP_CLOSE` and handled with `popup_destroy( )` as an ELSEIF arm of the event chain that was already there.

### Four figures AGENTS.md quotes from a run

The same failure the repository gates elsewhere, and the reason its badges are generated rather than typed:

| said | is |
|---|---|
| 148 app classes / 172 views / 2,178 controls | 150 / 173 / 2,313 |
| badge sentence: "86 rules passed" | 111 |
| `@docs` paragraph: 97 classes carry the line | 95 |

Every figure is now what the command beside it prints, verified by running each twice — the summary is deterministic.

### Note on the one finding that was not a defect

The same run reported `double-display-in-branch` on `src/01/z2ui5_cl_smp_app_493` — the Hello World sample. It has exactly one `view_display( )`; the other is inside the MessageStrip text that explains what the class does. That is a linter bug, fixed in abap2UI5/linter#95 along with twenty-two more of the same shape; nothing was changed here for it.

### Checks

`npm run check` green: abaplint 0 issues over 225 files, `abap2ui5lint` 0 findings over 150 classes with the render gate on, launchpad/catalogue/derived/keywords/prose/docs-links/app-rules/pin all up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ)_