### PR TITLE
Name the seven classes the linter reconstructs no view from

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1029,6 +1029,20 @@ By hand, because no script covers it:
   A `judged` line of zeroes, or `150 classes produced none`, is the earlier
   failure repeating itself — and now it says so instead of printing
   "Success! No findings detected."
+
+  **The seven that produce none are one shape, and they are these seven**
+  (measured 2026-09-04): `117`, `131`, `185`, `191`, `195`, `211`, `338` — all
+  in `src/00/98` ("testing"), all the same "main app calling subapps" scaffold.
+  Each builds a page, keeps the handle in an instance attribute, creates the
+  sub-app with `CREATE OBJECT mo_app TYPE (t002->class)` and hands the handle
+  over through ``CALL METHOD mo_app->(`SET_APP_DATA`)``; the sub-app builds into
+  it and a dynamic ``ASSIGN mo_app->(`MV_VIEW_DISPLAY`)`` decides when to
+  display. The linter resolves each builder statement against the handle it is
+  written on, so a handle that leaves the class through a dynamic call is
+  unfollowable — by design, not by oversight, and nothing in `src/01` does it.
+  Written out so the next run can tell **the same seven** from *seven different
+  ones*: a name appearing here that is not on this list is a sample that lost
+  its view, which is the failure the count exists to catch.
 - **The two README badges** (`.github/badges/abap2ui5.json` and
   `.github/badges/check-abap2ui5.json`, shields.io endpoint files) carry the
   same statement, split along what they mean: *abap2UI5 | 150 apps · 173 views


### PR DESCRIPTION
The run summary counts them:

```
views      173 documents reconstructed, nested 11 deep, 7 classes produced none
```

and AGENTS.md quotes that line and says, correctly, that a count which grows is the earlier failure repeating itself. What it did not say is **which** seven — so the next run can read *"7 classes produced none"* and learn nothing from it. The same seven and seven different ones print identically, and one sample silently losing its view while another gains one is exactly what the count exists to catch.

Measured 2026-09-04, they are **`117`, `131`, `185`, `191`, `195`, `211`, `338`** — all in `src/00/98` ("testing"), and all the same shape. Each builds a page, keeps the handle in an instance attribute, creates the sub-app dynamically and hands the handle over:

```abap
CREATE OBJECT mo_app TYPE (t002->class).
CALL METHOD mo_app->( `SET_APP_DATA` ) ...
ASSIGN mo_app->( `MV_VIEW_DISPLAY` ) TO <view_display>.
```

The linter resolves each builder statement against the handle it is written on, so a handle that leaves the class through a dynamic call is unfollowable — by design rather than by oversight, and nothing in `src/01` does it.

Written out so the next run can tell *the same seven* from *seven different ones*: a name appearing there that is not on this list is a sample that lost its view.

## Verification

`npm run check` — every gate green. The figures in that AGENTS.md block were re-measured while I was in there and are unchanged: 150 app classes, 173 documents, 2,313 controls of 106 types, 563 bindings, 72 icons, 4,353 attributes. The `check-abap2UI5` badge's *"111 rules passed"* is also correct — that is what the pinned `@abap2ui5/linter` 0.6.1 has; 124 is the unreleased count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD8XM2xmi9NHb17JHP67nZ)_